### PR TITLE
feat(gradebook): weighted view with weights and exclusions

### DIFF
--- a/app/controllers/components/course/gradebook_component.rb
+++ b/app/controllers/components/course/gradebook_component.rb
@@ -7,6 +7,12 @@ class Course::GradebookComponent < SimpleDelegator
   end
 
   def sidebar_items
+    main_sidebar_items + settings_sidebar_items
+  end
+
+  private
+
+  def main_sidebar_items
     return [] unless can?(:read_gradebook, current_course)
 
     [
@@ -16,6 +22,19 @@ class Course::GradebookComponent < SimpleDelegator
         type: :normal,
         weight: 9,
         path: course_gradebook_path(current_course)
+      }
+    ]
+  end
+
+  def settings_sidebar_items
+    return [] unless can?(:manage_gradebook_settings, current_course)
+
+    [
+      {
+        key: self.class.key,
+        type: :settings,
+        weight: 14,
+        path: course_admin_gradebook_path(current_course)
       }
     ]
   end

--- a/app/controllers/course/admin/gradebook_settings_controller.rb
+++ b/app/controllers/course/admin/gradebook_settings_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class Course::Admin::GradebookSettingsController < Course::Admin::Controller
+  def edit
+    respond_to(&:json)
+  end
+
+  def update
+    if @settings.update(gradebook_settings_params) && current_course.save
+      render 'edit'
+    else
+      render json: { errors: @settings.errors }, status: :bad_request
+    end
+  end
+
+  private
+
+  def gradebook_settings_params
+    params.require(:settings_gradebook_component).permit(:weighted_view_enabled)
+  end
+
+  def component
+    current_component_host[:course_gradebook_component]
+  end
+
+  def authorize_admin
+    authorize! :manage_gradebook_settings, current_course
+  end
+end

--- a/app/controllers/course/gradebook_controller.rb
+++ b/app/controllers/course/gradebook_controller.rb
@@ -6,10 +6,12 @@ class Course::GradebookController < Course::ComponentController
   def index
     respond_to do |format|
       format.json do
+        @weighted_view_enabled = @settings.weighted_view_enabled
         @published_assessments = fetch_published_assessments
         @categories, @tabs = fetch_categories_and_tabs
         @students = fetch_students
         assessment_ids = @published_assessments.pluck(:id)
+        load_weighted_view_contributions(assessment_ids) if @weighted_view_enabled
         @assessment_max_grades = Course::Assessment.max_grades(assessment_ids)
         @submissions = Course::Assessment::Submission.grade_summary(
           student_ids: @students.map(&:user_id),
@@ -19,10 +21,60 @@ class Course::GradebookController < Course::ComponentController
     end
   end
 
+  def update_weights
+    authorize! :manage_gradebook_weights, current_course
+    updates = (update_weights_params[:weights] || []).map { |entry| parse_weight_entry(entry) }
+    Course::Gradebook::TabContribution.bulk_update(course: current_course, updates: updates)
+    render json: { weights: serialize_weight_updates(updates) }
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+    render json: { errors: { base: e.message } }, status: :unprocessable_entity
+  end
+
   private
 
   def authorize_read_gradebook!
     authorize! :read_gradebook, current_course
+  end
+
+  def load_weighted_view_contributions(assessment_ids)
+    @tab_contributions = Course::Gradebook::TabContribution.
+                         where(tab_id: @tabs.map(&:id)).index_by(&:tab_id)
+    @assessment_contributions = Course::Gradebook::AssessmentContribution.
+                                where(assessment_id: assessment_ids).index_by(&:assessment_id)
+  end
+
+  # Weights are stored as DECIMAL(5,2); round at the boundary so the echoed response
+  # matches the persisted value and the custom-weight sum check stays exact at 2dp.
+  def parse_weight_entry(entry)
+    {
+      tab_id: entry[:tabId].to_i,
+      weight: entry[:weight].to_f.round(2),
+      weight_mode: entry[:weightMode] || 'equal',
+      excluded_assessment_ids: (entry[:excludedAssessmentIds] || []).map(&:to_i),
+      assessment_weights: (entry[:assessmentWeights] || []).map do |aw|
+        { assessment_id: aw[:assessmentId].to_i, weight: aw[:weight].to_f.round(2) }
+      end
+    }
+  end
+
+  def update_weights_params
+    params.permit(
+      weights: [:tabId, :weight, :weightMode,
+                excludedAssessmentIds: [], assessmentWeights: [:assessmentId, :weight]]
+    )
+  end
+
+  def serialize_weight_updates(updates)
+    updates.map do |u|
+      entry = { tabId: u[:tab_id], weight: u[:weight], weightMode: u[:weight_mode].to_s,
+                excludedAssessmentIds: u[:excluded_assessment_ids] }
+      if u[:weight_mode].to_s == 'custom'
+        entry[:assessmentWeights] = u[:assessment_weights].map do |aw|
+          { assessmentId: aw[:assessment_id], weight: aw[:weight] }
+        end
+      end
+      entry
+    end
   end
 
   def component

--- a/app/models/components/course/gradebook_ability_component.rb
+++ b/app/models/components/course/gradebook_ability_component.rb
@@ -3,7 +3,9 @@ module Course::GradebookAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    can :read_gradebook, Course, id: course.id if course_user&.staff?
+    can :read_gradebook, Course, id: course.id if course_user&.manager_or_owner?
+    can :manage_gradebook_weights, Course, id: course.id if course_user&.manager_or_owner?
+    can :manage_gradebook_settings, Course, id: course.id if course_user&.manager_or_owner?
     super
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course < ApplicationRecord
+class Course < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Course::SearchConcern
   include Course::DuplicationConcern
   include Course::CourseComponentsConcern
@@ -53,6 +53,8 @@ class Course < ApplicationRecord
                                    dependent: :destroy, inverse_of: :course
   has_many :assessment_tabs, source: :tabs, through: :assessment_categories
   has_many :assessments, through: :assessment_categories
+  has_many :gradebook_contributions, class_name: 'Course::Gradebook::TabContribution',
+                                     dependent: :destroy, inverse_of: :course
   has_many :assessment_skills, class_name: 'Course::Assessment::Skill',
                                dependent: :destroy
   has_many :assessment_skill_branches, class_name: 'Course::Assessment::SkillBranch',
@@ -362,12 +364,14 @@ class Course < ApplicationRecord
   # Set default values
   def set_defaults
     self.start_at ||= Time.zone.now.beginning_of_hour
-    self.end_at ||= self.start_at + 1.month
+    self.end_at ||= start_at + 1.month
     self.default_reference_timeline ||= reference_timelines.new(default: true)
     self.default_timeline_algorithm ||= 0 # 'fixed' algorithm
 
-    return unless creator && course_users.empty?
+    build_owner_course_user if creator && course_users.empty?
+  end
 
+  def build_owner_course_user
     course_users.build(user: creator,
                        role: :owner,
                        creator: creator,

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -79,6 +79,9 @@ class Course::Assessment < ApplicationRecord
                                   inverse_of: :assessment, dependent: :destroy
   has_one :plagiarism_check, class_name: 'Course::Assessment::PlagiarismCheck',
                              inverse_of: :assessment, dependent: :destroy, autosave: true
+  has_one :gradebook_assessment_contribution,
+          class_name: 'Course::Gradebook::AssessmentContribution',
+          dependent: :destroy, inverse_of: :assessment
   has_many :live_feedbacks, class_name: 'Course::Assessment::LiveFeedback',
                             inverse_of: :assessment, dependent: :destroy
   has_many :links, class_name: 'Course::Assessment::Link', inverse_of: :assessment, dependent: :destroy

--- a/app/models/course/assessment/tab.rb
+++ b/app/models/course/assessment/tab.rb
@@ -8,6 +8,9 @@ class Course::Assessment::Tab < ApplicationRecord
 
   belongs_to :category, class_name: 'Course::Assessment::Category', inverse_of: :tabs
   has_many :assessments, class_name: 'Course::Assessment', dependent: :destroy, inverse_of: :tab
+  has_one :gradebook_contribution, class_name: 'Course::Gradebook::TabContribution',
+                                   dependent: :destroy, inverse_of: :tab
+
   has_many :folders, class_name: 'Course::Material::Folder', through: :assessments,
                      inverse_of: nil
 

--- a/app/models/course/gradebook.rb
+++ b/app/models/course/gradebook.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module Course::Gradebook
+  def self.table_name_prefix
+    "#{Course.table_name.singularize}_gradebook_"
+  end
+end

--- a/app/models/course/gradebook/assessment_contribution.rb
+++ b/app/models/course/gradebook/assessment_contribution.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Course::Gradebook::AssessmentContribution < ApplicationRecord
+  belongs_to :assessment, class_name: 'Course::Assessment',
+                          inverse_of: :gradebook_assessment_contribution
+
+  validates :creator, presence: true
+  validates :updater, presence: true
+  validates :weight, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :excluded, inclusion: { in: [true, false] }
+  validates :assessment_id, uniqueness: true
+end

--- a/app/models/course/gradebook/tab_contribution.rb
+++ b/app/models/course/gradebook/tab_contribution.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+class Course::Gradebook::TabContribution < ApplicationRecord
+  # `prefix: true` keeps Rails from generating a bare `equal?` predicate that would
+  # override Ruby's Object#equal? (identity, arity 1). Helpers become
+  # `weight_mode_equal?` etc.; the `weight_mode` reader still returns 'equal'/'custom'.
+  enum :weight_mode, { equal: 0, custom: 1 }, prefix: true
+
+  belongs_to :course, inverse_of: :gradebook_contributions
+  belongs_to :tab, class_name: 'Course::Assessment::Tab',
+                   inverse_of: :gradebook_contribution
+
+  validates :creator, presence: true
+  validates :updater, presence: true
+  validates :weight, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+  validates :weight_mode, presence: true
+  validates :tab_id, uniqueness: true
+  validate :course_matches_contributor
+  # Bulk-upserts tab contributions and their per-assessment contributions for a course.
+  # Consumes the identical `updates` payload the controller parses today.
+  # Raises ActiveRecord::RecordNotFound if any tab_id/assessment_id is unknown, and
+  # ActiveRecord::RecordInvalid if validation fails or, for custom tabs, the included
+  # assessment weights do not sum (at 2dp) to the tab total; the transaction rolls back.
+  #
+  # @param course [Course]
+  # @param updates [Array<Hash>] each { tab_id:, weight:, weight_mode:,
+  #   excluded_assessment_ids: [Integer], assessment_weights: [{ assessment_id:, weight: }] }
+  def self.bulk_update(course:, updates:)
+    course_tab_ids = course.assessment_tabs.pluck(:id).to_set
+    updates.each { |e| raise ActiveRecord::RecordNotFound unless course_tab_ids.include?(e[:tab_id]) }
+
+    tabs_by_id = Course::Assessment::Tab.where(id: updates.map { |e| e[:tab_id] }).
+                 includes(:assessments).index_by(&:id)
+
+    transaction { updates.each { |entry| apply_entry(course, tabs_by_id, entry) } }
+  end
+
+  # @api private
+  def self.apply_entry(course, tabs_by_id, entry)
+    tab = tabs_by_id[entry[:tab_id]]
+    mode = (entry[:weight_mode] || 'equal').to_s
+
+    contribution = find_or_initialize_by(tab_id: tab.id)
+    contribution.course = course
+    contribution.assign_attributes(weight: entry[:weight], weight_mode: mode)
+    contribution.save!
+
+    excluded_ids = entry[:excluded_assessment_ids] || []
+    apply_assessment_exclusions(tab, excluded_ids)
+
+    if mode == 'custom'
+      apply_custom_assessment_weights(tab, entry, excluded_ids.to_set)
+    else
+      clear_assessment_weights(tab)
+    end
+  end
+  private_class_method :apply_entry
+
+  # @api private
+  def self.assessment_contribution_for(assessment)
+    Course::Gradebook::AssessmentContribution.find_or_initialize_by(assessment_id: assessment.id)
+  end
+  private_class_method :assessment_contribution_for
+
+  # @api private
+  # Membership applies in both modes: excluded ids -> true, the rest of the tab -> false.
+  def self.apply_assessment_exclusions(tab, excluded_ids)
+    excluded_set = excluded_ids.to_set
+    tab.assessments.each do |assessment|
+      ac = assessment_contribution_for(assessment)
+      ac.excluded = excluded_set.include?(assessment.id)
+      ac.save!
+    end
+  end
+  private_class_method :apply_assessment_exclusions
+
+  # @api private
+  def self.clear_assessment_weights(tab)
+    tab.assessments.each do |assessment|
+      ac = assessment_contribution_for(assessment)
+      ac.weight = nil
+      ac.save!
+    end
+  end
+  private_class_method :clear_assessment_weights
+
+  # @api private
+  def self.apply_custom_assessment_weights(tab, entry, excluded_ids)
+    assessments_by_id = tab.assessments.index_by(&:id)
+    included_sum = 0
+    included_any = false
+    (entry[:assessment_weights] || []).each do |aw|
+      assessment = assessments_by_id[aw[:assessment_id]]
+      raise ActiveRecord::RecordNotFound if assessment.nil?
+
+      ac = assessment_contribution_for(assessment)
+      ac.weight = aw[:weight]
+      ac.save!
+      next if excluded_ids.include?(aw[:assessment_id])
+
+      included_sum += aw[:weight]
+      included_any = true
+    end
+    validate_custom_assessment_weights_sum!(tab, entry, included_sum, included_any)
+  end
+  private_class_method :apply_custom_assessment_weights
+
+  def self.validate_custom_assessment_weights_sum!(tab, entry, included_sum, included_any)
+    return unless included_any
+    return unless (included_sum * 100).round != (entry[:weight] * 100).round
+
+    tab.errors.add(:base, :custom_weights_mismatch)
+    raise ActiveRecord::RecordInvalid, tab
+  end
+
+  private
+
+  def course_matches_contributor
+    return if tab.nil? || course.nil?
+
+    errors.add(:course, :invalid) if tab.category.course_id != course_id
+  end
+end

--- a/app/models/course/settings/gradebook_component.rb
+++ b/app/models/course/settings/gradebook_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class Course::Settings::GradebookComponent < Course::Settings::Component
+  # Returns whether weighted view is enabled (disabled by default).
+  #
+  # @return [Boolean] Setting on whether weighted view is enabled.
+  def weighted_view_enabled
+    ActiveRecord::Type::Boolean.new.cast(settings.weighted_view_enabled) || false
+  end
+
+  # Enable or disable the weighted view.
+  #
+  # @param [Boolean|Integer|String] value Setting on whether weighted view is enabled.
+  def weighted_view_enabled=(value)
+    settings.weighted_view_enabled = ActiveRecord::Type::Boolean.new.cast(value)
+  end
+end

--- a/app/views/course/admin/gradebook_settings/edit.json.jbuilder
+++ b/app/views/course/admin/gradebook_settings/edit.json.jbuilder
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+json.weightedViewEnabled @settings.weighted_view_enabled

--- a/app/views/course/gradebook/index.json.jbuilder
+++ b/app/views/course/gradebook/index.json.jbuilder
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+json.weightedViewEnabled @weighted_view_enabled
+json.canManageWeights can?(:manage_gradebook_weights, current_course)
+
 json.categories @categories do |cat|
   json.id cat.id
   json.title cat.title
@@ -8,6 +11,11 @@ json.tabs @tabs do |tab|
   json.id tab.id
   json.title tab.title
   json.categoryId tab.category_id
+  if @weighted_view_enabled
+    contribution = @tab_contributions[tab.id]
+    json.gradebookWeight (contribution&.weight || 0).to_f
+    json.weightMode(contribution&.weight_mode || 'equal')
+  end
 end
 
 json.assessments @published_assessments do |assessment|
@@ -15,6 +23,11 @@ json.assessments @published_assessments do |assessment|
   json.title assessment.title
   json.tabId assessment.tab_id
   json.maxGrade @assessment_max_grades[assessment.id] || 0
+  if @weighted_view_enabled
+    contribution = @assessment_contributions[assessment.id]
+    json.gradebookWeight contribution&.weight&.to_f
+    json.gradebookExcluded(contribution&.excluded || false)
+  end
 end
 
 json.students @students do |course_user|

--- a/client/app/api/course/Admin/Gradebook.ts
+++ b/client/app/api/course/Admin/Gradebook.ts
@@ -1,0 +1,23 @@
+import { AxiosResponse } from 'axios';
+import {
+  GradebookSettingsData,
+  GradebookSettingsPostData,
+} from 'types/course/admin/gradebook';
+
+import BaseAdminAPI from './Base';
+
+export default class GradebookAdminAPI extends BaseAdminAPI {
+  override get urlPrefix(): string {
+    return `${super.urlPrefix}/gradebook`;
+  }
+
+  index(): Promise<AxiosResponse<GradebookSettingsData>> {
+    return this.client.get(this.urlPrefix);
+  }
+
+  update(
+    data: GradebookSettingsPostData,
+  ): Promise<AxiosResponse<GradebookSettingsData>> {
+    return this.client.patch(this.urlPrefix, data);
+  }
+}

--- a/client/app/api/course/Admin/index.ts
+++ b/client/app/api/course/Admin/index.ts
@@ -6,6 +6,7 @@ import CommentsAdminAPI from './Comments';
 import ComponentsAdminAPI from './Components';
 import CourseAdminAPI from './Course';
 import ForumsAdminAPI from './Forums';
+import GradebookAdminAPI from './Gradebook';
 import LeaderboardAdminAPI from './Leaderboard';
 import LessonPlanSettingsAPI from './LessonPlan';
 import MaterialsAdminAPI from './Materials';
@@ -28,6 +29,7 @@ const AdminAPI = {
   lessonPlan: new LessonPlanSettingsAPI(),
   materials: new MaterialsAdminAPI(),
   forums: new ForumsAdminAPI(),
+  gradebook: new GradebookAdminAPI(),
   videos: new VideosAdminAPI(),
   notifications: new NotificationsSettingsAPI(),
   codaveri: new CodaveriAdminAPI(),

--- a/client/app/api/course/Gradebook.ts
+++ b/client/app/api/course/Gradebook.ts
@@ -1,4 +1,4 @@
-import { GradebookData } from 'types/course/gradebook';
+import { GradebookData, UpdateWeightsPayload } from 'types/course/gradebook';
 
 import { APIResponse } from 'api/types';
 
@@ -11,5 +11,11 @@ export default class GradebookAPI extends BaseCourseAPI {
 
   index(): APIResponse<GradebookData> {
     return this.client.get(this.#urlPrefix);
+  }
+
+  updateWeights(
+    payload: UpdateWeightsPayload,
+  ): APIResponse<UpdateWeightsPayload> {
+    return this.client.patch(`${this.#urlPrefix}/weights`, payload);
   }
 }

--- a/client/app/bundles/course/admin/pages/GradebookSettings/GradebookSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/GradebookSettings/GradebookSettingsForm.tsx
@@ -1,0 +1,59 @@
+import { forwardRef } from 'react';
+import { Controller } from 'react-hook-form';
+import { Typography } from '@mui/material';
+import { GradebookSettingsData } from 'types/course/admin/gradebook';
+
+import Section from 'lib/components/core/layouts/Section';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import Form, { FormRef } from 'lib/components/form/Form';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from './translations';
+
+interface GradebookSettingsFormProps {
+  data: GradebookSettingsData;
+  onSubmit: (data: GradebookSettingsData) => void;
+  disabled?: boolean;
+}
+
+const GradebookSettingsForm = forwardRef<
+  FormRef<GradebookSettingsData>,
+  GradebookSettingsFormProps
+>((props, ref): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Form
+      ref={ref}
+      disabled={props.disabled}
+      headsUp
+      initialValues={props.data}
+      onSubmit={props.onSubmit}
+    >
+      {(control): JSX.Element => (
+        <Section sticksToNavbar title={t(translations.gradebookSettings)}>
+          <Controller
+            control={control}
+            name="weightedViewEnabled"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormCheckboxField
+                disabled={props.disabled}
+                field={field}
+                fieldState={fieldState}
+                label={t(translations.weightedViewEnabled)}
+              />
+            )}
+          />
+
+          <Typography className="!mt-2" color="text.secondary" variant="body2">
+            {t(translations.weightedViewEnabledHint)}
+          </Typography>
+        </Section>
+      )}
+    </Form>
+  );
+});
+
+GradebookSettingsForm.displayName = 'GradebookSettingsForm';
+
+export default GradebookSettingsForm;

--- a/client/app/bundles/course/admin/pages/GradebookSettings/__tests__/GradebookSettings.test.tsx
+++ b/client/app/bundles/course/admin/pages/GradebookSettings/__tests__/GradebookSettings.test.tsx
@@ -1,0 +1,142 @@
+import { createMockAdapter } from 'mocks/axiosMock';
+import { fireEvent, render, screen, waitFor } from 'test-utils';
+
+import CourseAPI from 'api/course';
+
+import GradebookSettings from '../index';
+
+const mock = createMockAdapter(CourseAPI.admin.gradebook.client);
+
+describe('<GradebookSettings />', () => {
+  it('shows the loading indicator before settings load', () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: false });
+
+    render(<GradebookSettings />);
+
+    expect(
+      screen.queryByRole('checkbox', { name: /Enable Weighted Total view/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the toggle unchecked when weightedViewEnabled is false', async () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: false });
+
+    render(<GradebookSettings />);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /Enable Weighted Total view/i,
+    });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('renders the toggle checked when weightedViewEnabled is true', async () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: true });
+
+    render(<GradebookSettings />);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /Enable Weighted Total view/i,
+    });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('PATCHes when toggle is checked and form submitted', async () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: false });
+    mock
+      .onPatch(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: true });
+
+    const spy = jest.spyOn(CourseAPI.admin.gradebook, 'update');
+
+    render(<GradebookSettings />);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /Enable Weighted Total view/i,
+    });
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        settings_gradebook_component: { weighted_view_enabled: true },
+      });
+    });
+  });
+
+  it('shows a success toast after a successful save', async () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: false });
+    mock
+      .onPatch(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: true });
+
+    render(<GradebookSettings />);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /Enable Weighted Total view/i,
+    });
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(
+      await screen.findByText('Your changes have been saved.'),
+    ).toBeVisible();
+  });
+
+  it('PATCHes false when toggle is unchecked and form submitted', async () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: true });
+    mock
+      .onPatch(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: false });
+
+    const spy = jest.spyOn(CourseAPI.admin.gradebook, 'update');
+
+    render(<GradebookSettings />);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /Enable Weighted Total view/i,
+    });
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        settings_gradebook_component: { weighted_view_enabled: false },
+      });
+    });
+  });
+
+  it('does not toast success when the save fails', async () => {
+    mock
+      .onGet(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(200, { weightedViewEnabled: false });
+    mock
+      .onPatch(`/courses/${global.courseId}/admin/gradebook`)
+      .reply(422, { errors: { weightedViewEnabled: 'is invalid' } });
+
+    render(<GradebookSettings />);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /Enable Weighted Total view/i,
+    });
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Your changes have been saved.'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/bundles/course/admin/pages/GradebookSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/GradebookSettings/index.tsx
@@ -1,0 +1,49 @@
+import { ComponentRef, useRef, useState } from 'react';
+import { GradebookSettingsData } from 'types/course/admin/gradebook';
+
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+import translations from 'lib/translations/form';
+
+import { useItemsReloader } from '../../components/SettingsNavigation';
+
+import GradebookSettingsForm from './GradebookSettingsForm';
+import { fetchGradebookSettings, updateGradebookSettings } from './operations';
+
+const GradebookSettings = (): JSX.Element => {
+  const reloadItems = useItemsReloader();
+  const { t } = useTranslation();
+  const formRef = useRef<ComponentRef<typeof GradebookSettingsForm>>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = (data: GradebookSettingsData): void => {
+    setSubmitting(true);
+
+    updateGradebookSettings(data)
+      .then((newData) => {
+        if (!newData) return;
+        formRef.current?.resetTo?.(newData);
+        reloadItems();
+        toast.success(t(translations.changesSaved));
+      })
+      .catch(formRef.current?.receiveErrors)
+      .finally(() => setSubmitting(false));
+  };
+
+  return (
+    <Preload render={<LoadingIndicator />} while={fetchGradebookSettings}>
+      {(data): JSX.Element => (
+        <GradebookSettingsForm
+          ref={formRef}
+          data={data}
+          disabled={submitting}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </Preload>
+  );
+};
+
+export default GradebookSettings;

--- a/client/app/bundles/course/admin/pages/GradebookSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/GradebookSettings/operations.ts
@@ -1,0 +1,32 @@
+import { AxiosError } from 'axios';
+import {
+  GradebookSettingsData,
+  GradebookSettingsPostData,
+} from 'types/course/admin/gradebook';
+
+import CourseAPI from 'api/course';
+
+type Data = Promise<GradebookSettingsData>;
+
+export const fetchGradebookSettings = async (): Data => {
+  const response = await CourseAPI.admin.gradebook.index();
+  return response.data;
+};
+
+export const updateGradebookSettings = async (
+  data: GradebookSettingsData,
+): Data => {
+  const adaptedData: GradebookSettingsPostData = {
+    settings_gradebook_component: {
+      weighted_view_enabled: data.weightedViewEnabled,
+    },
+  };
+
+  try {
+    const response = await CourseAPI.admin.gradebook.update(adaptedData);
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) throw error.response?.data?.errors;
+    throw error;
+  }
+};

--- a/client/app/bundles/course/admin/pages/GradebookSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/GradebookSettings/translations.ts
@@ -1,0 +1,17 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  gradebookSettings: {
+    id: 'course.admin.GradebookSettings.gradebookSettings',
+    defaultMessage: 'Gradebook settings',
+  },
+  weightedViewEnabled: {
+    id: 'course.admin.GradebookSettings.weightedViewEnabled',
+    defaultMessage: 'Enable Weighted Total view',
+  },
+  weightedViewEnabledHint: {
+    id: 'course.admin.GradebookSettings.weightedViewEnabledHint',
+    defaultMessage:
+      'Enables a "Weighted Total" view in the gradebook where staff can configure per-tab weights and see a weighted total column.',
+  },
+});

--- a/client/app/bundles/course/gradebook/__tests__/ConfigureWeightsPrompt.test.tsx
+++ b/client/app/bundles/course/gradebook/__tests__/ConfigureWeightsPrompt.test.tsx
@@ -1,0 +1,546 @@
+import { fireEvent, render, screen, waitFor, within } from 'test-utils';
+
+import toast from 'lib/hooks/toast';
+
+import ConfigureWeightsPrompt from '../components/ConfigureWeightsPrompt';
+import * as operations from '../operations';
+
+// Render synchronously without the real provider's locale-loading spinner
+// (uses the manual mock at lib/components/wrappers/__mocks__/I18nProvider).
+jest.mock('lib/components/wrappers/I18nProvider');
+jest.mock('lib/hooks/toast', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+jest
+  .spyOn(operations, 'updateGradebookWeights')
+  .mockReturnValue(async () => {});
+
+const A1 = 'Assignment 1';
+const A2 = 'Assignment 2';
+const ASSIGN_A1 = 'Assignments: Assignment 1';
+const INCLUDE_A1 = 'Include Assignment 1 in grade';
+
+const categories = [{ id: 1, title: 'Missions' }];
+const tabs = [
+  { id: 10, title: 'Assignments', categoryId: 1, gradebookWeight: 50 },
+  { id: 11, title: 'Optional', categoryId: 1, gradebookWeight: 50 },
+];
+// Differing max grades to prove equal mode is 1/n (NOT proportional to max grade).
+const assessments = [
+  { id: 101, title: A1, tabId: 10, maxGrade: 100 },
+  { id: 102, title: A2, tabId: 10, maxGrade: 50 },
+];
+
+const setup = (overrides = {}): ReturnType<typeof render> =>
+  render(
+    <ConfigureWeightsPrompt
+      assessments={assessments}
+      categories={categories}
+      onClose={jest.fn()}
+      open
+      tabs={tabs}
+      {...overrides}
+    />,
+  );
+
+const modeGroup = (tabTitle: string): HTMLElement =>
+  screen.getByRole('radiogroup', { name: `${tabTitle} weight mode` });
+
+describe('<ConfigureWeightsPrompt />', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders one tab total input per tab grouped by category', () => {
+    setup();
+    expect(screen.getByText('Missions')).toBeInTheDocument();
+    expect(screen.getByLabelText('Assignments')).toHaveValue(50);
+    expect(screen.getByLabelText('Optional')).toHaveValue(50);
+  });
+
+  it('shows Total: 100% with no warning when sum = 100', () => {
+    setup();
+    expect(screen.getByText(/Total:\s*100%/)).toBeInTheDocument();
+    expect(screen.queryByText(/do not sum to 100/i)).not.toBeInTheDocument();
+  });
+
+  it('shows warning when sum != 100', () => {
+    setup();
+    fireEvent.change(screen.getByLabelText('Optional'), {
+      target: { value: '30' },
+    });
+    expect(screen.getByText(/Total:\s*80%/)).toBeInTheDocument();
+    expect(screen.getByText(/do not sum to 100/i)).toBeInTheDocument();
+  });
+
+  it('shows inline error for tab total > 100', () => {
+    setup();
+    fireEvent.change(screen.getByLabelText('Assignments'), {
+      target: { value: '101' },
+    });
+    expect(screen.getByText(/must be at most 100/i)).toBeInTheDocument();
+  });
+
+  it('shows inline error for negative tab total', () => {
+    setup();
+    fireEvent.change(screen.getByLabelText('Optional'), {
+      target: { value: '-1' },
+    });
+    expect(screen.getByText(/must be at least 0/i)).toBeInTheDocument();
+  });
+
+  it('accepts a 2dp tab total without error', () => {
+    setup();
+    fireEvent.change(screen.getByLabelText('Assignments'), {
+      target: { value: '49.55' },
+    });
+    expect(screen.queryByText(/decimal places/i)).not.toBeInTheDocument();
+  });
+
+  it('auto-rounds to 2 decimal places on blur', () => {
+    setup();
+    const input = screen.getByLabelText('Assignments');
+    fireEvent.change(input, { target: { value: '49.555' } });
+    fireEvent.blur(input);
+    expect(input).toHaveValue(49.56);
+    expect(screen.queryByText(/decimal places/i)).not.toBeInTheDocument();
+  });
+
+  it('defaults every tab to Equal mode', () => {
+    setup();
+    expect(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /equal/i }),
+    ).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('equal mode preview shows tabTotal / n per assessment (ignores max grade)', () => {
+    setup();
+    const expandBtns = screen.getAllByRole('button', { name: '' });
+    fireEvent.click(expandBtns[0]); // expand Assignments (weight 50, n=2)
+    // 1/n => 25.00 each; proportional-to-maxGrade would be 33.33 / 16.67.
+    expect(screen.getAllByText('25.00% of grade')).toHaveLength(2);
+  });
+
+  it('equal mode preview rebalances % of grade across remaining included assessments', async () => {
+    setup();
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]); // expand Assignments (50, n=2)
+    expect(screen.getAllByText('25.00% of grade')).toHaveLength(2);
+    // Exclude Assignment 2 -> the single remaining assessment now carries the full 50.
+    fireEvent.click(
+      await screen.findByRole('checkbox', {
+        name: 'Include Assignment 2 in grade',
+      }),
+    );
+    expect(screen.getByText('50.00% of grade')).toBeInTheDocument();
+    expect(screen.queryByText('25.00% of grade')).not.toBeInTheDocument();
+  });
+
+  it('switching to Custom reveals per-assessment inputs seeded to sum the tab total', () => {
+    setup();
+    fireEvent.click(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /custom/i }),
+    );
+    expect(screen.getByLabelText(ASSIGN_A1)).toHaveValue(25);
+    expect(screen.getByLabelText('Assignments: Assignment 2')).toHaveValue(25);
+  });
+
+  it('switching to Custom preserves existing non-zero assessment weights instead of reseeding', () => {
+    setup({
+      assessments: [
+        { id: 101, title: A1, tabId: 10, maxGrade: 100, gradebookWeight: 40 },
+        { id: 102, title: A2, tabId: 10, maxGrade: 50, gradebookWeight: 10 },
+      ],
+    });
+    fireEvent.click(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /custom/i }),
+    );
+    // allZero === false -> seeds left untouched (NOT redistributed to 25/25).
+    expect(screen.getByLabelText(ASSIGN_A1)).toHaveValue(40);
+    expect(screen.getByLabelText('Assignments: Assignment 2')).toHaveValue(10);
+  });
+
+  it('shows an inline error Alert and disables Save when a custom tab is unbalanced', () => {
+    setup();
+    fireEvent.click(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /custom/i }),
+    );
+    fireEvent.change(screen.getByLabelText(ASSIGN_A1), {
+      target: { value: '10' }, // 10 + 25 = 35 != 50
+    });
+    expect(screen.getByText(/must sum to its tab total/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('shows the running assessment-weight sum against the tab total', () => {
+    setup();
+    fireEvent.click(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /custom/i }),
+    );
+    fireEvent.change(screen.getByLabelText(ASSIGN_A1), {
+      target: { value: '10' }, // 10 + 25 = 35 of 50
+    });
+    expect(
+      screen.getByText('Assessment weights: 35.00 / 50.00'),
+    ).toBeInTheDocument();
+  });
+
+  it('Save sends weightMode for equal tabs and assessmentWeights for custom tabs', async () => {
+    setup();
+    fireEvent.click(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /custom/i }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(operations.updateGradebookWeights).toHaveBeenCalledWith([
+        {
+          tabId: 10,
+          weight: 50,
+          weightMode: 'custom',
+          excludedAssessmentIds: [],
+          assessmentWeights: [
+            { assessmentId: 101, weight: 25 },
+            { assessmentId: 102, weight: 25 },
+          ],
+        },
+        {
+          tabId: 11,
+          weight: 50,
+          weightMode: 'equal',
+          excludedAssessmentIds: [],
+        },
+      ]);
+    });
+  });
+
+  it('calls onClose after a successful save', async () => {
+    const onClose = jest.fn();
+    setup({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('shows an error toast and keeps the dialog open when save fails', async () => {
+    (operations.updateGradebookWeights as jest.Mock).mockReturnValueOnce(
+      async () => {
+        throw new Error('boom');
+      },
+    );
+    const onClose = jest.fn();
+    setup({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Failed to save weights. Please try again.',
+      ),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('seeds odd splits so they still sum exactly to the tab total', () => {
+    setup({
+      tabs: [
+        { id: 10, title: 'Assignments', categoryId: 1, gradebookWeight: 50 },
+      ],
+      assessments: [
+        { id: 101, title: 'A1', tabId: 10, maxGrade: 100 },
+        { id: 102, title: 'A2', tabId: 10, maxGrade: 100 },
+        { id: 103, title: 'A3', tabId: 10, maxGrade: 100 },
+      ],
+    });
+    fireEvent.click(
+      within(modeGroup('Assignments')).getByRole('radio', { name: /custom/i }),
+    );
+    expect(screen.getByLabelText('Assignments: A1')).toHaveValue(16.67);
+    expect(screen.getByLabelText('Assignments: A2')).toHaveValue(16.67);
+    expect(screen.getByLabelText('Assignments: A3')).toHaveValue(16.66);
+    expect(
+      screen.queryByText(/must sum to its tab total/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Cancel does not dispatch', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(operations.updateGradebookWeights).not.toHaveBeenCalled();
+  });
+
+  it('disables the mode toggle + expand for tabs with no assessments', () => {
+    setup();
+    const expandBtns = screen.getAllByRole('button', { name: '' });
+    expect(expandBtns[1]).toBeDisabled();
+    expect(
+      within(modeGroup('Optional')).getByRole('radio', { name: /custom/i }),
+    ).toBeDisabled();
+  });
+});
+
+describe('per-assessment exclusion', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders an include checkbox per assessment (expanded), checked by default', async () => {
+    setup();
+    // expand the Assignments tab to reveal its assessments
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]); // first expand caret
+    const cb = await screen.findByRole('checkbox', {
+      name: INCLUDE_A1,
+    });
+    expect(cb).toBeChecked();
+  });
+
+  it('sends excludedAssessmentIds for unchecked assessments on save', async () => {
+    const onClose = jest.fn();
+    setup({ onClose });
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]);
+    fireEvent.click(
+      await screen.findByRole('checkbox', {
+        name: INCLUDE_A1,
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(operations.updateGradebookWeights).toHaveBeenCalled(),
+    );
+    const arg = (operations.updateGradebookWeights as jest.Mock).mock
+      .calls[0][0];
+    const tab10 = arg.find((e: { tabId: number }) => e.tabId === 10);
+    expect(tab10.excludedAssessmentIds).toEqual([101]);
+  });
+
+  it('warns when every assessment in a tab is excluded', async () => {
+    setup();
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]);
+    fireEvent.click(
+      await screen.findByRole('checkbox', {
+        name: INCLUDE_A1,
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole('checkbox', {
+        name: 'Include Assignment 2 in grade',
+      }),
+    );
+    expect(
+      screen.getByText(/contributes nothing to the total/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows excluded count on the tab header when some assessments start excluded', () => {
+    setup({
+      assessments: [
+        {
+          id: 101,
+          title: A1,
+          tabId: 10,
+          maxGrade: 100,
+          gradebookExcluded: true,
+        },
+        { id: 102, title: A2, tabId: 10, maxGrade: 50 },
+      ],
+    });
+    // Badge is in the header row — no expand needed
+    expect(screen.getByText('1 excluded')).toBeInTheDocument();
+  });
+
+  it('does not show excluded count when no assessments are excluded', () => {
+    setup();
+    expect(screen.queryByText(/excluded/i)).not.toBeInTheDocument();
+  });
+
+  it('updates the excluded count when user toggles a checkbox', async () => {
+    setup();
+    // Expand and exclude one assessment
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]);
+    fireEvent.click(
+      await screen.findByRole('checkbox', {
+        name: INCLUDE_A1,
+      }),
+    );
+    expect(screen.getByText('1 excluded')).toBeInTheDocument();
+    // Re-include it — count should disappear
+    fireEvent.click(screen.getByRole('checkbox', { name: INCLUDE_A1 }));
+    expect(screen.queryByText(/excluded/)).not.toBeInTheDocument();
+  });
+
+  it('labels the chip "All N excluded" when every assessment is excluded', () => {
+    setup({
+      assessments: [
+        {
+          id: 101,
+          title: A1,
+          tabId: 10,
+          maxGrade: 100,
+          gradebookExcluded: true,
+        },
+        {
+          id: 102,
+          title: A2,
+          tabId: 10,
+          maxGrade: 50,
+          gradebookExcluded: true,
+        },
+      ],
+    });
+    expect(screen.getByText('All 2 excluded')).toBeInTheDocument();
+  });
+
+  it('shows 0 in the weight field and disables it when all assessments are excluded', () => {
+    setup({
+      assessments: [
+        {
+          id: 101,
+          title: A1,
+          tabId: 10,
+          maxGrade: 100,
+          gradebookExcluded: true,
+        },
+        {
+          id: 102,
+          title: A2,
+          tabId: 10,
+          maxGrade: 50,
+          gradebookExcluded: true,
+        },
+      ],
+    });
+    const field = screen.getByLabelText('Assignments');
+    expect(field).toHaveValue(0);
+    expect(field).toBeDisabled();
+  });
+
+  it('drops an all-excluded tab from the Total and restores it on re-include', async () => {
+    setup({
+      assessments: [
+        {
+          id: 101,
+          title: A1,
+          tabId: 10,
+          maxGrade: 100,
+          gradebookExcluded: true,
+        },
+        {
+          id: 102,
+          title: A2,
+          tabId: 10,
+          maxGrade: 50,
+          gradebookExcluded: true,
+        },
+        { id: 201, title: 'Optional 1', tabId: 11, maxGrade: 100 },
+      ],
+    });
+    // Assignments (50) is all-excluded -> only Optional (50) counts toward Total.
+    expect(screen.getByText(/Total:\s*50%/)).toBeInTheDocument();
+    // Re-include one assessment -> Assignments contributes its 50 again.
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]);
+    fireEvent.click(
+      await screen.findByRole('checkbox', {
+        name: INCLUDE_A1,
+      }),
+    );
+    expect(screen.getByText(/Total:\s*100%/)).toBeInTheDocument();
+  });
+
+  it('still persists the retained tab weight when all-excluded (display 0 only)', async () => {
+    setup({
+      assessments: [
+        {
+          id: 101,
+          title: A1,
+          tabId: 10,
+          maxGrade: 100,
+          gradebookExcluded: true,
+        },
+        {
+          id: 102,
+          title: A2,
+          tabId: 10,
+          maxGrade: 50,
+          gradebookExcluded: true,
+        },
+      ],
+      tabs: [
+        { id: 10, title: 'Assignments', categoryId: 1, gradebookWeight: 50 },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(operations.updateGradebookWeights).toHaveBeenCalled(),
+    );
+    const arg = (operations.updateGradebookWeights as jest.Mock).mock
+      .calls[0][0];
+    expect(arg[0]).toMatchObject({
+      tabId: 10,
+      weight: 50,
+      excludedAssessmentIds: [101, 102],
+    });
+  });
+
+  it('seeds checkboxes from gradebookExcluded and restores weight on re-include', async () => {
+    setup({
+      assessments: [
+        {
+          id: 101,
+          title: A1,
+          tabId: 10,
+          maxGrade: 100,
+          gradebookWeight: 50,
+          gradebookExcluded: true,
+        },
+        {
+          id: 102,
+          title: A2,
+          tabId: 10,
+          maxGrade: 50,
+          gradebookWeight: 0,
+        },
+      ],
+      tabs: [
+        {
+          id: 10,
+          title: 'Assignments',
+          categoryId: 1,
+          gradebookWeight: 50,
+          weightMode: 'custom',
+        },
+      ],
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: '' })[0]);
+    const cb = await screen.findByRole('checkbox', {
+      name: INCLUDE_A1,
+    });
+    expect(cb).not.toBeChecked();
+    // re-include -> its retained weight (50) is still in the input
+    fireEvent.click(cb);
+    expect(screen.getByLabelText(ASSIGN_A1)).toHaveValue(50);
+  });
+
+  describe('default weights when unconfigured', () => {
+    const zeroTabs = [
+      { id: 10, title: 'Assignments', categoryId: 1, gradebookWeight: 0 },
+      { id: 11, title: 'Optional', categoryId: 1, gradebookWeight: 0 },
+    ];
+    const bothPopulated = [
+      { id: 101, title: 'Graded item', tabId: 10, maxGrade: 100 },
+      { id: 201, title: 'Bonus item', tabId: 11, maxGrade: 100 },
+    ];
+
+    it('pre-fills an equal split summing to 100 and shows the defaults hint', () => {
+      setup({ tabs: zeroTabs, assessments: bothPopulated });
+      expect(screen.getByText(/no weights set yet/i)).toBeInTheDocument();
+      expect(screen.getByLabelText('Assignments')).toHaveValue(50);
+      expect(screen.getByLabelText('Optional')).toHaveValue(50);
+      expect(screen.getByText(/Total:\s*100%/)).toBeInTheDocument();
+    });
+
+    it('gives empty tabs 0% and the full default to the populated tab', () => {
+      // Only tab 10 has an assessment (shared fixture), so it absorbs all 100.
+      setup({ tabs: zeroTabs });
+      expect(screen.getByLabelText('Assignments')).toHaveValue(100);
+      expect(screen.getByLabelText('Optional')).toHaveValue(0);
+    });
+
+    it('does not show the defaults hint once a weight is configured', () => {
+      setup(); // shared fixture tabs carry 50/50
+      expect(screen.queryByText(/no weights set yet/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/bundles/course/gradebook/__tests__/GradebookIndex.test.tsx
+++ b/client/app/bundles/course/gradebook/__tests__/GradebookIndex.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from 'test-utils';
+import { fireEvent, render, screen, waitFor, within } from 'test-utils';
 
 import toast from 'lib/hooks/toast';
 
@@ -32,6 +32,8 @@ const emptyState = {
     students: [],
     submissions: [],
     gamificationEnabled: false,
+    weightedViewEnabled: false,
+    canManageWeights: false,
   },
 };
 
@@ -43,6 +45,8 @@ const noStudentsState = {
     students: [],
     submissions: [],
     gamificationEnabled: false,
+    weightedViewEnabled: false,
+    canManageWeights: false,
   },
 };
 
@@ -65,6 +69,8 @@ const populatedState = {
       { studentId: 1, assessmentId: 100, submissionId: 1000, grade: 8 },
     ],
     gamificationEnabled: false,
+    weightedViewEnabled: false,
+    canManageWeights: false,
   },
 };
 
@@ -72,6 +78,39 @@ const populatedStateWithGamification = {
   gradebook: {
     ...populatedState.gradebook,
     gamificationEnabled: true,
+  },
+};
+
+const populatedStateWithWeightedView = {
+  gradebook: {
+    ...populatedState.gradebook,
+    weightedViewEnabled: true,
+    canManageWeights: false,
+  },
+};
+
+const populatedStateWithWeightedViewAndGamification = {
+  gradebook: {
+    ...populatedState.gradebook,
+    weightedViewEnabled: true,
+    gamificationEnabled: true,
+    canManageWeights: false,
+  },
+};
+
+const populatedStateManagerWeightedOff = {
+  gradebook: {
+    ...populatedState.gradebook,
+    weightedViewEnabled: false,
+    canManageWeights: true,
+  },
+};
+
+const populatedStateManagerWeightedOn = {
+  gradebook: {
+    ...populatedState.gradebook,
+    weightedViewEnabled: true,
+    canManageWeights: true,
   },
 };
 
@@ -145,5 +184,67 @@ describe('GradebookIndex', () => {
         'No grade or gamification columns selected - export will include student info only.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('does not render view toggle when weightedViewEnabled is false', async () => {
+    render(<GradebookIndex />, { state: populatedState });
+    // Wait for loading to finish
+    await screen.findByRole('button', { name: /export/i });
+    expect(screen.queryByText(/weighted total/i)).not.toBeInTheDocument();
+  });
+
+  it('renders view toggle when weightedViewEnabled is true', async () => {
+    render(<GradebookIndex />, { state: populatedStateWithWeightedView });
+    expect(await screen.findByText(/all assessments/i)).toBeInTheDocument();
+    expect(await screen.findByText(/weighted total/i)).toBeInTheDocument();
+  });
+
+  it('switches to Weighted Total view on toggle click', async () => {
+    render(<GradebookIndex />, { state: populatedStateWithWeightedView });
+    const byWeightButton = await screen.findByText(/weighted total/i);
+    fireEvent.click(byWeightButton);
+    expect(
+      await screen.findByTestId('gradebook-weighted-table'),
+    ).toBeInTheDocument();
+  });
+
+  it('weighted view does not expose gamification columns in picker', async () => {
+    render(<GradebookIndex />, {
+      state: populatedStateWithWeightedViewAndGamification,
+    });
+    const byWeightButton = await screen.findByText(/weighted total/i);
+    fireEvent.click(byWeightButton);
+    await screen.findByTestId('gradebook-weighted-table');
+    fireEvent.click(
+      await screen.findByRole('button', { name: /select columns/i }),
+    );
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).queryByText('Level')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Total XP')).not.toBeInTheDocument();
+  });
+
+  describe('weighted-view discoverability hint', () => {
+    it('shows the hint to managers when the weighted view is off', async () => {
+      render(<GradebookIndex />, { state: populatedStateManagerWeightedOff });
+      expect(
+        await screen.findByRole('link', { name: /gradebook settings/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the hint once the weighted view is enabled', async () => {
+      render(<GradebookIndex />, { state: populatedStateManagerWeightedOn });
+      await screen.findByText(/weighted total/i); // wait for data to load
+      expect(
+        screen.queryByRole('link', { name: /gradebook settings/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show the hint to staff who cannot manage weights', async () => {
+      render(<GradebookIndex />, { state: populatedState });
+      await screen.findByRole('button', { name: /export/i }); // wait for load
+      expect(
+        screen.queryByRole('link', { name: /gradebook settings/i }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/app/bundles/course/gradebook/__tests__/ProjectedTotalHint.test.tsx
+++ b/client/app/bundles/course/gradebook/__tests__/ProjectedTotalHint.test.tsx
@@ -1,0 +1,54 @@
+import { store as appStore } from 'store';
+import { fireEvent, render, screen } from 'test-utils';
+
+import ProjectedTotalHint, {
+  PROJECTED_TOTAL_POLICY_HINT_KEY,
+} from '../components/ProjectedTotalHint';
+
+// Render synchronously without the real provider's locale-loading spinner
+// (uses the manual mock at lib/components/wrappers/__mocks__/I18nProvider).
+jest.mock('lib/components/wrappers/I18nProvider');
+
+const USER_ID = 42;
+const STORAGE_KEY = `${USER_ID}:${PROJECTED_TOTAL_POLICY_HINT_KEY}`;
+
+const userState = {
+  global: {
+    ...appStore.getState().global,
+    user: {
+      ...appStore.getState().global.user,
+      user: { id: USER_ID, name: '', imageUrl: '' },
+    },
+  },
+};
+
+const renderHint = (): void => {
+  render(<ProjectedTotalHint />, { state: userState });
+};
+
+beforeEach(() => localStorage.clear());
+
+describe('ProjectedTotalHint', () => {
+  it('teaches the projected-total policy on first view', () => {
+    renderHint();
+    expect(screen.getByText(/ungraded assessments as 0/i)).toBeInTheDocument();
+  });
+
+  it('hides and persists dismissal when the close button is clicked', () => {
+    renderHint();
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(
+      screen.queryByText(/ungraded assessments as 0/i),
+    ).not.toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('does not render when already dismissed', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    renderHint();
+    expect(
+      screen.queryByText(/ungraded assessments as 0/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/app/bundles/course/gradebook/__tests__/WeightedGradebookColumnTree.test.tsx
+++ b/client/app/bundles/course/gradebook/__tests__/WeightedGradebookColumnTree.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, within } from 'test-utils';
+
+import WeightedGradebookColumnTree from '../components/WeightedGradebookColumnTree';
+
+// Render synchronously without the real provider's locale-loading spinner
+// (uses the manual mock at lib/components/wrappers/__mocks__/I18nProvider).
+jest.mock('lib/components/wrappers/I18nProvider');
+
+const STUDENT_INFO = 'Student info';
+
+const baseContext = {
+  isVisible: (): boolean => false,
+  setVisible: (): void => {},
+  setManyVisible: (): void => {},
+};
+
+describe('WeightedGradebookColumnTree', () => {
+  it('renders Student info group with a locked Name and a toggleable Email', () => {
+    render(<WeightedGradebookColumnTree {...baseContext} />);
+    expect(screen.getByText(STUDENT_INFO)).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Always included')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+
+  it('renders Name as a checked, disabled checkbox that cannot be toggled', () => {
+    const setVisible = jest.fn();
+    render(
+      <WeightedGradebookColumnTree {...baseContext} setVisible={setVisible} />,
+    );
+    const nameRow = screen.getByText('Name').closest('label')!;
+    const nameCheckbox = within(nameRow).getByRole('checkbox');
+    expect(nameCheckbox).toBeChecked();
+    expect(nameCheckbox).toBeDisabled();
+    nameCheckbox.click();
+    expect(setVisible).not.toHaveBeenCalled();
+  });
+
+  it('renders Email and External ID checked when isVisible returns true', () => {
+    render(
+      <WeightedGradebookColumnTree
+        {...baseContext}
+        isVisible={(): boolean => true}
+      />,
+    );
+    const emailRow = screen.getByText('Email').closest('label')!;
+    expect(within(emailRow).getByRole('checkbox')).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /external id/i }),
+    ).toBeChecked();
+  });
+
+  it('calls setVisible with false when a visible Email checkbox is unchecked', () => {
+    const setVisible = jest.fn();
+    render(
+      <WeightedGradebookColumnTree
+        {...baseContext}
+        isVisible={(): boolean => true}
+        setVisible={setVisible}
+      />,
+    );
+    const emailRow = screen.getByText('Email').closest('label')!;
+    within(emailRow).getByRole('checkbox').click();
+    expect(setVisible).toHaveBeenCalledWith('email', false);
+  });
+
+  it('does not render Gamification group', () => {
+    render(<WeightedGradebookColumnTree {...baseContext} />);
+    expect(screen.queryByText('Gamification')).not.toBeInTheDocument();
+    expect(screen.queryByText('Level')).not.toBeInTheDocument();
+    expect(screen.queryByText('Total XP')).not.toBeInTheDocument();
+  });
+
+  it('calls setVisible when Email is toggled', async () => {
+    const setVisible = jest.fn();
+    render(
+      <WeightedGradebookColumnTree {...baseContext} setVisible={setVisible} />,
+    );
+    const emailRow = screen.getByText('Email').closest('label')!;
+    within(emailRow).getByRole('checkbox').click();
+    expect(setVisible).toHaveBeenCalledWith('email', true);
+  });
+
+  it('renders an External ID checkbox in the Student info group', () => {
+    render(<WeightedGradebookColumnTree {...baseContext} />);
+    expect(
+      screen.getByRole('checkbox', { name: /external id/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls setVisible with externalId when the External ID checkbox is toggled', () => {
+    const setVisible = jest.fn();
+    render(
+      <WeightedGradebookColumnTree {...baseContext} setVisible={setVisible} />,
+    );
+    screen.getByRole('checkbox', { name: /external id/i }).click();
+    expect(setVisible).toHaveBeenCalledWith('externalId', true);
+  });
+
+  it('renders the Student info parent checkbox unchecked when no children are visible', () => {
+    render(<WeightedGradebookColumnTree {...baseContext} />);
+    const groupRow = screen.getByText(STUDENT_INFO).closest('label')!;
+    expect(within(groupRow).getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('renders the Student info parent checkbox checked when all children are visible', () => {
+    render(
+      <WeightedGradebookColumnTree
+        {...baseContext}
+        isVisible={(): boolean => true}
+      />,
+    );
+    const groupRow = screen.getByText(STUDENT_INFO).closest('label')!;
+    expect(within(groupRow).getByRole('checkbox')).toBeChecked();
+  });
+
+  it('shows the Student info parent checkbox as indeterminate when only some children are visible', () => {
+    render(
+      <WeightedGradebookColumnTree
+        {...baseContext}
+        isVisible={(id): boolean => id === 'email'}
+      />,
+    );
+    expect(
+      screen.getByRole('checkbox', { name: /student info/i }),
+    ).toHaveAttribute('data-indeterminate', 'true');
+  });
+
+  it('calls setManyVisible to bulk-show all Student info columns when the parent is checked', () => {
+    const setManyVisible = jest.fn();
+    render(
+      <WeightedGradebookColumnTree
+        {...baseContext}
+        setManyVisible={setManyVisible}
+      />,
+    );
+    const groupRow = screen.getByText(STUDENT_INFO).closest('label')!;
+    within(groupRow).getByRole('checkbox').click();
+    expect(setManyVisible).toHaveBeenCalledWith(
+      ['name', 'email', 'externalId'],
+      true,
+    );
+  });
+
+  it('calls setManyVisible to bulk-hide all Student info columns when the parent is unchecked', () => {
+    const setManyVisible = jest.fn();
+    render(
+      <WeightedGradebookColumnTree
+        {...baseContext}
+        isVisible={(): boolean => true}
+        setManyVisible={setManyVisible}
+      />,
+    );
+    const groupRow = screen.getByText(STUDENT_INFO).closest('label')!;
+    within(groupRow).getByRole('checkbox').click();
+    expect(setManyVisible).toHaveBeenCalledWith(
+      ['name', 'email', 'externalId'],
+      false,
+    );
+  });
+});

--- a/client/app/bundles/course/gradebook/__tests__/WeightedGradebookTable.test.tsx
+++ b/client/app/bundles/course/gradebook/__tests__/WeightedGradebookTable.test.tsx
@@ -1,0 +1,1333 @@
+import userEvent from '@testing-library/user-event';
+import { store as appStore } from 'store';
+import { render, screen, waitFor, within } from 'test-utils';
+
+import WeightedGradebookTable from '../components/WeightedGradebookTable';
+import type {
+  AssessmentData,
+  CategoryData,
+  StudentData,
+  SubmissionData,
+  TabData,
+} from '../types';
+
+// Render synchronously without the real provider's locale-loading spinner
+// (uses the manual mock at lib/components/wrappers/__mocks__/I18nProvider).
+jest.mock('lib/components/wrappers/I18nProvider');
+
+const USER_ID = 42;
+const WEIGHTED_STORAGE_KEY = `${USER_ID}:gradebook_weighted_columns_1`;
+const EXTERNAL_ID = 'External ID';
+
+// Mirrors the component's data-testid for a breakdown row:
+// `breakdown-row-${studentId}-${tabId}-${assessmentId}`.
+const breakdownRowId = (
+  studentId: number,
+  tabId: number,
+  assessmentId: number,
+): string => `breakdown-row-${studentId}-${tabId}-${assessmentId}`;
+const userState = {
+  global: {
+    ...appStore.getState().global,
+    user: {
+      ...appStore.getState().global.user,
+      user: { id: USER_ID, name: '', imageUrl: '' },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Minimal shared fixtures
+// ---------------------------------------------------------------------------
+const makeCategory = (id: number, title: string): CategoryData => ({
+  id,
+  title,
+});
+
+const makeTab = (
+  id: number,
+  title: string,
+  categoryId: number,
+  gradebookWeight = 50,
+): TabData => ({ id, title, categoryId, gradebookWeight });
+
+const makeAssessment = (
+  id: number,
+  title: string,
+  tabId: number,
+  maxGrade: number,
+): AssessmentData => ({ id, title, tabId, maxGrade });
+
+const makeStudent = (id: number, name: string): StudentData => ({
+  id,
+  name,
+  email: `${name.toLowerCase()}@example.com`,
+  externalId: null,
+  level: 1,
+  totalXp: 0,
+});
+
+const makeSub = (
+  studentId: number,
+  assessmentId: number,
+  grade: number | null,
+): SubmissionData => ({ submissionId: 0, studentId, assessmentId, grade });
+
+interface RenderWeightedOptions {
+  categories?: CategoryData[];
+  tabs?: TabData[];
+  assessments?: AssessmentData[];
+  students?: StudentData[];
+  submissions?: SubmissionData[];
+  canManageWeights?: boolean;
+  courseTitle?: string;
+  courseId?: number;
+}
+
+const renderWeighted = (
+  opts: RenderWeightedOptions = {},
+): ReturnType<typeof render> => {
+  const cats = opts.categories ?? [makeCategory(1, 'Cat A')];
+  const tabs = opts.tabs ?? [makeTab(10, 'Tab 1', 1, 100)];
+  const assessments = opts.assessments ?? [
+    makeAssessment(100, 'Quiz 1', 10, 150),
+  ];
+  const students = opts.students ?? [makeStudent(1, 'Alice')];
+  const submissions = opts.submissions ?? [];
+  return render(
+    <WeightedGradebookTable
+      assessments={assessments}
+      canManageWeights={opts.canManageWeights ?? true}
+      categories={cats}
+      courseId={opts.courseId ?? 1}
+      courseTitle={opts.courseTitle ?? 'Test Course'}
+      students={students}
+      submissions={submissions}
+      tabs={tabs}
+    />,
+    { state: userState },
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('WeightedGradebookTable', () => {
+  beforeEach(() => localStorage.clear());
+
+  // 1. Row 1: category cells with colSpan
+  it('renders category cells in row 1 with colSpan equal to number of tabs in that category', () => {
+    const cats = [makeCategory(1, 'Cat A'), makeCategory(2, 'Cat B')];
+    const tabs = [
+      makeTab(10, 'Tab 1', 1, 50),
+      makeTab(11, 'Tab 2', 1, 50),
+      makeTab(20, 'Tab 3', 2, 0),
+    ];
+    const assessments = [
+      makeAssessment(100, 'Q1', 10, 10),
+      makeAssessment(101, 'Q2', 11, 10),
+      makeAssessment(102, 'Q3', 20, 10),
+    ];
+    renderWeighted({ categories: cats, tabs, assessments });
+    const thead = document.querySelector('thead')!;
+    const rows = thead.querySelectorAll('tr');
+    const row1Cells = rows[0].querySelectorAll('th');
+    const catACell = Array.from(row1Cells).find(
+      (c) => c.textContent === 'Cat A',
+    );
+    const catBCell = Array.from(row1Cells).find(
+      (c) => c.textContent === 'Cat B',
+    );
+    expect(catACell).toBeTruthy();
+    expect(catBCell).toBeTruthy();
+    expect(
+      catACell!.getAttribute('colspan') ?? catACell!.colSpan.toString(),
+    ).toBe('2');
+    expect(
+      catBCell!.getAttribute('colspan') ?? catBCell!.colSpan.toString(),
+    ).toBe('1');
+  });
+
+  // 1b. Category not in tabs → header absent
+  it('does not render a category header for categories with no tabs', () => {
+    renderWeighted({
+      categories: [makeCategory(1, 'Active'), makeCategory(2, 'Ghost')],
+      tabs: [makeTab(10, 'Tab 1', 1, 100)], // only category 1 has a tab
+    });
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.queryByText('Ghost')).not.toBeInTheDocument();
+  });
+
+  // 2. Row 2: tab title cells
+  it('renders tab title cells in row 2', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Homework', 1, 60), makeTab(11, 'Exams', 1, 40)],
+    });
+    const thead = document.querySelector('thead')!;
+    const row2 = thead.querySelectorAll('tr')[1];
+    expect(
+      within(row2 as HTMLElement).getByText('Homework'),
+    ).toBeInTheDocument();
+    expect(within(row2 as HTMLElement).getByText('Exams')).toBeInTheDocument();
+  });
+
+  // 3. Weight subheader shows "/N" (points-out-of) per tab by default
+  it('shows "/N" points subheader for each tab in row 3 by default', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 30), makeTab(11, 'Tab 2', 1, 70)],
+    });
+    expect(screen.getByText('/30')).toBeInTheDocument();
+    expect(screen.getByText('/70')).toBeInTheDocument();
+  });
+
+  // 4a. Total column shows "/100" when sum = 100 (points default)
+  it('shows "/100" in total column header when weights sum to 100', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 60), makeTab(11, 'Tab 2', 1, 40)],
+    });
+    expect(screen.getByText('/100')).toBeInTheDocument();
+  });
+
+  // 4b. Total column shows just "/N" on one line when sum ≠ 100
+  it('shows "/N" when weight sum ≠ 100 in total header', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 30), makeTab(11, 'Tab 2', 1, 30)],
+    });
+    expect(screen.getByText('/60')).toBeInTheDocument();
+  });
+
+  // 4c. Hovering the warning-coloured total reveals the full message via tooltip
+  it('total tooltip explains the unbalanced sum on hover', async () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 60), makeTab(11, 'Tab 2', 1, 20)],
+    });
+    await userEvent.hover(screen.getByText('/80'));
+    await waitFor(() =>
+      expect(
+        screen.getByText('Weights do not sum to 100. Total may be inaccurate.'),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  // 4b. Total column shows just "/N" on one line when sum ≠ 100
+  it('shows "N% total" when sum ≠ 100 in total header', async () => {
+    const user = userEvent.setup();
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 30), makeTab(11, 'Tab 2', 1, 30)],
+    });
+    await user.click(screen.getByRole('radio', { name: /percentage/i }));
+    const thead = document.querySelector('thead')!;
+    const row3 = thead.querySelectorAll('tr')[2] as HTMLElement;
+    expect(within(row3).getByText('60% total')).toBeInTheDocument();
+  });
+
+  // 4d. Percent mode, weights = 100 → total header shows exact "100% total"
+  it('total column header shows "100% total" in percent mode when sum = 100', async () => {
+    const user = userEvent.setup();
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 60), makeTab(11, 'Tab 2', 1, 40)],
+    });
+    await user.click(screen.getByRole('radio', { name: /percentage/i }));
+    const thead = document.querySelector('thead')!;
+    const row3 = thead.querySelectorAll('tr')[2] as HTMLElement;
+    expect(within(row3).getByText('100% total')).toBeInTheDocument();
+  });
+
+  // 5. Cell renders subtotal × weight as points (not percentage); non-integer → 2dp
+  it('renders cell as subtotal × weight in points (not a percentage); 2dp when non-integer', () => {
+    // grade=130, maxGrade=150 → subtotal=130/150≈0.8667; weight=100
+    // points = 0.8667 × 100 = 86.67 (non-integer → 2dp)
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 150)],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [makeSub(1, 100, 130)],
+    });
+    expect(screen.getAllByText('86.67').length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 5b. Column precision: 1dp — all values shown at 1dp when any value needs 1dp
+  it('shows 1dp for all values in a column when any value needs 1dp but none needs 2dp', () => {
+    // grade=15, maxGrade=40, weight=100 → 37.5 (needs 1dp)
+    // grade=20, maxGrade=40, weight=100 → 50.0 (integer alone, but column needs 1dp)
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 40)],
+      students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      submissions: [makeSub(1, 100, 15), makeSub(2, 100, 20)],
+    });
+    // Tab cell + total cell both show the same value for single-tab setup
+    expect(screen.getAllByText('37.5').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('50.0').length).toBeGreaterThanOrEqual(1);
+    // Confirm the old 2dp format is NOT shown
+    expect(screen.queryByText('37.50')).not.toBeInTheDocument();
+    expect(screen.queryByText('50.00')).not.toBeInTheDocument();
+  });
+
+  // 5c. Column precision: 2dp forces all values to 2dp, even whole numbers
+  it('shows 2dp for ALL values in a column when any value needs 2dp', () => {
+    // Alice: grade=130, maxGrade=150, weight=100 → 86.67 (needs 2dp)
+    // Bob: grade=150, maxGrade=150, weight=100 → 100 (integer, but column needs 2dp)
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 150)],
+      students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      submissions: [makeSub(1, 100, 130), makeSub(2, 100, 150)],
+    });
+    expect(screen.getAllByText('86.67').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('100.00').length).toBeGreaterThanOrEqual(1);
+    // Confirm the integer format is NOT shown in any table cell
+    expect(
+      screen.queryAllByRole('cell').some((c) => c.textContent === '100'),
+    ).toBe(false);
+  });
+
+  // 5d. Different columns can have independent precision
+  it('applies column precision independently per tab column', () => {
+    // Tab 1 weight=100: Alice → 86.67 (2dp); Tab 2 weight=40: Alice → 36 (integer)
+    renderWeighted({
+      categories: [makeCategory(1, 'Cat A')],
+      tabs: [makeTab(10, 'Tab 1', 1, 100), makeTab(20, 'Tab 2', 1, 40)],
+      assessments: [
+        makeAssessment(100, 'Q1', 10, 150),
+        makeAssessment(200, 'Q2', 20, 100),
+      ],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [makeSub(1, 100, 130), makeSub(1, 200, 90)],
+    });
+    // Tab 1: 86.67 (2dp); Tab 2: 36 (integer)
+    expect(screen.getByText('86.67')).toBeInTheDocument();
+    expect(screen.getByText('36')).toBeInTheDocument();
+  });
+
+  // 5e. Total column precision is independent of tab column precision
+  it('total column uses its own column precision', () => {
+    // Tab 1 weight=100: Alice=86.67, Bob=100.00; total=86.67 and 100.00
+    // Both totals have same precision as tab (2dp), but they're independently computed
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 150)],
+      students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      submissions: [makeSub(1, 100, 130), makeSub(2, 100, 150)],
+    });
+    // Total for Alice = 86.67 (needs 2dp), so all totals show 2dp
+    expect(screen.getAllByText('86.67').length).toBeGreaterThanOrEqual(2); // tab cell + total cell
+    expect(screen.getAllByText('100.00').length).toBeGreaterThanOrEqual(2);
+  });
+
+  // 6a. Tab with no assessments → cell shows "—"
+  it('shows "—" for a tab with no assessments', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Empty Tab', 1, 100)],
+      assessments: [],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [],
+    });
+    const aliceRow = screen.getByText('Alice').closest('tr')!;
+    const cells = within(aliceRow).getAllByRole('cell');
+    // The tab cell (between Name and Total) renders "—" for an empty tab.
+    expect(cells[cells.length - 2]).toHaveTextContent('—');
+  });
+
+  // 6b. Total cell shows "—" when every tab subtotal is null (no assessments at all)
+  it('shows "—" in the total cell when the row has no contributing tabs', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Empty Tab', 1, 100)],
+      assessments: [],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [],
+    });
+    const aliceRow = screen.getByText('Alice').closest('tr')!;
+    const cells = within(aliceRow).getAllByRole('cell');
+    expect(cells[cells.length - 1]).toHaveTextContent('—');
+  });
+
+  // 7. Student with no graded submissions → cell shows 0 (ungraded count as 0)
+  it('shows 0 when student has no graded submissions in a tab', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 10)],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [],
+    });
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 7b. Total cell shows 0 when all assessments are ungraded
+  it('shows 0 in both the tab cell and the total cell when all assessments are ungraded', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 10)],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [],
+    });
+    // tab cell = 0, total cell = 0 → at least 2 zeros
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(2);
+  });
+
+  // 8. Total equals the sum of the row's cells
+  it('total cell equals the sum of per-tab point cells', () => {
+    // tab10 equal-weight: (80/100 + 50/50) / 2 = 0.9 → points = 60*0.9 = 54
+    // tab20 equal-weight: 90/100 = 0.9 → points = 40*0.9 = 36
+    // total = 54 + 36 = 90
+    renderWeighted({
+      categories: [makeCategory(1, 'Cat A')],
+      tabs: [makeTab(10, 'Tab 1', 1, 60), makeTab(20, 'Tab 2', 1, 40)],
+      assessments: [
+        makeAssessment(1, 'A1', 10, 100),
+        makeAssessment(2, 'A2', 10, 50),
+        makeAssessment(3, 'A3', 20, 100),
+      ],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [makeSub(1, 1, 80), makeSub(1, 2, 50), makeSub(1, 3, 90)],
+    });
+    expect(screen.getByText('54')).toBeInTheDocument();
+    expect(screen.getByText('36')).toBeInTheDocument();
+    expect(screen.getByText('90')).toBeInTheDocument();
+  });
+
+  // 9. Ungraded assessments always count as 0
+  it('counts ungraded assessments as 0 in the subtotal', () => {
+    // Q1 graded (40/50), Q2 ungraded → (40/50 + 0) / 2 = 0.4; weight=100 → 40 pts
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [
+        makeAssessment(100, 'Q1', 10, 50),
+        makeAssessment(101, 'Q2', 10, 50),
+      ],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [makeSub(1, 100, 40)],
+    });
+    expect(screen.getAllByText('40').length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 10. No weights configured but tabs have assessments → equal-split default
+  // banner (with Configure CTA for managers), not the bare empty state.
+  it('shows the default-weights banner when no weights are configured', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 0), makeTab(11, 'Tab 2', 1, 0)],
+      assessments: [
+        makeAssessment(100, 'Quiz 1', 10, 150),
+        makeAssessment(101, 'Quiz 2', 11, 100),
+      ],
+    });
+    expect(screen.getByText(/showing default weights/i)).toBeInTheDocument();
+    expect(screen.getByText(/set your own/i)).toBeInTheDocument();
+  });
+
+  // 10a. Default split feeds the totals: two tabs → 50/100 each, summing to 100.
+  it('applies an equal split (sums to 100) when no weights are configured', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 0), makeTab(11, 'Tab 2', 1, 0)],
+      assessments: [
+        makeAssessment(100, 'Quiz 1', 10, 100),
+        makeAssessment(101, 'Quiz 2', 11, 100),
+      ],
+    });
+    // Total subheader reads "/100" (points), with no "does not sum" warning.
+    expect(screen.getByText('/100')).toBeInTheDocument();
+    expect(screen.queryByText(/does not sum to 100/i)).not.toBeInTheDocument();
+  });
+
+  // 10b. No weights configured + canManageWeights=false → no-access default copy
+  it('shows the no-access default-weights banner when canManageWeights is false', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 0)],
+      canManageWeights: false,
+    });
+    expect(
+      screen.getByText(/until weights are configured/i),
+    ).toBeInTheDocument();
+  });
+
+  // 10d. Degenerate case: weights 0 AND no assessments to default → bare empty state
+  it('shows the bare empty-state banner when no tab has any assessment', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 0)],
+      assessments: [],
+    });
+    expect(screen.getByText(/no weights configured/i)).toBeInTheDocument();
+  });
+
+  // 10c. At least one non-zero weight → banner absent
+  it('does not show empty-state banner when at least one tab has a non-zero weight', () => {
+    renderWeighted({
+      tabs: [makeTab(10, 'Tab 1', 1, 50)],
+    });
+    expect(
+      screen.queryByText(/no weights configured/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/no tab weights have been configured yet/i),
+    ).not.toBeInTheDocument();
+  });
+
+  // 11. canManageWeights === false → no "Configure Weights" button
+  it('does not show Configure Weights button when canManageWeights is false', () => {
+    renderWeighted({ canManageWeights: false });
+    expect(
+      screen.queryByRole('button', { name: /configure weights/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // 12. canManageWeights === true → "Configure Weights" button present
+  it('shows Configure Weights button when canManageWeights is true', () => {
+    renderWeighted({ canManageWeights: true });
+    expect(
+      screen.getByRole('button', { name: /configure weights/i }),
+    ).toBeInTheDocument();
+  });
+
+  // 13. Search bar is rendered
+  it('renders a search bar', () => {
+    renderWeighted();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  // 14. Typing in the search bar filters student rows
+  it('filters student rows when typing a name in the search bar', async () => {
+    const user = userEvent.setup();
+    renderWeighted({
+      students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+    });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+
+    await user.type(screen.getByRole('textbox'), 'Alice');
+
+    await waitFor(() =>
+      expect(screen.queryByText('Bob')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  // 14b. Typing an external ID filters student rows (externalId column is searchable)
+  it('filters student rows when typing an external ID in the search bar', async () => {
+    const user = userEvent.setup();
+    renderWeighted({
+      students: [
+        { ...makeStudent(1, 'Alice'), externalId: 'EXT-001' },
+        { ...makeStudent(2, 'Bob'), externalId: 'EXT-002' },
+      ],
+    });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+
+    await user.type(screen.getByRole('textbox'), 'EXT-001');
+
+    await waitFor(() =>
+      expect(screen.queryByText('Bob')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  // 14c. Typing an email filters student rows when Email column is visible
+  it('filters student rows when typing an email in the search bar', async () => {
+    const user = userEvent.setup();
+
+    localStorage.setItem(WEIGHTED_STORAGE_KEY, JSON.stringify({ email: true }));
+
+    renderWeighted({
+      students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+    });
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+
+    await user.type(screen.getByRole('textbox'), 'alice@example.com');
+
+    await waitFor(() =>
+      expect(screen.queryByText('Bob')).not.toBeInTheDocument(),
+    );
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  // 15. Pagination controls appear when there are more students than the page size
+  it('shows pagination controls when students exceed the default page size', () => {
+    const manyStudents = Array.from({ length: 101 }, (_, i) =>
+      makeStudent(i + 1, `Student ${i + 1}`),
+    );
+    renderWeighted({ students: manyStudents });
+    expect(screen.getByText('1-100 / 101')).toBeInTheDocument();
+  });
+
+  // 16. Row selection checkboxes are rendered for each student
+  it('renders checkboxes for row selection', () => {
+    renderWeighted({
+      students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+    });
+    // One "select all" header checkbox + one per student row
+    expect(screen.getAllByRole('checkbox').length).toBeGreaterThanOrEqual(3);
+  });
+
+  describe('column picker', () => {
+    it('shows Select Columns and Export buttons', () => {
+      renderWeighted();
+      expect(
+        screen.getByRole('button', { name: /select columns/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /export/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Export all rows" when no rows are selected', () => {
+      renderWeighted();
+      expect(
+        screen.getByRole('button', { name: /export all rows/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Export 1 row" when one row is selected', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      });
+      const checkboxes = screen.getAllByRole('checkbox');
+      // checkboxes[0] is header "select all"; [1] is the first row
+      await user.click(checkboxes[1]);
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /export 1 row/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it('shows "Export all rows" when all rows are selected', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      });
+      const checkboxes = screen.getAllByRole('checkbox');
+      // checkboxes[0] is the header "select all" checkbox
+      await user.click(checkboxes[0]);
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /export all rows/i }),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.queryByRole('button', { name: /export 2 rows/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows export tooltip when no rows are selected', async () => {
+      renderWeighted();
+      await userEvent.hover(
+        screen.getByRole('button', { name: /export all rows/i }),
+      );
+      await waitFor(() =>
+        expect(
+          screen.getByText('No rows selected - all rows will be exported.'),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it('hides the export tooltip when at least one row is selected', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      });
+      const checkboxes = screen.getAllByRole('checkbox');
+      await user.click(checkboxes[1]);
+      const exportBtn = await screen.findByRole('button', {
+        name: /export 1 row/i,
+      });
+      await userEvent.hover(exportBtn);
+      await waitFor(() =>
+        expect(
+          screen.queryByText('No rows selected - all rows will be exported.'),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it('lists Email in the picker dialog (no gamification columns)', async () => {
+      const user = userEvent.setup();
+      renderWeighted();
+      await user.click(screen.getByRole('button', { name: /select columns/i }));
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText('Email')).toBeInTheDocument();
+      expect(
+        within(dialog).queryByText('Gamification'),
+      ).not.toBeInTheDocument();
+      expect(within(dialog).queryByText('Level')).not.toBeInTheDocument();
+      expect(within(dialog).queryByText('Total XP')).not.toBeInTheDocument();
+    });
+
+    it('puts the select-all checkbox in an indeterminate state on a partial selection', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        students: [makeStudent(1, 'Alice'), makeStudent(2, 'Bob')],
+      });
+      const checkboxes = screen.getAllByRole('checkbox');
+      await user.click(checkboxes[1]); // select one of two rows
+      await waitFor(() =>
+        // MUI marks the indeterminate checkbox input with data-indeterminate="true"
+        expect(checkboxes[0]).toHaveAttribute('data-indeterminate', 'true'),
+      );
+    });
+  });
+
+  describe('truncation tooltips', () => {
+    it('shows a tooltip with the student name on hover', async () => {
+      const user = userEvent.setup();
+      renderWeighted({ students: [makeStudent(1, 'Alice')] });
+      await user.hover(screen.getByText('Alice'));
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('Alice');
+    });
+
+    it('shows a tooltip with the tab title on hover of the tab header', async () => {
+      const user = userEvent.setup();
+      renderWeighted({ tabs: [makeTab(10, 'Recitation Quizzes', 1, 100)] });
+      await user.hover(screen.getByText('Recitation Quizzes'));
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        'Recitation Quizzes',
+      );
+    });
+
+    it('shows a tooltip with the email on hover when the Email column is shown', async () => {
+      const user = userEvent.setup();
+      localStorage.setItem(
+        WEIGHTED_STORAGE_KEY,
+        JSON.stringify({ email: true }),
+      );
+      const { email } = makeStudent(1, 'Alice');
+      renderWeighted({ students: [makeStudent(1, 'Alice')] });
+      await user.hover(screen.getByText(email));
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(email);
+    });
+
+    it('shows a tooltip with the assessment title on hover of a breakdown row title', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        students: [makeStudent(1, 'Alice')],
+        tabs: [makeTab(10, 'Tab 1', 1, 100)],
+        assessments: [makeAssessment(100, 'Mission 1', 10, 10)],
+        submissions: [makeSub(1, 100, 5)],
+      });
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      await user.hover(await screen.findByText('Mission 1'));
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('Mission 1');
+    });
+  });
+
+  describe('name column auto-expands with row breakdown', () => {
+    // colgroup order: checkbox(0) | name(1) | [email] | [externalId] | tabs | total
+    const nameCol = (): HTMLElement =>
+      document.querySelectorAll('colgroup col')[1] as HTMLElement;
+
+    it('keeps the Name column collapsed while all rows are collapsed', () => {
+      renderWeighted({ students: [makeStudent(1, 'Alice')] });
+      expect(nameCol().style.width).toBe('150px');
+    });
+
+    it('widens the Name column when a row is expanded and restores it on collapse', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        students: [makeStudent(1, 'Alice')],
+        tabs: [makeTab(10, 'Tab 1', 1, 100)],
+        assessments: [makeAssessment(100, 'Mission 1', 10, 10)],
+        submissions: [makeSub(1, 100, 5)],
+      });
+      expect(nameCol().style.width).toBe('150px');
+
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      expect(nameCol().style.width).toBe('260px');
+
+      await user.click(screen.getByRole('button', { name: /collapse Alice/i }));
+      expect(nameCol().style.width).toBe('150px');
+    });
+  });
+
+  describe('row-expand breakdown', () => {
+    const expandable = {
+      tabs: [makeTab(10, 'Missions', 1, 60), makeTab(20, 'Quizzes', 1, 40)],
+      assessments: [
+        makeAssessment(1, 'Mission 1', 10, 100),
+        makeAssessment(2, 'Mission 2', 10, 50),
+        makeAssessment(3, 'Quiz 1', 20, 100),
+      ],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [
+        makeSub(1, 1, 80), // 0.8
+        makeSub(1, 2, 50), // 1.0
+        makeSub(1, 3, 90), // 0.9
+      ],
+    };
+
+    it('renders an expand control on each student row', () => {
+      renderWeighted(expandable);
+      expect(
+        screen.getByRole('button', { name: /expand Alice/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show assessment breakdown until expanded', () => {
+      renderWeighted(expandable);
+      expect(screen.queryByText(/Mission 1/)).not.toBeInTheDocument();
+    });
+
+    it('shows per-assessment grade and points after expanding, and hides on collapse', async () => {
+      const user = userEvent.setup();
+      renderWeighted(expandable);
+      const toggle = screen.getByRole('button', { name: /expand Alice/i });
+      await user.click(toggle);
+      // grade/max shown in the muted "raw · weightage" subtitle
+      expect(await screen.findByText(/Mission 1/)).toBeInTheDocument();
+      expect(screen.getByText(/80\/100 ·/)).toBeInTheDocument();
+      // points contribution: Mission 1 = (0.8/2)*60 = 24
+      const detail = screen.getByTestId(breakdownRowId(1, 10, 1));
+      expect(within(detail).getByText('24')).toBeInTheDocument();
+      // collapse
+      await user.click(screen.getByRole('button', { name: /collapse Alice/i }));
+      await waitFor(() =>
+        expect(screen.queryByText(/Mission 1/)).not.toBeInTheDocument(),
+      );
+    });
+
+    it('shows only the assessment name in the breakdown, without the tab prefix', async () => {
+      const user = userEvent.setup();
+      renderWeighted(expandable);
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      const detail = await screen.findByTestId(breakdownRowId(1, 10, 1));
+      // Assessment name shown verbatim on its own line — not tab-prefixed as
+      // "Missions · Mission 1". (The "·" still appears legitimately in the muted
+      // "raw · weightage" subtitle below the title.)
+      expect(within(detail).getByText('Mission 1')).toBeInTheDocument();
+      expect(
+        within(detail).queryByText(/Missions · Mission 1/),
+      ).not.toBeInTheDocument();
+    });
+
+    it('confines title + raw·weightage to the Name cell with empty identity cells (no merged span)', async () => {
+      const user = userEvent.setup();
+      // Surface two identity columns (Email, External ID) so we can assert the
+      // breakdown row leaves them as discrete empty cells rather than spanning.
+      localStorage.setItem(
+        WEIGHTED_STORAGE_KEY,
+        JSON.stringify({ email: true, externalId: true }),
+      );
+      renderWeighted(expandable);
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      const detail = await screen.findByTestId(breakdownRowId(1, 10, 1));
+
+      // No merged cell: the breakdown row no longer spans the identity columns,
+      // so it freezes the same checkbox | Name region as the student rows above
+      // instead of over-freezing across the identity area.
+      expect(detail.querySelectorAll('td[colspan]')).toHaveLength(0);
+
+      // Title and the muted "raw · weightage" subtitle live in the SAME (Name)
+      // cell, confined to the Name column.
+      const titleCell = within(detail).getByText('Mission 1').closest('td')!;
+      expect(
+        within(titleCell).getByText(/80\/100 · 30% of grade/),
+      ).toBeInTheDocument();
+
+      // Each visible identity column gets its own empty cell so the grid lines
+      // stay aligned with the rows above. Cells:
+      // checkbox | Name | Email(empty) | External ID(empty) | Missions(24) | Quizzes | Total
+      const cells = within(detail).getAllByRole('cell');
+      expect(cells).toHaveLength(7);
+      expect(cells[2]).toBeEmptyDOMElement();
+      expect(cells[3]).toBeEmptyDOMElement();
+    });
+
+    it('renders each assessment as a grade/maxGrade percentage in percent mode', async () => {
+      const user = userEvent.setup();
+      renderWeighted(expandable);
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      // Mission 1: 80/100 → 80% ; Mission 2: 50/50 → 100% ; Quiz 1: 90/100 → 90%
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 1))).getByText('80%'),
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 2))).getByText('100%'),
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 20, 3))).getByText('90%'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders — for an ungraded assessment in percent mode', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        tabs: [makeTab(10, 'Missions', 1, 100)],
+        assessments: [makeAssessment(1, 'Mission 1', 10, 100)],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 1, null)],
+      });
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 1))).getByText('—'),
+      ).toBeInTheDocument();
+    });
+
+    it('breakdown points for a tab sum to the tab cell shown on the main row', async () => {
+      const user = userEvent.setup();
+      renderWeighted(expandable);
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      // Missions cell (main row) = 24 + 30 = 54
+      expect(screen.getByText('54')).toBeInTheDocument();
+      // and both contributions are present in the detail
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 1))).getByText('24'),
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 2))).getByText('30'),
+      ).toBeInTheDocument();
+    });
+
+    it('shows each assessment\'s effective weightage as "% of grade" (equal mode)', async () => {
+      const user = userEvent.setup();
+      renderWeighted(expandable);
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      // Missions weight 60 split across 2 assessments → 30% each;
+      // Quizzes weight 40 with a single assessment → 40%.
+      expect(
+        within(await screen.findByTestId(breakdownRowId(1, 10, 1))).getByText(
+          /30% of grade/,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 2))).getByText(
+          /30% of grade/,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 20, 3))).getByText(
+          /40% of grade/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows effective weightage as "% of grade" regardless of the points/percentage lens', async () => {
+      const user = userEvent.setup();
+      renderWeighted(expandable);
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      // The weightage label never follows the lens: still "30% of grade".
+      expect(
+        within(await screen.findByTestId(breakdownRowId(1, 10, 1))).getByText(
+          /30% of grade/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('marks an excluded assessment in the breakdown with "Excluded" text and a — contribution cell', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        tabs: [makeTab(10, 'Missions', 1, 60)],
+        assessments: [
+          makeAssessment(1, 'Mission 1', 10, 100),
+          {
+            ...makeAssessment(2, 'Mission 2', 10, 100),
+            gradebookExcluded: true,
+          },
+        ],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 1, 80), makeSub(1, 2, 100)],
+      });
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      const detail = await screen.findByTestId(breakdownRowId(1, 10, 2));
+      // "Excluded" label present instead of "… · X% of grade" weightage text
+      expect(within(detail).getByText(/Excluded/i)).toBeInTheDocument();
+      // Contribution cell shows — (dash), not a numeric value
+      expect(within(detail).getByText('—')).toBeInTheDocument();
+      expect(within(detail).queryByText(/^[\d.]+$/)).not.toBeInTheDocument();
+    });
+
+    it('renders 0 (not —) for an ungraded-but-counted assessment, distinguishing it from excluded', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        tabs: [makeTab(10, 'Missions', 1, 60)],
+        assessments: [makeAssessment(1, 'Mission 1', 10, 100)],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [], // ungraded — no submission
+      });
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      const detail = await screen.findByTestId(breakdownRowId(1, 10, 1));
+      // Ungraded counted as 0 in points mode
+      expect(within(detail).getByText('0')).toBeInTheDocument();
+      // No "Excluded" text
+      expect(within(detail).queryByText(/Excluded/i)).not.toBeInTheDocument();
+    });
+
+    it("uses the assessment's own weight for effective weightage in custom mode", async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        tabs: [
+          {
+            id: 10,
+            title: 'Missions',
+            categoryId: 1,
+            gradebookWeight: 60,
+            weightMode: 'custom',
+          },
+        ],
+        assessments: [
+          {
+            id: 1,
+            title: 'Mission 1',
+            tabId: 10,
+            maxGrade: 100,
+            gradebookWeight: 25,
+          },
+          {
+            id: 2,
+            title: 'Mission 2',
+            tabId: 10,
+            maxGrade: 50,
+            gradebookWeight: 35,
+          },
+        ],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 1, 80), makeSub(1, 2, 50)],
+      });
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      expect(
+        within(await screen.findByTestId(breakdownRowId(1, 10, 1))).getByText(
+          /25% of grade/,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId(breakdownRowId(1, 10, 2))).getByText(
+          /35% of grade/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('rounds a fractional effective weightage to 2dp in the breakdown', async () => {
+      const user = userEvent.setup();
+      // Tab weight 100 split equally across 3 assessments → 33.333…% → "33.33% of grade"
+      renderWeighted({
+        tabs: [makeTab(10, 'Missions', 1, 100)],
+        assessments: [
+          makeAssessment(1, 'M1', 10, 100),
+          makeAssessment(2, 'M2', 10, 100),
+          makeAssessment(3, 'M3', 10, 100),
+        ],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 1, 50)],
+      });
+      await user.click(screen.getByRole('button', { name: /expand Alice/i }));
+      expect(
+        within(await screen.findByTestId(breakdownRowId(1, 10, 1))).getByText(
+          /33\.33% of grade/,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('display mode toggle — values', () => {
+    // weight 100, one assessment max 100, grade 80 → subtotal 0.8
+    // points cell = 80 ; percent cell = 80%
+    const singleTab = {
+      tabs: [makeTab(10, 'Tab 1', 1, 100)],
+      assessments: [makeAssessment(100, 'Q1', 10, 100)],
+      students: [makeStudent(1, 'Alice')],
+      submissions: [makeSub(1, 100, 80)],
+    };
+
+    it('shows points (no % suffix) by default', () => {
+      renderWeighted(singleTab);
+      expect(screen.getAllByText('80').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('80%')).not.toBeInTheDocument();
+    });
+
+    it('shows percentage with % suffix after switching to Percentage', async () => {
+      const user = userEvent.setup();
+      renderWeighted(singleTab);
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      await waitFor(() =>
+        expect(screen.getAllByText('80%').length).toBeGreaterThanOrEqual(1),
+      );
+    });
+
+    it('normalizes the total in percent mode when weights do not sum to 100', async () => {
+      const user = userEvent.setup();
+      // weight 50, max 100, grade 80 → subtotal 0.8
+      // points total = 40 ; percent total = 40 / 50 * 100 = 80%
+      renderWeighted({
+        tabs: [makeTab(10, 'Tab 1', 1, 50)],
+        assessments: [makeAssessment(100, 'Q1', 10, 100)],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 100, 80)],
+      });
+      expect(screen.getAllByText('40').length).toBeGreaterThanOrEqual(1); // points default
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      await waitFor(() =>
+        expect(screen.getAllByText('80%').length).toBeGreaterThanOrEqual(1),
+      );
+    });
+
+    it('shows the Points and Percentage explanatory tooltips on hover', async () => {
+      renderWeighted();
+      await userEvent.hover(screen.getByRole('radio', { name: /points/i }));
+      await waitFor(() =>
+        expect(
+          screen.getByText(/columns add up to the projected total/i),
+        ).toBeInTheDocument(),
+      );
+      await userEvent.hover(screen.getByRole('radio', { name: /percentage/i }));
+      await waitFor(() =>
+        expect(
+          screen.getByText(/what fraction of each tab the student earned/i),
+        ).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('display mode toggle — control', () => {
+    it('renders Points and Percentage toggle buttons with Points pressed by default', () => {
+      renderWeighted();
+      const points = screen.getByRole('radio', { name: /points/i });
+      const percent = screen.getByRole('radio', { name: /percentage/i });
+      expect(points).toBeInTheDocument();
+      expect(percent).toBeInTheDocument();
+      expect(points).toHaveAttribute('aria-checked', 'true');
+      expect(percent).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  describe('identity columns rendering', () => {
+    it('hides Email and External ID by default', () => {
+      renderWeighted();
+      expect(screen.queryByText('Email')).not.toBeInTheDocument();
+      expect(screen.queryByText(EXTERNAL_ID)).not.toBeInTheDocument();
+      expect(screen.queryByText('alice@example.com')).not.toBeInTheDocument();
+    });
+
+    it('shows the Email column header and value when Email is enabled via storage', async () => {
+      localStorage.setItem(
+        WEIGHTED_STORAGE_KEY,
+        JSON.stringify({ email: true }),
+      );
+      renderWeighted({ students: [makeStudent(1, 'Alice')] });
+      // header cell
+      const thead = document.querySelector('thead')!;
+      expect(
+        within(thead as HTMLElement).getByText('Email'),
+      ).toBeInTheDocument();
+      // body value
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    });
+
+    it('does not render Level or Total XP columns even if storage enables them', () => {
+      localStorage.setItem(
+        WEIGHTED_STORAGE_KEY,
+        JSON.stringify({ level: true, totalXp: true }),
+      );
+      renderWeighted();
+      const thead = document.querySelector('thead')!;
+      expect(
+        within(thead as HTMLElement).queryByText('Level'),
+      ).not.toBeInTheDocument();
+      expect(
+        within(thead as HTMLElement).queryByText('Total XP'),
+      ).not.toBeInTheDocument();
+    });
+
+    describe('external ID column', () => {
+      const studentsWithExtId: StudentData[] = [
+        { ...makeStudent(1, 'Alice'), externalId: 'EXT-001' },
+        { ...makeStudent(2, 'Bob'), externalId: null },
+      ];
+
+      it('shows External ID column by default when a student has one', async () => {
+        renderWeighted({ students: studentsWithExtId });
+        await screen.findByText('Alice');
+        const thead = document.querySelector('thead')!;
+        expect(
+          within(thead as HTMLElement).getByText(EXTERNAL_ID),
+        ).toBeInTheDocument();
+        expect(screen.getByText('EXT-001')).toBeInTheDocument();
+        // Bob has no external ID → his External ID cell renders empty, not "null".
+        const bobRow = screen.getByText('Bob').closest('tr')!;
+        expect(within(bobRow).queryByText('null')).not.toBeInTheDocument();
+      });
+
+      it('hides External ID column by default when no student has one', async () => {
+        renderWeighted();
+        await screen.findByText('Alice');
+        expect(screen.queryByText(EXTERNAL_ID)).not.toBeInTheDocument();
+      });
+
+      it('treats a blank external ID as absent and hides the column by default', async () => {
+        renderWeighted({
+          students: [{ ...makeStudent(1, 'Alice'), externalId: '' }],
+        });
+        await screen.findByText('Alice');
+        expect(screen.queryByText(EXTERNAL_ID)).not.toBeInTheDocument();
+      });
+
+      it('shows External ID when enabled via localStorage even with no external IDs', async () => {
+        localStorage.setItem(
+          WEIGHTED_STORAGE_KEY,
+          JSON.stringify({ externalId: true }),
+        );
+        renderWeighted();
+        await screen.findByText('Alice');
+        const thead = document.querySelector('thead')!;
+        expect(
+          within(thead as HTMLElement).getByText(EXTERNAL_ID),
+        ).toBeInTheDocument();
+      });
+
+      it('offers External ID checkbox in picker regardless of whether students have one', async () => {
+        const user = userEvent.setup();
+        renderWeighted();
+        await user.click(
+          await screen.findByRole('button', { name: /select columns/i }),
+        );
+        const dialog = await screen.findByRole('dialog');
+        expect(
+          within(dialog).getByRole('checkbox', { name: /external id/i }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('projected-total policy', () => {
+    it('shows a "Weighted Total" header without the inline policy sentence', () => {
+      renderWeighted();
+      const thead = document.querySelector('thead')!;
+      expect(
+        within(thead as HTMLElement).getByText('Weighted Total'),
+      ).toBeInTheDocument();
+      // The policy is no longer crammed into the header label itself.
+      expect(
+        within(thead as HTMLElement).queryByText(/ungraded assessments/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exposes the projected-total policy via an ⓘ control on the header', () => {
+      renderWeighted();
+      expect(
+        screen.getByRole('button', {
+          name: /ungraded assessments as 0/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('reveals the projected-total policy text in the header ⓘ tooltip on hover', async () => {
+      renderWeighted();
+      await userEvent.hover(
+        screen.getByRole('button', { name: /ungraded assessments as 0/i }),
+      );
+      await waitFor(() =>
+        expect(
+          screen.getAllByText(/totals count ungraded assessments as 0/i).length,
+        ).toBeGreaterThanOrEqual(1),
+      );
+    });
+
+    it('shows a one-time projected-total policy banner that can be dismissed', async () => {
+      const user = userEvent.setup();
+      renderWeighted();
+      expect(
+        screen.getByText(/totals count ungraded assessments as 0/i),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /close/i }));
+      expect(
+        screen.queryByText(/totals count ungraded assessments as 0/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show the policy banner once it has been dismissed', () => {
+      localStorage.setItem(
+        `${USER_ID}:gradebook_projected_total_policy_hint`,
+        'true',
+      );
+      renderWeighted();
+      expect(
+        screen.queryByText(/totals count ungraded assessments as 0/i),
+      ).not.toBeInTheDocument();
+      // The ⓘ on the header still carries the policy after dismissal.
+      expect(
+        screen.getByRole('button', {
+          name: /ungraded assessments as 0/i,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('all-excluded tab (effective weight 0)', () => {
+    const excluded = (a: AssessmentData): AssessmentData => ({
+      ...a,
+      gradebookExcluded: true,
+    });
+
+    // Assignments (30) is fully excluded → contributes nothing; Quizzes (70) is live.
+    const oneTabAllExcluded = {
+      tabs: [makeTab(10, 'Assignments', 1, 30), makeTab(11, 'Quizzes', 1, 70)],
+      assessments: [
+        excluded(makeAssessment(100, 'A1', 10, 100)),
+        excluded(makeAssessment(101, 'A2', 10, 100)),
+        makeAssessment(200, 'Q1', 11, 100),
+      ],
+    };
+
+    const row3 = (): HTMLElement =>
+      document.querySelector('thead')!.querySelectorAll('tr')[2] as HTMLElement;
+
+    it('row 3 reads "Excluded" instead of /N for an all-excluded tab (points)', () => {
+      renderWeighted(oneTabAllExcluded);
+      expect(within(row3()).getByText('Excluded')).toBeInTheDocument();
+      // The dead tab's stored weight is never shown as a "/30" subheader.
+      expect(screen.queryByText('/30')).not.toBeInTheDocument();
+    });
+
+    it('row 3 reads "Excluded" instead of "% of grade" for an all-excluded tab (percent)', async () => {
+      const user = userEvent.setup();
+      renderWeighted(oneTabAllExcluded);
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      expect(within(row3()).getByText('Excluded')).toBeInTheDocument();
+      expect(screen.queryByText('30% of grade')).not.toBeInTheDocument();
+    });
+
+    it('drops the all-excluded tab from the projected-total weight (header)', () => {
+      renderWeighted(oneTabAllExcluded);
+      // Live weight is only Quizzes (70), so the total header shows /70, not /100.
+      expect(screen.queryByText('/100')).not.toBeInTheDocument();
+      const cells = row3().querySelectorAll('th');
+      expect(cells[cells.length - 1]).toHaveTextContent('/70');
+    });
+
+    it('normalizes the percent-mode total over live weight only', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        ...oneTabAllExcluded,
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 200, 90)], // 0.9 on the only live tab (Quizzes/70)
+      });
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      // Total points = 0.9×70 = 63. Normalized over live weight (70): 63/70 = 90%.
+      // The buggy denominator (100) would render 63%.
+      const aliceRow = screen.getByText('Alice').closest('tr')!;
+      const cells = within(aliceRow).getAllByRole('cell');
+      expect(cells[cells.length - 1]).toHaveTextContent('90%');
+    });
+
+    it('renders "—" for the total in percent mode when all live weight is excluded', async () => {
+      const user = userEvent.setup();
+      renderWeighted({
+        tabs: [makeTab(10, 'Assignments', 1, 30)],
+        assessments: [
+          excluded(makeAssessment(100, 'A1', 10, 100)),
+          excluded(makeAssessment(101, 'A2', 10, 100)),
+        ],
+        students: [makeStudent(1, 'Alice')],
+        submissions: [makeSub(1, 100, 80)],
+      });
+      await user.click(screen.getByRole('radio', { name: /percentage/i }));
+      const aliceRow = screen.getByText('Alice').closest('tr')!;
+      const cells = within(aliceRow).getAllByRole('cell');
+      expect(cells[cells.length - 1]).toHaveTextContent('—');
+    });
+  });
+});

--- a/client/app/bundles/course/gradebook/__tests__/WeightedViewHint.test.tsx
+++ b/client/app/bundles/course/gradebook/__tests__/WeightedViewHint.test.tsx
@@ -1,0 +1,54 @@
+import { store as appStore } from 'store';
+import { fireEvent, render, screen } from 'test-utils';
+
+import WeightedViewHint, {
+  WEIGHTED_VIEW_HINT_KEY,
+} from '../components/WeightedViewHint';
+
+// Render synchronously without the real provider's locale-loading spinner
+// (uses the manual mock at lib/components/wrappers/__mocks__/I18nProvider).
+jest.mock('lib/components/wrappers/I18nProvider');
+
+const USER_ID = 42;
+const STORAGE_KEY = `${USER_ID}:${WEIGHTED_VIEW_HINT_KEY}`;
+
+const userState = {
+  global: {
+    ...appStore.getState().global,
+    user: {
+      ...appStore.getState().global.user,
+      user: { id: USER_ID, name: '', imageUrl: '' },
+    },
+  },
+};
+
+const renderHint = (): void => {
+  render(<WeightedViewHint courseId={7} />, { state: userState });
+};
+
+beforeEach(() => localStorage.clear());
+
+describe('WeightedViewHint', () => {
+  it('renders the capability hint with a link to gradebook settings', () => {
+    renderHint();
+    // Copy names the capability (weighted total grade), not the mechanism.
+    expect(screen.getByText(/weighted total/i)).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /gradebook settings/i });
+    expect(link).toHaveAttribute('href', '/courses/7/admin/gradebook');
+  });
+
+  it('hides and persists dismissal when the close button is clicked', () => {
+    renderHint();
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(screen.queryByText(/weighted total/i)).not.toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('does not render when already dismissed', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    renderHint();
+    expect(screen.queryByText(/weighted total/i)).not.toBeInTheDocument();
+  });
+});

--- a/client/app/bundles/course/gradebook/__tests__/computeWeighted.test.ts
+++ b/client/app/bundles/course/gradebook/__tests__/computeWeighted.test.ts
@@ -1,0 +1,870 @@
+// client/app/bundles/course/gradebook/__tests__/computeWeighted.test.ts
+import {
+  computeStudentBreakdown,
+  computeStudentTotal,
+  computeTabSubtotal,
+  computeWeightedRows,
+  resolveTabWeights,
+  sumWeights,
+  usingDefaultWeights,
+} from '../computeWeighted';
+
+const assessments = [
+  { id: 1, tabId: 10, maxGrade: 100, title: 'A' },
+  { id: 2, tabId: 10, maxGrade: 50, title: 'B' },
+  { id: 3, tabId: 20, maxGrade: 100, title: 'C' },
+];
+
+const subs = (
+  entries: { studentId: number; assessmentId: number; grade: number | null }[],
+): { studentId: number; assessmentId: number; grade: number | null }[] =>
+  entries;
+
+describe('computeTabSubtotal — equal mode (default)', () => {
+  it('returns null when tab has no assessments', () => {
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { id: 999, title: 'X', categoryId: 0 },
+        assessments,
+        submissions: [],
+      }),
+    ).toBeNull();
+  });
+
+  it('returns 0 when student has no graded submissions (ungraded count as 0)', () => {
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { id: 10, title: 'M', categoryId: 0 },
+        assessments,
+        submissions: [],
+      }),
+    ).toBe(0);
+  });
+
+  it('average of (grade/maxGrade) ratios with ungraded assessments counted as 0', () => {
+    // Assessment 1 graded (80/100=0.8), assessment 2 ungraded (0)
+    // sub = (0.8 + 0) / 2 = 0.4
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { id: 10, title: 'M', categoryId: 0 },
+        assessments,
+        submissions: subs([
+          { studentId: 1, assessmentId: 1, grade: 80 },
+          // assessment 2 ungraded
+        ]),
+      }),
+    ).toBeCloseTo(0.4);
+  });
+
+  it('average of all ratios when fully graded', () => {
+    // Assessment 1: 80/100=0.8, assessment 2: 50/50=1.0
+    // sub = (0.8 + 1.0) / 2 = 0.9
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { id: 10, title: 'M', categoryId: 0 },
+        assessments,
+        submissions: subs([
+          { studentId: 1, assessmentId: 1, grade: 80 },
+          { studentId: 1, assessmentId: 2, grade: 50 },
+        ]),
+      }),
+    ).toBeCloseTo(0.9);
+  });
+});
+
+describe('computeTabSubtotal — custom mode', () => {
+  const customTab = {
+    id: 10,
+    title: 'M',
+    categoryId: 0,
+    gradebookWeight: 100,
+    weightMode: 'custom' as const,
+  };
+  const customAssessments = [
+    { id: 1, tabId: 10, maxGrade: 100, title: 'A', gradebookWeight: 30 },
+    { id: 2, tabId: 10, maxGrade: 50, title: 'B', gradebookWeight: 70 },
+  ];
+
+  it('computes weighted sum over tab weight when fully graded', () => {
+    // sub = (80/100 * 30 + 50/50 * 70) / 100 = (24 + 70) / 100 = 0.94
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: customTab,
+        assessments: customAssessments,
+        submissions: subs([
+          { studentId: 1, assessmentId: 1, grade: 80 },
+          { studentId: 1, assessmentId: 2, grade: 50 },
+        ]),
+      }),
+    ).toBeCloseTo(0.94);
+  });
+
+  it('treats ungraded as zero (only graded weight contributes to numerator)', () => {
+    // Only assessment 1 graded: sub = (80/100 * 30 + 0 * 70) / 100 = 24/100 = 0.24
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: customTab,
+        assessments: customAssessments,
+        submissions: subs([{ studentId: 1, assessmentId: 1, grade: 80 }]),
+      }),
+    ).toBeCloseTo(0.24);
+  });
+
+  it('returns 0 when no graded assessments', () => {
+    // sub = (0 + 0) / 100 = 0
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: customTab,
+        assessments: customAssessments,
+        submissions: [],
+      }),
+    ).toBe(0);
+  });
+
+  it('returns null when tab gradebookWeight is 0 (divide-by-zero guard)', () => {
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { ...customTab, gradebookWeight: 0 },
+        assessments: customAssessments,
+        submissions: subs([{ studentId: 1, assessmentId: 1, grade: 80 }]),
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when every assessment in a custom tab is excluded', () => {
+    const allExcluded = [
+      {
+        id: 1,
+        tabId: 10,
+        maxGrade: 100,
+        title: 'A',
+        gradebookWeight: 30,
+        gradebookExcluded: true,
+      },
+      {
+        id: 2,
+        tabId: 10,
+        maxGrade: 100,
+        title: 'B',
+        gradebookWeight: 20,
+        gradebookExcluded: true,
+      },
+    ];
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: {
+          id: 10,
+          title: 'M',
+          categoryId: 0,
+          weightMode: 'custom',
+          gradebookWeight: 50,
+        },
+        assessments: allExcluded,
+        submissions: [{ studentId: 1, assessmentId: 1, grade: 90 }],
+      }),
+    ).toBeNull();
+  });
+
+  it('treats a custom assessment with no gradebookWeight as weight 0', () => {
+    // a1 weight 30 graded 100/100 -> 30; a2 has NO weight -> 0; sub = 30/100 = 0.3
+    const mixed = [
+      { id: 1, tabId: 10, maxGrade: 100, title: 'A', gradebookWeight: 30 },
+      { id: 2, tabId: 10, maxGrade: 50, title: 'B' },
+    ];
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: customTab,
+        assessments: mixed,
+        submissions: subs([
+          { studentId: 1, assessmentId: 1, grade: 100 },
+          { studentId: 1, assessmentId: 2, grade: 50 },
+        ]),
+      }),
+    ).toBeCloseTo(0.3);
+  });
+});
+
+describe('computeStudentTotal', () => {
+  const tabs = [
+    { id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 },
+    { id: 20, title: 'T', categoryId: 0, gradebookWeight: 40 },
+  ];
+
+  it('returns additive sum of weight × subtotal (equal-weight count-based)', () => {
+    // tab10 equal subtotal = (80/100 + 50/50) / 2 = (0.8 + 1.0) / 2 = 0.9
+    // tab20 equal subtotal = 90/100 = 0.9
+    // total = 60*0.9 + 40*0.9 = 54 + 36 = 90
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs,
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+        { studentId: 1, assessmentId: 3, grade: 90 },
+      ]),
+    });
+    expect(total).toBeCloseTo(60 * 0.9 + 40 * 0.9);
+  });
+
+  it('weight-0 tab contributes 0 to the sum', () => {
+    // tab20 weight=0 → 0; tab10 subtotal = (80/100 + 50/50) / 2 = 0.9
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs: [
+        { id: 10, title: 'M', categoryId: 0, gradebookWeight: 100 },
+        { id: 20, title: 'T', categoryId: 0, gradebookWeight: 0 },
+      ],
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+        { studentId: 1, assessmentId: 3, grade: 90 },
+      ]),
+    });
+    expect(total).toBeCloseTo(100 * 0.9);
+  });
+
+  it('returns 0 when tab weight is 0 and no graded submissions', () => {
+    expect(
+      computeStudentTotal({
+        studentId: 1,
+        tabs: [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 0 }],
+        assessments,
+        submissions: [],
+      }),
+    ).toBe(0);
+  });
+
+  it('is additive (not normalized) when weights do not sum to 100', () => {
+    // total = 60*0.9 + 30*0.9 = 54 + 27 = 81 (NOT divided by 90)
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs: [
+        { id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 },
+        { id: 20, title: 'T', categoryId: 0, gradebookWeight: 30 },
+      ],
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+        { studentId: 1, assessmentId: 3, grade: 90 },
+      ]),
+    });
+    expect(total).toBeCloseTo(60 * 0.9 + 30 * 0.9);
+  });
+
+  it('bonus: weights summing past 100 yield a total > 100 for a perfect student', () => {
+    // perfect student: all grades = maxGrade → each ratio = 1.0 → subtotal = 1.0
+    // total = 60*1 + 50*1 = 110
+    const bonusTabs = [
+      { id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 },
+      { id: 20, title: 'T', categoryId: 0, gradebookWeight: 50 },
+    ];
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs: bonusTabs,
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 100 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+        { studentId: 1, assessmentId: 3, grade: 100 },
+      ]),
+    });
+    expect(total).toBeCloseTo(110);
+    expect(total!).toBeGreaterThan(100);
+  });
+
+  it('ungraded tab contributes 0 to the total', () => {
+    // tab10 subtotal = (80/100 + 50/50) / 2 = 0.9; tab20 no submissions → subtotal = 0
+    // total = 60*0.9 + 40*0 = 54
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs,
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+      ]),
+    });
+    expect(total).toBeCloseTo(60 * 0.9);
+  });
+
+  it('returns null when every tab is empty (no contributing subtotal)', () => {
+    expect(
+      computeStudentTotal({
+        studentId: 1,
+        tabs: [
+          { id: 77, title: 'X', categoryId: 0, gradebookWeight: 60 },
+          { id: 88, title: 'Y', categoryId: 0, gradebookWeight: 40 },
+        ],
+        assessments, // none belong to tabs 77/88
+        submissions: [],
+      }),
+    ).toBeNull();
+  });
+
+  it('a negative tab weight subtracts from the additive total (no flooring)', () => {
+    // tab10 subtotal 0.9 * 100 = 90 ; tab20 subtotal 0.9 * -20 = -18 ; total = 72
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs: [
+        { id: 10, title: 'M', categoryId: 0, gradebookWeight: 100 },
+        { id: 20, title: 'T', categoryId: 0, gradebookWeight: -20 },
+      ],
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+        { studentId: 1, assessmentId: 3, grade: 90 },
+      ]),
+    });
+    expect(total).toBeCloseTo(100 * 0.9 + -20 * 0.9);
+  });
+});
+
+describe('sumWeights', () => {
+  it('returns the sum of all tab weights', () => {
+    const tabs = [
+      { id: 1, title: 'T1', categoryId: 1, gradebookWeight: 60 },
+      { id: 2, title: 'T2', categoryId: 1, gradebookWeight: 40 },
+    ];
+    expect(sumWeights(tabs)).toBe(100);
+  });
+
+  it('includes all tabs regardless of weight value', () => {
+    const tabs = [
+      { id: 1, title: 'T1', categoryId: 1, gradebookWeight: 60 },
+      { id: 2, title: 'T2', categoryId: 1, gradebookWeight: 0 },
+    ];
+    expect(sumWeights(tabs)).toBe(60);
+  });
+
+  it('handles tabs with no gradebookWeight (treats as 0)', () => {
+    const tabs = [
+      { id: 1, title: 'T1', categoryId: 1, gradebookWeight: 40 },
+      { id: 2, title: 'T2', categoryId: 1 },
+    ];
+    expect(sumWeights(tabs)).toBe(40);
+  });
+});
+
+describe('resolveTabWeights — equal-split default when unconfigured', () => {
+  const twoTabs = [
+    { id: 10, title: 'M', categoryId: 0, gradebookWeight: 0 },
+    { id: 20, title: 'T', categoryId: 0, gradebookWeight: 0 },
+  ];
+  // assessments fixture (top of file) covers tabs 10 and 20.
+
+  it('returns tabs unchanged when any tab already carries a weight', () => {
+    const configured = [
+      { id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 },
+      { id: 20, title: 'T', categoryId: 0, gradebookWeight: 0 },
+    ];
+    expect(resolveTabWeights(configured, assessments)).toBe(configured);
+  });
+
+  it('splits 100 equally across non-empty tabs when every weight is 0', () => {
+    const resolved = resolveTabWeights(twoTabs, assessments);
+    expect(resolved.map((t) => t.gradebookWeight)).toEqual([50, 50]);
+    expect(sumWeights(resolved)).toBe(100);
+  });
+
+  it('last non-empty tab absorbs the rounding remainder so it sums to exactly 100', () => {
+    const threeTabs = [
+      { id: 10, title: 'A', categoryId: 0, gradebookWeight: 0 },
+      { id: 20, title: 'B', categoryId: 0, gradebookWeight: 0 },
+      { id: 30, title: 'C', categoryId: 0, gradebookWeight: 0 },
+    ];
+    const threeAssessments = [
+      { id: 1, tabId: 10, maxGrade: 10, title: 'a' },
+      { id: 2, tabId: 20, maxGrade: 10, title: 'b' },
+      { id: 3, tabId: 30, maxGrade: 10, title: 'c' },
+    ];
+    const resolved = resolveTabWeights(threeTabs, threeAssessments);
+    expect(resolved.map((t) => t.gradebookWeight)).toEqual([
+      33.33, 33.33, 33.34,
+    ]);
+    expect(sumWeights(resolved)).toBe(100);
+  });
+
+  it('gives empty tabs (no assessments) 0% and shares 100 among the rest', () => {
+    const withEmpty = [
+      { id: 10, title: 'M', categoryId: 0, gradebookWeight: 0 },
+      { id: 20, title: 'T', categoryId: 0, gradebookWeight: 0 },
+      { id: 99, title: 'Empty', categoryId: 0, gradebookWeight: 0 },
+    ];
+    const resolved = resolveTabWeights(withEmpty, assessments);
+    expect(resolved.find((t) => t.id === 99)!.gradebookWeight).toBe(0);
+    expect(sumWeights(resolved)).toBe(100);
+  });
+
+  it('defaults the weight mode to equal on resolved tabs', () => {
+    const resolved = resolveTabWeights(twoTabs, assessments);
+    expect(resolved.every((t) => t.weightMode === 'equal')).toBe(true);
+  });
+
+  it('returns tabs unchanged when no tab has any assessment (nothing to weight)', () => {
+    const emptyTabs = [
+      { id: 77, title: 'X', categoryId: 0, gradebookWeight: 0 },
+    ];
+    expect(resolveTabWeights(emptyTabs, assessments)).toBe(emptyTabs);
+  });
+
+  it('gives a lone non-empty tab the full 100', () => {
+    const oneTab = [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 0 }];
+    const resolved = resolveTabWeights(oneTab, assessments);
+    expect(resolved[0].gradebookWeight).toBe(100);
+    expect(sumWeights(resolved)).toBe(100);
+  });
+
+  it('preserves an already-set weightMode while injecting the default weight', () => {
+    const customModeTabs = [
+      {
+        id: 10,
+        title: 'M',
+        categoryId: 0,
+        gradebookWeight: 0,
+        weightMode: 'custom' as const,
+      },
+      { id: 20, title: 'T', categoryId: 0, gradebookWeight: 0 },
+    ];
+    const resolved = resolveTabWeights(customModeTabs, assessments);
+    expect(resolved.find((t) => t.id === 10)!.weightMode).toBe('custom');
+    expect(resolved.find((t) => t.id === 20)!.weightMode).toBe('equal');
+  });
+});
+
+describe('usingDefaultWeights', () => {
+  it('is true when no weight is configured and a non-empty tab exists', () => {
+    const tabs = [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 0 }];
+    expect(usingDefaultWeights(tabs, assessments)).toBe(true);
+  });
+
+  it('is false once any tab carries a weight', () => {
+    const tabs = [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 50 }];
+    expect(usingDefaultWeights(tabs, assessments)).toBe(false);
+  });
+
+  it('is false when every tab is empty (no default would apply)', () => {
+    const tabs = [{ id: 77, title: 'X', categoryId: 0, gradebookWeight: 0 }];
+    expect(usingDefaultWeights(tabs, assessments)).toBe(false);
+  });
+});
+
+describe('computeWeightedRows', () => {
+  const rowTabs = [
+    { id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 },
+    { id: 20, title: 'T', categoryId: 0, gradebookWeight: 40 },
+  ];
+  const rowStudents = [
+    {
+      id: 1,
+      name: 'Alice',
+      email: 'alice@e.com',
+      externalId: null,
+      level: 1,
+      totalXp: 0,
+    },
+    {
+      id: 2,
+      name: 'Bob',
+      email: 'bob@e.com',
+      externalId: null,
+      level: 1,
+      totalXp: 0,
+    },
+  ];
+  const rowSubmissions = subs([
+    // Alice: full data
+    { studentId: 1, assessmentId: 1, grade: 80 },
+    { studentId: 1, assessmentId: 2, grade: 50 },
+    { studentId: 1, assessmentId: 3, grade: 90 },
+    // Bob: only tab10 graded
+    { studentId: 2, assessmentId: 1, grade: 100 },
+    { studentId: 2, assessmentId: 2, grade: 50 },
+  ]);
+
+  it('returns one row per student carrying studentId, name and email', () => {
+    const rows = computeWeightedRows({
+      students: rowStudents,
+      tabs: rowTabs,
+      assessments,
+      submissions: rowSubmissions,
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      studentId: 1,
+      name: 'Alice',
+      email: 'alice@e.com',
+    });
+    expect(rows[1]).toMatchObject({
+      studentId: 2,
+      name: 'Bob',
+      email: 'bob@e.com',
+    });
+  });
+
+  it('produces subtotals and total identical to the per-student helpers', () => {
+    const rows = computeWeightedRows({
+      students: rowStudents,
+      tabs: rowTabs,
+      assessments,
+      submissions: rowSubmissions,
+    });
+    rowStudents.forEach((student, i) => {
+      rowTabs.forEach((tab, j) => {
+        expect(rows[i].subtotals[j]).toEqual(
+          computeTabSubtotal({
+            studentId: student.id,
+            tab,
+            assessments,
+            submissions: rowSubmissions,
+          }),
+        );
+      });
+      expect(rows[i].total).toEqual(
+        computeStudentTotal({
+          studentId: student.id,
+          tabs: rowTabs,
+          assessments,
+          submissions: rowSubmissions,
+        }),
+      );
+    });
+  });
+
+  it('computes the known additive total for a fully-graded student (equal-weight)', () => {
+    // Alice tab10 = (80/100 + 50/50) / 2 = (0.8 + 1.0) / 2 = 0.9
+    // Alice tab20 = 90/100 = 0.9
+    // total = 60*0.9 + 40*0.9 = 90
+    const rows = computeWeightedRows({
+      students: [rowStudents[0]],
+      tabs: rowTabs,
+      assessments,
+      submissions: rowSubmissions,
+    });
+    expect(rows[0].subtotals[0]).toBeCloseTo(0.9);
+    expect(rows[0].subtotals[1]).toBeCloseTo(0.9);
+    expect(rows[0].total).toBeCloseTo(60 * 0.9 + 40 * 0.9);
+  });
+
+  it('a tab with no graded submissions yields a 0 subtotal (ungraded count as 0)', () => {
+    // Bob tab10: (100/100 + 50/50) / 2 = 1.0; tab20: no submissions → 0
+    const rows = computeWeightedRows({
+      students: [rowStudents[1]],
+      tabs: rowTabs,
+      assessments,
+      submissions: rowSubmissions,
+    });
+    expect(rows[0].subtotals[0]).toBeCloseTo(1);
+    expect(rows[0].subtotals[1]).toBe(0);
+    expect(rows[0].total).toBeCloseTo(60 * 1 + 40 * 0);
+  });
+
+  it('returns an empty array when there are no students', () => {
+    expect(
+      computeWeightedRows({
+        students: [],
+        tabs: rowTabs,
+        assessments,
+        submissions: rowSubmissions,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('computeWeightedRows — identity passthrough', () => {
+  it('carries name, email and externalId from each student onto the row', () => {
+    const students = [
+      {
+        id: 1,
+        name: 'Alice',
+        email: 'a@x.com',
+        externalId: 'EXT-1',
+        level: 5,
+        totalXp: 1234,
+      },
+    ];
+    const tabs = [
+      { id: 10, title: 'Tab 1', categoryId: 1, gradebookWeight: 100 },
+    ];
+    const localAssessments = [
+      { id: 100, title: 'Q1', tabId: 10, maxGrade: 10 },
+    ];
+    const submissions = [{ studentId: 1, assessmentId: 100, grade: 8 }];
+
+    const rows = computeWeightedRows({
+      students,
+      tabs,
+      assessments: localAssessments,
+      submissions,
+    });
+
+    expect(rows[0].name).toBe('Alice');
+    expect(rows[0].email).toBe('a@x.com');
+    expect(rows[0].externalId).toBe('EXT-1');
+  });
+});
+
+describe('computeStudentBreakdown', () => {
+  const tabs = [
+    { id: 10, title: 'Tab 1', categoryId: 1, gradebookWeight: 60 },
+    { id: 20, title: 'Tab 2', categoryId: 1, gradebookWeight: 40 },
+  ];
+
+  it('equal mode: per-assessment points sum to the tab cell (subtotal × weight)', () => {
+    // Tab 10 (weight 60), equal: A(80/100=0.8), B(50/50=1.0); n=2
+    //   A points = (0.8/2)*60 = 24 ; B points = (1.0/2)*60 = 30 ; Σ = 54
+    const breakdown = computeStudentBreakdown({
+      studentId: 1,
+      tabs,
+      assessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+        { studentId: 1, assessmentId: 3, grade: 90 },
+      ]),
+    });
+    const tab10 = breakdown.find((b) => b.tabId === 10)!;
+    const a = tab10.assessments.find((x) => x.assessmentId === 1)!;
+    const b = tab10.assessments.find((x) => x.assessmentId === 2)!;
+    expect(a.points).toBeCloseTo(24);
+    expect(b.points).toBeCloseTo(30);
+    expect(a.points + b.points).toBeCloseTo(54); // = tab cell
+  });
+
+  it('carries grade and maxGrade per assessment; ungraded contributes 0 points', () => {
+    // Tab 10: A graded 80/100, B ungraded; n=2 → A=(0.8/2)*60=24, B=0
+    const breakdown = computeStudentBreakdown({
+      studentId: 1,
+      tabs,
+      assessments,
+      submissions: subs([{ studentId: 1, assessmentId: 1, grade: 80 }]),
+    });
+    const tab10 = breakdown.find((b) => b.tabId === 10)!;
+    const b = tab10.assessments.find((x) => x.assessmentId === 2)!;
+    expect(b.grade).toBeNull();
+    expect(b.maxGrade).toBe(50);
+    expect(b.points).toBe(0);
+  });
+
+  it('custom mode: per-assessment points = ratio × assessmentWeight, summing to the cell', () => {
+    // Tab 10 custom, weight 60: A weight 40 (80/100=0.8 → 32), B weight 20 (50/50=1 → 20)
+    //   subtotal = (0.8*40 + 1*20)/60 = 52/60 ; cell = subtotal*60 = 52 ; Σpoints = 32 + 20 = 52
+    const customTabs = [
+      {
+        id: 10,
+        title: 'Tab 1',
+        categoryId: 1,
+        gradebookWeight: 60,
+        weightMode: 'custom' as const,
+      },
+    ];
+    const customAssessments = [
+      { id: 1, tabId: 10, maxGrade: 100, title: 'A', gradebookWeight: 40 },
+      { id: 2, tabId: 10, maxGrade: 50, title: 'B', gradebookWeight: 20 },
+    ];
+    const breakdown = computeStudentBreakdown({
+      studentId: 1,
+      tabs: customTabs,
+      assessments: customAssessments,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 80 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+      ]),
+    });
+    const tab10 = breakdown[0];
+    const a = tab10.assessments.find((x) => x.assessmentId === 1)!;
+    const b = tab10.assessments.find((x) => x.assessmentId === 2)!;
+    expect(a.points).toBeCloseTo(32);
+    expect(b.points).toBeCloseTo(20);
+    expect(a.points + b.points).toBeCloseTo(52); // = tab cell
+  });
+
+  it('returns an empty assessment list for a tab with no assessments', () => {
+    const breakdown = computeStudentBreakdown({
+      studentId: 1,
+      tabs: [{ id: 999, title: 'Empty', categoryId: 1, gradebookWeight: 50 }],
+      assessments,
+      submissions: [],
+    });
+    expect(breakdown[0].assessments).toEqual([]);
+  });
+});
+
+describe('exclusion — equal mode', () => {
+  it('averages over included assessments only (excluded dropped from numerator and count)', () => {
+    // a1 80/100=0.8 included, a2 excluded -> subtotal = 0.8 / 1 = 0.8
+    const withExcluded = [
+      { id: 1, tabId: 10, maxGrade: 100, title: 'A' },
+      { id: 2, tabId: 10, maxGrade: 50, title: 'B', gradebookExcluded: true },
+    ];
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { id: 10, title: 'M', categoryId: 0 },
+        assessments: withExcluded,
+        submissions: [{ studentId: 1, assessmentId: 1, grade: 80 }],
+      }),
+    ).toBeCloseTo(0.8);
+  });
+
+  it('returns null when every assessment in the tab is excluded', () => {
+    const allExcluded = [
+      { id: 1, tabId: 10, maxGrade: 100, title: 'A', gradebookExcluded: true },
+      { id: 2, tabId: 10, maxGrade: 50, title: 'B', gradebookExcluded: true },
+    ];
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: { id: 10, title: 'M', categoryId: 0 },
+        assessments: allExcluded,
+        submissions: [{ studentId: 1, assessmentId: 1, grade: 80 }],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('exclusion — custom mode', () => {
+  it('drops excluded assessments from the numerator', () => {
+    // tab weight 30; a1 weight 30 graded 90/100=0.9 -> 0.9*30=27; a2 excluded.
+    // subtotal = 27 / 30 = 0.9
+    const customAssessments = [
+      { id: 1, tabId: 10, maxGrade: 100, title: 'A', gradebookWeight: 30 },
+      {
+        id: 2,
+        tabId: 10,
+        maxGrade: 100,
+        title: 'B',
+        gradebookWeight: 20,
+        gradebookExcluded: true,
+      },
+    ];
+    expect(
+      computeTabSubtotal({
+        studentId: 1,
+        tab: {
+          id: 10,
+          title: 'M',
+          categoryId: 0,
+          weightMode: 'custom',
+          gradebookWeight: 30,
+        },
+        assessments: customAssessments,
+        submissions: [
+          { studentId: 1, assessmentId: 1, grade: 90 },
+          { studentId: 1, assessmentId: 2, grade: 100 },
+        ],
+      }),
+    ).toBeCloseTo(0.9);
+  });
+});
+
+describe('breakdown — exclusion', () => {
+  const bdAssessments = [
+    { id: 1, tabId: 10, maxGrade: 100, title: 'A' },
+    { id: 2, tabId: 10, maxGrade: 50, title: 'B', gradebookExcluded: true },
+  ];
+
+  it('flags excluded assessments and gives them zero points/effectiveWeight', () => {
+    const [tab] = computeStudentBreakdown({
+      studentId: 1,
+      tabs: [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 }],
+      assessments: bdAssessments,
+      submissions: [{ studentId: 1, assessmentId: 1, grade: 100 }],
+    });
+    const a = tab.assessments.find((x) => x.assessmentId === 1)!;
+    const b = tab.assessments.find((x) => x.assessmentId === 2)!;
+    expect(b.excluded).toBe(true);
+    expect(b.points).toBe(0);
+    expect(b.effectiveWeight).toBe(0);
+    // equal effectiveWeight uses included count (1), so a gets the full 60
+    expect(a.excluded).toBe(false);
+    expect(a.effectiveWeight).toBeCloseTo(60);
+    expect(a.points).toBeCloseTo(60);
+  });
+});
+
+describe('zero-maxGrade assessments (0/0 must not produce NaN)', () => {
+  it('equal mode: a graded 0/0 assessment contributes a 0 ratio, not NaN', () => {
+    // a1 graded 0/0 → ratio 0 (not 0/0=NaN), a2 graded 50/50 → 1.0
+    // subtotal = (0 + 1.0) / 2 = 0.5
+    const zeroMax = [
+      { id: 1, tabId: 10, maxGrade: 0, title: 'A' },
+      { id: 2, tabId: 10, maxGrade: 50, title: 'B' },
+    ];
+    const result = computeTabSubtotal({
+      studentId: 1,
+      tab: { id: 10, title: 'M', categoryId: 0 },
+      assessments: zeroMax,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 0 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+      ]),
+    });
+    expect(Number.isNaN(result)).toBe(false);
+    expect(result).toBeCloseTo(0.5);
+  });
+
+  it('custom mode: a graded 0/0 assessment contributes 0, not NaN', () => {
+    // a1 0/0 weight 30 → 0 points, a2 50/50 weight 70 → 70 points
+    // subtotal = (0 + 70) / 100 = 0.7
+    const zeroMax = [
+      { id: 1, tabId: 10, maxGrade: 0, title: 'A', gradebookWeight: 30 },
+      { id: 2, tabId: 10, maxGrade: 50, title: 'B', gradebookWeight: 70 },
+    ];
+    const result = computeTabSubtotal({
+      studentId: 1,
+      tab: {
+        id: 10,
+        title: 'M',
+        categoryId: 0,
+        gradebookWeight: 100,
+        weightMode: 'custom' as const,
+      },
+      assessments: zeroMax,
+      submissions: subs([
+        { studentId: 1, assessmentId: 1, grade: 0 },
+        { studentId: 1, assessmentId: 2, grade: 50 },
+      ]),
+    });
+    expect(Number.isNaN(result)).toBe(false);
+    expect(result).toBeCloseTo(0.7);
+  });
+
+  it('does not propagate NaN into the student total', () => {
+    const zeroMax = [{ id: 1, tabId: 10, maxGrade: 0, title: 'A' }];
+    const total = computeStudentTotal({
+      studentId: 1,
+      tabs: [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 100 }],
+      assessments: zeroMax,
+      submissions: subs([{ studentId: 1, assessmentId: 1, grade: 0 }]),
+    });
+    expect(Number.isNaN(total)).toBe(false);
+    expect(total).toBe(0);
+  });
+
+  it('breakdown: a graded 0/0 assessment has 0 points/ratio, not NaN', () => {
+    const zeroMax = [{ id: 1, tabId: 10, maxGrade: 0, title: 'A' }];
+    const [tab] = computeStudentBreakdown({
+      studentId: 1,
+      tabs: [{ id: 10, title: 'M', categoryId: 0, gradebookWeight: 60 }],
+      assessments: zeroMax,
+      submissions: subs([{ studentId: 1, assessmentId: 1, grade: 0 }]),
+    });
+    const a = tab.assessments.find((x) => x.assessmentId === 1)!;
+    expect(Number.isNaN(a.points)).toBe(false);
+    expect(a.points).toBe(0);
+  });
+});

--- a/client/app/bundles/course/gradebook/__tests__/store.test.ts
+++ b/client/app/bundles/course/gradebook/__tests__/store.test.ts
@@ -1,0 +1,153 @@
+import reducer, { actions } from '../store';
+
+const baseState = {
+  categories: [],
+  tabs: [
+    { id: 1, title: 'T1', categoryId: 1, gradebookWeight: 50 },
+    { id: 2, title: 'T2', categoryId: 1, gradebookWeight: 50 },
+  ],
+  assessments: [
+    { id: 101, title: 'A1', tabId: 1, maxGrade: 100 },
+    { id: 102, title: 'A2', tabId: 1, maxGrade: 100 },
+  ],
+  students: [],
+  submissions: [],
+  gamificationEnabled: false,
+  weightedViewEnabled: false,
+  canManageWeights: false,
+};
+
+describe('UPDATE_TAB_WEIGHTS reducer', () => {
+  it('updates gradebookWeight and weightMode for the matching tab', () => {
+    const next = reducer(
+      baseState,
+      actions.updateTabWeights({
+        weights: [{ tabId: 1, weight: 80, weightMode: 'equal' }],
+      }),
+    );
+    expect(next.tabs.find((t) => t.id === 1)?.gradebookWeight).toBe(80);
+    expect(next.tabs.find((t) => t.id === 1)?.weightMode).toBe('equal');
+    expect(next.tabs.find((t) => t.id === 2)?.gradebookWeight).toBe(50);
+  });
+
+  it('does not set any excluded field', () => {
+    const next = reducer(
+      baseState,
+      actions.updateTabWeights({
+        weights: [{ tabId: 1, weight: 0, weightMode: 'equal' }],
+      }),
+    );
+    const tab = next.tabs.find((t) => t.id === 1)!;
+    expect(tab).not.toHaveProperty('gradebookExcluded');
+  });
+
+  it('updates multiple tabs in one action', () => {
+    const next = reducer(
+      baseState,
+      actions.updateTabWeights({
+        weights: [
+          { tabId: 1, weight: 30, weightMode: 'equal' },
+          { tabId: 2, weight: 70, weightMode: 'custom' },
+        ],
+      }),
+    );
+    expect(next.tabs.find((t) => t.id === 1)?.gradebookWeight).toBe(30);
+    expect(next.tabs.find((t) => t.id === 2)?.gradebookWeight).toBe(70);
+    expect(next.tabs.find((t) => t.id === 2)?.weightMode).toBe('custom');
+  });
+
+  it('applies per-assessment weights for custom mode', () => {
+    const next = reducer(
+      baseState,
+      actions.updateTabWeights({
+        weights: [
+          {
+            tabId: 1,
+            weight: 100,
+            weightMode: 'custom',
+            assessmentWeights: [
+              { assessmentId: 101, weight: 30 },
+              { assessmentId: 102, weight: 70 },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(next.assessments.find((a) => a.id === 101)?.gradebookWeight).toBe(
+      30,
+    );
+    expect(next.assessments.find((a) => a.id === 102)?.gradebookWeight).toBe(
+      70,
+    );
+  });
+
+  it('clears per-assessment weights for equal mode', () => {
+    const stateWithWeights = {
+      ...baseState,
+      assessments: [
+        { id: 101, title: 'A1', tabId: 1, maxGrade: 100, gradebookWeight: 30 },
+        { id: 102, title: 'A2', tabId: 1, maxGrade: 100, gradebookWeight: 70 },
+      ],
+    };
+    const next = reducer(
+      stateWithWeights,
+      actions.updateTabWeights({
+        weights: [{ tabId: 1, weight: 100, weightMode: 'equal' }],
+      }),
+    );
+    expect(
+      next.assessments.find((a) => a.id === 101)?.gradebookWeight,
+    ).toBeNull();
+    expect(
+      next.assessments.find((a) => a.id === 102)?.gradebookWeight,
+    ).toBeNull();
+  });
+
+  it('applies per-assessment exclusion flips from the payload', () => {
+    const start = reducer(
+      undefined,
+      actions.saveGradebook({
+        categories: [{ id: 1, title: 'C' }],
+        tabs: [
+          {
+            id: 10,
+            title: 'T',
+            categoryId: 1,
+            gradebookWeight: 50,
+            weightMode: 'equal',
+          },
+        ],
+        assessments: [
+          { id: 101, title: 'A', tabId: 10, maxGrade: 100 },
+          { id: 102, title: 'B', tabId: 10, maxGrade: 100 },
+        ],
+        students: [],
+        submissions: [],
+        gamificationEnabled: false,
+        weightedViewEnabled: true,
+        canManageWeights: true,
+      }),
+    );
+
+    const next = reducer(
+      start,
+      actions.updateTabWeights({
+        weights: [
+          {
+            tabId: 10,
+            weight: 50,
+            weightMode: 'equal',
+            excludedAssessmentIds: [101],
+          },
+        ],
+      }),
+    );
+
+    expect(next.assessments.find((a) => a.id === 101)!.gradebookExcluded).toBe(
+      true,
+    );
+    expect(next.assessments.find((a) => a.id === 102)!.gradebookExcluded).toBe(
+      false,
+    );
+  });
+});

--- a/client/app/bundles/course/gradebook/components/ConfigureWeightsPrompt.tsx
+++ b/client/app/bundles/course/gradebook/components/ConfigureWeightsPrompt.tsx
@@ -1,0 +1,600 @@
+import { FC, useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import {
+  Alert,
+  Checkbox,
+  Collapse,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type {
+  AssessmentData,
+  CategoryData,
+  TabData,
+} from 'types/course/gradebook';
+
+import SegmentedSwitch from 'lib/components/core/buttons/SegmentedSwitch';
+import Prompt from 'lib/components/core/dialogs/Prompt';
+import { useAppDispatch } from 'lib/hooks/store';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+import formTranslations from 'lib/translations/form';
+
+import { resolveTabWeights, usingDefaultWeights } from '../computeWeighted';
+import { updateGradebookWeights } from '../operations';
+
+const translations = defineMessages({
+  promptTitle: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.promptTitle',
+    defaultMessage: 'Configure contributions',
+  },
+  descriptionIntro: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.descriptionIntro',
+    defaultMessage:
+      "Control how tabs and assessments count toward each student's total grade.",
+  },
+  descriptionWeights: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.descriptionWeights',
+    defaultMessage:
+      "Set each tab's weight - how much it contributes to the total (weights should sum to 100).",
+  },
+  descriptionExclusion: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.descriptionExclusion',
+    defaultMessage:
+      'Expand a tab to include or exclude individual assessments from grading.',
+  },
+  descriptionModes: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.descriptionModes',
+    defaultMessage:
+      "Choose Equal (all assessments share the tab's weight) or Custom (set each assessment's share).",
+  },
+  descriptionDrop: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.descriptionDrop',
+    defaultMessage:
+      "In Equal mode, optionally drop each student's N lowest-scoring assessments before averaging.",
+  },
+  total: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.total',
+    defaultMessage: 'Total: {sum}%',
+  },
+  weightsDoNotSum: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.weightsDoNotSum',
+    defaultMessage:
+      'Weights do not sum to 100. Saving is allowed; Total may be inaccurate.',
+  },
+  valueTooLow: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.valueTooLow',
+    defaultMessage: 'Value must be at least 0',
+  },
+  valueTooHigh: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.valueTooHigh',
+    defaultMessage: 'Value must be at most 100',
+  },
+  saveError: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.saveError',
+    defaultMessage: 'Failed to save weights. Please try again.',
+  },
+  ofGrade: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.ofGrade',
+    defaultMessage: '{pct}% of grade',
+  },
+  equalMode: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.equalMode',
+    defaultMessage: 'Equal',
+  },
+  customMode: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.customMode',
+    defaultMessage: 'Custom',
+  },
+  modeAria: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.modeAria',
+    defaultMessage: '{tab} weight mode',
+  },
+  customSum: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.customSum',
+    defaultMessage: 'Assessment weights: {sum} / {total}',
+  },
+  unbalanced: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.unbalanced',
+    defaultMessage:
+      'Assessment weights for "{tab}" must sum to its tab total before saving.',
+  },
+  includeAssessment: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.includeAssessment',
+    defaultMessage: 'Include {assessment} in grade',
+  },
+  excluded: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.excluded',
+    defaultMessage: 'Excluded',
+  },
+  allExcluded: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.allExcluded',
+    defaultMessage:
+      'All assessments in "{tab}" are excluded - it contributes nothing to the total.',
+  },
+  excludedCount: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.excludedCount',
+    defaultMessage: '{n} excluded',
+  },
+  allExcludedCount: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.allExcludedCount',
+    defaultMessage: 'All {n} excluded',
+  },
+  defaultsHint: {
+    id: 'course.gradebook.ConfigureWeightsPrompt.defaultsHint',
+    defaultMessage:
+      'No weights set yet - these are suggested defaults with every tab counting equally. Save to confirm, or adjust below.',
+  },
+});
+
+type WeightMode = 'equal' | 'custom';
+
+const r2 = (n: number): number => Math.round(n * 100) / 100;
+const cents = (n: number): number => Math.round(n * 100);
+// Distribute a tab total across assessment ids at 2dp; the last id absorbs the rounding
+// remainder so the seeded values sum back exactly to total.
+const distributeEqual = (
+  total: number,
+  ids: number[],
+): Record<number, number> => {
+  const result: Record<number, number> = {};
+  const n = ids.length;
+  if (n === 0) return result;
+  const base = r2(total / n);
+  ids.forEach((id, i) => {
+    result[id] = i === n - 1 ? r2(total - base * (n - 1)) : base;
+  });
+  return result;
+};
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  categories: CategoryData[];
+  tabs: TabData[];
+  assessments: AssessmentData[];
+}
+
+const ConfigureWeightsPrompt: FC<Props> = ({
+  open,
+  onClose,
+  categories,
+  tabs,
+  assessments,
+}) => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  // Pre-fill from the same equal-split default the table shows when no weights
+  // are configured, so opening the dialog confirms what is already on screen
+  // rather than presenting a blank 0%.
+  const resolvedTabs = resolveTabWeights(tabs, assessments);
+  const showingDefaults = usingDefaultWeights(tabs, assessments);
+
+  const validate = (value: number): string | null => {
+    if (Number.isNaN(value)) return t(translations.valueTooLow);
+    if (value < 0) return t(translations.valueTooLow);
+    if (value > 100) return t(translations.valueTooHigh);
+    return null;
+  };
+
+  const seedWeights = (): Record<number, number> =>
+    Object.fromEntries(
+      resolvedTabs.map((tb) => [tb.id, tb.gradebookWeight ?? 0]),
+    );
+  const seedModes = (): Record<number, WeightMode> =>
+    Object.fromEntries(
+      resolvedTabs.map((tb) => [tb.id, tb.weightMode ?? 'equal']),
+    );
+  const seedAssessmentWeights = (): Record<number, number> =>
+    Object.fromEntries(assessments.map((a) => [a.id, a.gradebookWeight ?? 0]));
+  const seedExclusions = (): Record<number, boolean> =>
+    Object.fromEntries(assessments.map((a) => [a.id, !!a.gradebookExcluded]));
+
+  const [weights, setWeights] = useState<Record<number, number>>(seedWeights);
+  const [modes, setModes] = useState<Record<number, WeightMode>>(seedModes);
+  const [assessmentWeights, setAssessmentWeights] = useState<
+    Record<number, number>
+  >(seedAssessmentWeights);
+  const [excluded, setExcluded] =
+    useState<Record<number, boolean>>(seedExclusions);
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setWeights(seedWeights());
+      setModes(seedModes());
+      setAssessmentWeights(seedAssessmentWeights());
+      setExcluded(seedExclusions());
+      setExpanded({});
+    }
+  }, [open]);
+
+  const tabAssessmentIds = (tabId: number): number[] =>
+    assessments.filter((a) => a.tabId === tabId).map((a) => a.id);
+
+  const tabIncludedIds = (tabId: number): number[] =>
+    tabAssessmentIds(tabId).filter((id) => !excluded[id]);
+
+  const customSum = (tabId: number): number =>
+    tabIncludedIds(tabId).reduce(
+      (acc, id) => acc + (assessmentWeights[id] ?? 0),
+      0,
+    );
+
+  const isUnbalanced = (tabId: number): boolean =>
+    (modes[tabId] ?? 'equal') === 'custom' &&
+    tabIncludedIds(tabId).length > 0 &&
+    cents(customSum(tabId)) !== cents(weights[tabId] ?? 0);
+
+  const isAllExcluded = (tabId: number): boolean =>
+    tabAssessmentIds(tabId).length > 0 && tabIncludedIds(tabId).length === 0;
+
+  // An all-excluded tab contributes nothing, so its stored weight is treated as 0
+  // for the Total. The stored value is retained (still saved, restored on re-include).
+  const effectiveWeight = (tabId: number): number =>
+    isAllExcluded(tabId) ? 0 : weights[tabId] ?? 0;
+
+  const sum = tabs.reduce((acc, tb) => acc + effectiveWeight(tb.id), 0);
+  const hasInvalid =
+    Object.values(weights).some((w) => validate(w) !== null) ||
+    Object.values(assessmentWeights).some((w) => validate(w) !== null);
+  const hasUnbalanced = tabs.some((tb) => isUnbalanced(tb.id));
+
+  const handleChange = (tabId: number, raw: string): void => {
+    const parsed = raw === '' ? 0 : Number(raw);
+    setWeights((prev) => ({ ...prev, [tabId]: parsed }));
+  };
+
+  const handleAssessmentChange = (assessmentId: number, raw: string): void => {
+    const parsed = raw === '' ? 0 : Number(raw);
+    setAssessmentWeights((prev) => ({ ...prev, [assessmentId]: parsed }));
+  };
+
+  const handleToggleExcluded = (assessmentId: number): void =>
+    setExcluded((prev) => ({ ...prev, [assessmentId]: !prev[assessmentId] }));
+
+  const handleModeChange = (tabId: number, next: WeightMode | null): void => {
+    if (!next) return; // ToggleButtonGroup emits null when clicking the active button
+    setModes((prev) => ({ ...prev, [tabId]: next }));
+    if (next === 'custom') {
+      const includedIds = tabIncludedIds(tabId);
+      const allZero = includedIds.every(
+        (id) => (assessmentWeights[id] ?? 0) === 0,
+      );
+      if (allZero) {
+        const seeded = distributeEqual(weights[tabId] ?? 0, includedIds);
+        setAssessmentWeights((prev) => ({ ...prev, ...seeded }));
+      }
+      setExpanded((prev) => ({ ...prev, [tabId]: true }));
+    }
+  };
+
+  const toggleExpanded = (tabId: number): void =>
+    setExpanded((prev) => ({ ...prev, [tabId]: !prev[tabId] }));
+
+  const handleSave = async (): Promise<void> => {
+    if (hasInvalid || hasUnbalanced) return;
+    setSubmitting(true);
+    try {
+      await dispatch(
+        updateGradebookWeights(
+          tabs.map((tb) => {
+            const mode = modes[tb.id] ?? 'equal';
+            const entry = {
+              tabId: tb.id,
+              weight: weights[tb.id] ?? 0,
+              weightMode: mode,
+              excludedAssessmentIds: tabAssessmentIds(tb.id).filter(
+                (id) => excluded[id],
+              ),
+            };
+            if (mode === 'custom') {
+              return {
+                ...entry,
+                assessmentWeights: tabAssessmentIds(tb.id).map((id) => ({
+                  assessmentId: id,
+                  weight: assessmentWeights[id] ?? 0,
+                })),
+              };
+            }
+            return entry;
+          }),
+        ),
+      );
+      onClose();
+    } catch {
+      toast.error(t(translations.saveError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Prompt
+      onClickPrimary={handleSave}
+      onClose={onClose}
+      open={open}
+      primaryDisabled={submitting || hasInvalid || hasUnbalanced}
+      primaryLabel={t(formTranslations.save)}
+      title={t(translations.promptTitle)}
+    >
+      {showingDefaults && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {t(translations.defaultsHint)}
+        </Alert>
+      )}
+      <Typography color="text.secondary" gutterBottom variant="body2">
+        {t(translations.descriptionIntro)}
+      </Typography>
+      <ul style={{ margin: '4px 0 16px', paddingLeft: 20 }}>
+        {[
+          translations.descriptionWeights,
+          translations.descriptionExclusion,
+          translations.descriptionModes,
+        ].map((key) => (
+          <Typography
+            key={key.id}
+            color="text.secondary"
+            component="li"
+            variant="body2"
+          >
+            {t(key)}
+          </Typography>
+        ))}
+      </ul>
+      <Stack spacing={2} sx={{ mt: 2 }}>
+        {categories.map((cat) => (
+          <div key={cat.id}>
+            <Typography variant="subtitle2">{cat.title}</Typography>
+            <Stack spacing={0.5} sx={{ pl: 1, mt: 1 }}>
+              {tabs
+                .filter((tb) => tb.categoryId === cat.id)
+                .map((tb) => {
+                  const value = weights[tb.id] ?? 0;
+                  const err = validate(value);
+                  const tabAssessments = assessments.filter(
+                    (a) => a.tabId === tb.id,
+                  );
+                  const mode = modes[tb.id] ?? 'equal';
+                  const isExpanded = !!expanded[tb.id];
+                  const unbalanced = isUnbalanced(tb.id);
+                  const noAssessments = tabAssessments.length === 0;
+                  const includedCount = tabIncludedIds(tb.id).length;
+                  const excludedCount = tabAssessments.length - includedCount;
+                  const pct = includedCount > 0 ? r2(value / includedCount) : 0;
+
+                  return (
+                    <div key={tb.id}>
+                      <div className="flex items-center gap-1">
+                        <IconButton
+                          disabled={noAssessments}
+                          onClick={() => toggleExpanded(tb.id)}
+                          size="small"
+                        >
+                          {isExpanded ? (
+                            <ExpandLess fontSize="small" />
+                          ) : (
+                            <ExpandMore fontSize="small" />
+                          )}
+                        </IconButton>
+                        <Typography className="flex-1" variant="body2">
+                          {tb.title}
+                          {excludedCount > 0 && (
+                            <>
+                              {' · '}
+                              <Typography
+                                color="text.secondary"
+                                component="span"
+                                variant="caption"
+                              >
+                                {isAllExcluded(tb.id)
+                                  ? t(translations.allExcludedCount, {
+                                      n: excludedCount,
+                                    })
+                                  : t(translations.excludedCount, {
+                                      n: excludedCount,
+                                    })}
+                              </Typography>
+                            </>
+                          )}
+                        </Typography>
+                        <SegmentedSwitch
+                          ariaLabel={t(translations.modeAria, {
+                            tab: tb.title,
+                          })}
+                          // Match the weight input's height on this row without
+                          // hardcoding it: stretch to the row's tallest control.
+                          className="self-stretch"
+                          disabled={noAssessments}
+                          onChange={(next) => handleModeChange(tb.id, next)}
+                          options={[
+                            {
+                              value: 'equal',
+                              label: t(translations.equalMode),
+                            },
+                            {
+                              value: 'custom',
+                              label: t(translations.customMode),
+                            },
+                          ]}
+                          value={mode}
+                        />
+                        <TextField
+                          disabled={isAllExcluded(tb.id)}
+                          error={err !== null}
+                          inputProps={{
+                            'aria-label': tb.title,
+                            min: 0,
+                            max: 100,
+                            step: 0.01,
+                          }}
+                          onBlur={() =>
+                            setWeights((prev) => ({
+                              ...prev,
+                              [tb.id]: r2(prev[tb.id] ?? 0),
+                            }))
+                          }
+                          onChange={(e) => handleChange(tb.id, e.target.value)}
+                          size="small"
+                          sx={{ width: 96 }}
+                          type="number"
+                          value={isAllExcluded(tb.id) ? 0 : value}
+                        />
+                      </div>
+                      {err && (
+                        <Typography
+                          className="pl-9"
+                          color="error"
+                          variant="caption"
+                        >
+                          {err}
+                        </Typography>
+                      )}
+                      {unbalanced && (
+                        <Alert severity="error" sx={{ mt: 1, ml: 4.5 }}>
+                          {t(translations.unbalanced, { tab: tb.title })}
+                        </Alert>
+                      )}
+                      {isAllExcluded(tb.id) && (
+                        <Alert severity="warning" sx={{ mt: 1, ml: 4.5 }}>
+                          {t(translations.allExcluded, { tab: tb.title })}
+                        </Alert>
+                      )}
+                      <Collapse in={isExpanded}>
+                        <Stack spacing={0} sx={{ pl: 4.5, pt: 0.5, pb: 0.5 }}>
+                          {tabAssessments.map((a) => {
+                            const isExcluded = !!excluded[a.id];
+                            const checkbox = (
+                              <Checkbox
+                                checked={!isExcluded}
+                                inputProps={{
+                                  'aria-label': t(
+                                    translations.includeAssessment,
+                                    {
+                                      assessment: a.title,
+                                    },
+                                  ),
+                                }}
+                                onChange={() => handleToggleExcluded(a.id)}
+                                size="small"
+                              />
+                            );
+                            if (mode === 'custom') {
+                              const awValue = assessmentWeights[a.id] ?? 0;
+                              const awErr = validate(awValue);
+                              return (
+                                <div
+                                  key={a.id}
+                                  className="flex items-center justify-between py-0.5"
+                                >
+                                  <div className="flex items-center">
+                                    {checkbox}
+                                    <Typography
+                                      color="text.secondary"
+                                      variant="caption"
+                                    >
+                                      {a.title}
+                                    </Typography>
+                                  </div>
+                                  {isExcluded ? (
+                                    <Typography
+                                      color="text.disabled"
+                                      variant="caption"
+                                    >
+                                      {t(translations.excluded)}
+                                    </Typography>
+                                  ) : (
+                                    <TextField
+                                      error={awErr !== null}
+                                      inputProps={{
+                                        'aria-label': `${tb.title}: ${a.title}`,
+                                        min: 0,
+                                        step: 0.01,
+                                      }}
+                                      onBlur={() =>
+                                        setAssessmentWeights((prev) => ({
+                                          ...prev,
+                                          [a.id]: r2(prev[a.id] ?? 0),
+                                        }))
+                                      }
+                                      onChange={(e) =>
+                                        handleAssessmentChange(
+                                          a.id,
+                                          e.target.value,
+                                        )
+                                      }
+                                      size="small"
+                                      sx={{ width: 88 }}
+                                      type="number"
+                                      value={awValue}
+                                    />
+                                  )}
+                                </div>
+                              );
+                            }
+                            return (
+                              <div
+                                key={a.id}
+                                className="flex items-center justify-between py-0.5"
+                              >
+                                <div className="flex items-center">
+                                  {checkbox}
+                                  <Typography
+                                    color="text.secondary"
+                                    variant="caption"
+                                  >
+                                    {a.title}
+                                  </Typography>
+                                </div>
+                                <Typography
+                                  color="text.disabled"
+                                  variant="caption"
+                                >
+                                  {isExcluded
+                                    ? t(translations.excluded)
+                                    : t(translations.ofGrade, {
+                                        pct: pct.toFixed(2),
+                                      })}
+                                </Typography>
+                              </div>
+                            );
+                          })}
+                          {mode === 'custom' && (
+                            <Typography
+                              className="pt-1"
+                              color={unbalanced ? 'error' : 'text.secondary'}
+                              variant="caption"
+                            >
+                              {t(translations.customSum, {
+                                sum: r2(customSum(tb.id)).toFixed(2),
+                                total: value.toFixed(2),
+                              })}
+                            </Typography>
+                          )}
+                        </Stack>
+                      </Collapse>
+                    </div>
+                  );
+                })}
+            </Stack>
+          </div>
+        ))}
+      </Stack>
+      <Typography sx={{ mt: 3, fontWeight: 500 }}>
+        {t(translations.total, { sum })}
+      </Typography>
+      {sum !== 100 && (
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          {t(translations.weightsDoNotSum)}
+        </Alert>
+      )}
+    </Prompt>
+  );
+};
+
+export default ConfigureWeightsPrompt;

--- a/client/app/bundles/course/gradebook/components/ProjectedTotalHint.tsx
+++ b/client/app/bundles/course/gradebook/components/ProjectedTotalHint.tsx
@@ -1,0 +1,51 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Alert, Typography } from '@mui/material';
+
+import { getUserEntity } from 'bundles/users/selectors';
+import { useAppSelector } from 'lib/hooks/store';
+import useDismissibleOnce from 'lib/hooks/useDismissibleOnce';
+import useTranslation from 'lib/hooks/useTranslation';
+
+export const PROJECTED_TOTAL_POLICY_HINT_KEY =
+  'gradebook_projected_total_policy_hint';
+
+// Single source for the projected-total policy sentence: the one-time banner
+// below and the ⓘ tooltip on the Total header (in WeightedGradebookTable) both
+// render this exact message, so the explanation never drifts between the two.
+export const projectedTotalPolicyTranslations = defineMessages({
+  policy: {
+    id: 'course.gradebook.ProjectedTotalHint.policy',
+    defaultMessage: 'Totals count ungraded assessments as 0.',
+  },
+});
+
+/**
+ * One-time, dismissable banner shown the first time a manager opens the weighted
+ * (Weighted Total) gradebook view. It teaches the projected-total policy — ungraded
+ * assessments are counted as 0 — so a low total isn't mistaken for a bug. After
+ * dismissal the policy stays available via the ⓘ tooltip on the Total header.
+ * Dismissal is remembered per user via localStorage (see useDismissibleOnce).
+ */
+const ProjectedTotalHint: FC = () => {
+  const { t } = useTranslation();
+  const userId = useAppSelector(getUserEntity).id;
+  const { dismissed, dismiss } = useDismissibleOnce(
+    PROJECTED_TOTAL_POLICY_HINT_KEY,
+    userId,
+  );
+
+  if (dismissed) return null;
+
+  return (
+    <div className="px-5 pt-3">
+      <Alert onClose={dismiss} severity="info">
+        <Typography variant="body2">
+          {t(projectedTotalPolicyTranslations.policy)}
+        </Typography>
+      </Alert>
+    </div>
+  );
+};
+
+export default ProjectedTotalHint;

--- a/client/app/bundles/course/gradebook/components/WeightedGradebookColumnTree.tsx
+++ b/client/app/bundles/course/gradebook/components/WeightedGradebookColumnTree.tsx
@@ -1,0 +1,79 @@
+import { defineMessages } from 'react-intl';
+import { Chip } from '@mui/material';
+
+import IndentedCheckbox from 'lib/components/core/IndentedCheckbox';
+import {
+  ColumnPickerRenderContext,
+  ColumnPickerTreeGroup,
+} from 'lib/components/table';
+import useTranslation from 'lib/hooks/useTranslation';
+import tableTranslations from 'lib/translations/table';
+
+import { STUDENT_INFO_COL_IDS, type StudentInfoColId } from '../constants';
+
+const translations = defineMessages({
+  studentInfo: {
+    id: 'course.gradebook.GradebookColumnTree.studentInfo',
+    defaultMessage: 'Student info',
+  },
+  alwaysIncluded: {
+    id: 'course.gradebook.GradebookColumnTree.alwaysIncluded',
+    defaultMessage: 'Always included',
+  },
+});
+
+const WeightedGradebookColumnTree = ({
+  isVisible,
+  setVisible,
+  setManyVisible,
+}: ColumnPickerRenderContext): JSX.Element => {
+  const { t } = useTranslation();
+  const context: ColumnPickerRenderContext = {
+    isVisible,
+    setVisible,
+    setManyVisible,
+  };
+
+  return (
+    <div>
+      <ColumnPickerTreeGroup
+        childIds={[...STUDENT_INFO_COL_IDS]}
+        context={context}
+        indentLevel={0}
+        label={t(translations.studentInfo)}
+      >
+        {STUDENT_INFO_COL_IDS.map((id: StudentInfoColId) =>
+          id === 'name' ? (
+            <IndentedCheckbox
+              key={id}
+              checked
+              disabled
+              indentLevel={1}
+              label={
+                <span className="flex items-center gap-2">
+                  {t(tableTranslations[id])}
+                  <Chip
+                    color="primary"
+                    label={t(translations.alwaysIncluded)}
+                    size="small"
+                    variant="outlined"
+                  />
+                </span>
+              }
+            />
+          ) : (
+            <IndentedCheckbox
+              key={id}
+              checked={isVisible(id)}
+              indentLevel={1}
+              label={t(tableTranslations[id])}
+              onChange={(e) => setVisible(id, e.target.checked)}
+            />
+          ),
+        )}
+      </ColumnPickerTreeGroup>
+    </div>
+  );
+};
+
+export default WeightedGradebookColumnTree;

--- a/client/app/bundles/course/gradebook/components/WeightedGradebookTable.tsx
+++ b/client/app/bundles/course/gradebook/components/WeightedGradebookTable.tsx
@@ -1,0 +1,1067 @@
+import { Fragment, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import {
+  Download,
+  InfoOutlined,
+  KeyboardArrowDown,
+  KeyboardArrowRight,
+} from '@mui/icons-material';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import type {
+  AssessmentData,
+  CategoryData,
+  StudentData,
+  SubmissionData,
+  TabData,
+} from 'types/course/gradebook';
+
+import SegmentedSwitch from 'lib/components/core/buttons/SegmentedSwitch';
+import SearchField from 'lib/components/core/fields/SearchField';
+import type { ColumnPickerRenderContext } from 'lib/components/table';
+import type { ColumnTemplate } from 'lib/components/table/builder';
+import MuiColumnPickerPrompt from 'lib/components/table/MuiTableAdapter/MuiColumnPickerPrompt';
+import MuiTablePagination from 'lib/components/table/MuiTableAdapter/MuiTablePagination';
+import useTanStackTableBuilder from 'lib/components/table/TanStackTableBuilder';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import useTranslation from 'lib/hooks/useTranslation';
+import tableTranslations from 'lib/translations/table';
+
+import type { AssessmentContribution, WeightedRow } from '../computeWeighted';
+import {
+  computeStudentBreakdown,
+  computeWeightedRows,
+  gradeRatio,
+  resolveTabWeights,
+  usingDefaultWeights,
+} from '../computeWeighted';
+
+import ConfigureWeightsPrompt from './ConfigureWeightsPrompt';
+import ProjectedTotalHint, {
+  projectedTotalPolicyTranslations,
+} from './ProjectedTotalHint';
+import WeightedGradebookColumnTree from './WeightedGradebookColumnTree';
+
+const translations = defineMessages({
+  configureWeights: {
+    id: 'course.gradebook.WeightedGradebookTable.configureWeights',
+    defaultMessage: 'Configure Weights',
+  },
+  noWeightsConfigured: {
+    id: 'course.gradebook.WeightedGradebookTable.noWeightsConfigured',
+    defaultMessage:
+      'No weights configured - all tab weights are 0. Click "Configure Weights" to assign weights.',
+  },
+  noWeightsNoAccess: {
+    id: 'course.gradebook.WeightedGradebookTable.noWeightsNoAccess',
+    defaultMessage: 'No tab weights have been configured yet.',
+  },
+  defaultWeights: {
+    id: 'course.gradebook.WeightedGradebookTable.defaultWeights',
+    defaultMessage:
+      'Showing default weights - every tab counts equally. Click "Configure Weights" to set your own.',
+  },
+  defaultWeightsNoAccess: {
+    id: 'course.gradebook.WeightedGradebookTable.defaultWeightsNoAccess',
+    defaultMessage:
+      'Showing default weights - every tab counts equally until weights are configured.',
+  },
+  percentOfGrade: {
+    id: 'course.gradebook.WeightedGradebookTable.percentOfGrade',
+    defaultMessage: '{weight}% of grade',
+  },
+  percentTotalExact: {
+    id: 'course.gradebook.WeightedGradebookTable.percentTotalExact',
+    defaultMessage: '100% total',
+  },
+  percentTotalWarning: {
+    id: 'course.gradebook.WeightedGradebookTable.percentTotalWarning',
+    defaultMessage: '{weight}% total',
+  },
+  outOfWeight: {
+    id: 'course.gradebook.WeightedGradebookTable.outOfWeight',
+    defaultMessage: '/{weight}',
+  },
+  displayMode: {
+    id: 'course.gradebook.WeightedGradebookTable.displayMode',
+    defaultMessage: 'Display mode',
+  },
+  displayPoints: {
+    id: 'course.gradebook.WeightedGradebookTable.displayPoints',
+    defaultMessage: 'Points',
+  },
+  displayPointsTooltip: {
+    id: 'course.gradebook.WeightedGradebookTable.displayPointsTooltip',
+    defaultMessage:
+      'How many grade points each tab contributes. Columns add up to the projected total.',
+  },
+  displayPercent: {
+    id: 'course.gradebook.WeightedGradebookTable.displayPercent',
+    defaultMessage: 'Percentage',
+  },
+  displayPercentTooltip: {
+    id: 'course.gradebook.WeightedGradebookTable.displayPercentTooltip',
+    defaultMessage:
+      'What fraction of each tab the student earned. 100% on a tab worth 20% = the student earned all 20 grade points from that tab.',
+  },
+  weightsDoNotSum: {
+    id: 'course.gradebook.WeightedGradebookTable.weightsDoNotSum',
+    defaultMessage: 'Weights do not sum to 100. Total may be inaccurate.',
+  },
+  searchStudents: {
+    id: 'course.gradebook.WeightedGradebookTable.searchStudents',
+    defaultMessage: 'Search students',
+  },
+  downloadCsv: {
+    id: 'course.gradebook.WeightedGradebookTable.downloadCsv',
+    defaultMessage: 'Download as CSV',
+  },
+  selectColumns: {
+    id: 'course.gradebook.GradebookIndex.selectColumns',
+    defaultMessage: 'Select Columns',
+  },
+  dialogTitle: {
+    id: 'course.gradebook.GradebookIndex.dialogTitle',
+    defaultMessage: 'Select columns',
+  },
+  exportButton: {
+    id: 'course.gradebook.GradebookIndex.exportButton',
+    defaultMessage: 'Export all rows',
+  },
+  exportRows: {
+    id: 'course.gradebook.GradebookIndex.exportRows',
+    defaultMessage: 'Export {count, plural, one {# row} other {# rows}}',
+  },
+  exportAllTooltip: {
+    id: 'course.gradebook.GradebookIndex.exportAllTooltip',
+    defaultMessage: 'No rows selected - all rows will be exported.',
+  },
+  expandRow: {
+    id: 'course.gradebook.WeightedGradebookTable.expandRow',
+    defaultMessage: 'Expand {name}',
+  },
+  collapseRow: {
+    id: 'course.gradebook.WeightedGradebookTable.collapseRow',
+    defaultMessage: 'Collapse {name}',
+  },
+  excluded: {
+    id: 'course.gradebook.WeightedGradebookTable.excluded',
+    defaultMessage: 'Excluded',
+  },
+  total: {
+    id: 'course.gradebook.WeightedGradebookTable.weightedTotal',
+    defaultMessage: 'Weighted Total',
+  },
+});
+
+type DisplayMode = 'points' | 'percent';
+
+interface Props {
+  categories: CategoryData[];
+  tabs: TabData[];
+  assessments: AssessmentData[];
+  students: StudentData[];
+  submissions: SubmissionData[];
+  canManageWeights: boolean;
+  courseTitle: string;
+  courseId: number;
+}
+
+const precisionNeeded = (v: number): 0 | 1 | 2 => {
+  const at2 = Math.round(v * 100) / 100;
+  const at1 = Math.round(v * 10) / 10;
+  const at0 = Math.round(v);
+  if (Math.abs(at2 - at1) > 1e-9) return 2;
+  if (Math.abs(at1 - at0) > 1e-9) return 1;
+  return 0;
+};
+
+const columnPrecision = (values: (number | null)[]): 0 | 1 | 2 => {
+  const precs = values
+    .filter((v): v is number => v !== null)
+    .map(precisionNeeded);
+  if (precs.includes(2)) return 2;
+  if (precs.includes(1)) return 1;
+  return 0;
+};
+
+const fmtCsv = (v: number | null): string => {
+  if (v === null) return '';
+  return v.toFixed(2);
+};
+
+const CHECKBOX_WIDTH = 56;
+const NAME_WIDTH_COLLAPSED = 150;
+const NAME_WIDTH_EXPANDED = 260;
+const EMAIL_WIDTH = 250;
+const EXTERNAL_ID_WIDTH = 150;
+const TAB_WIDTH = 120;
+
+const WeightedGradebookTable = ({
+  categories,
+  tabs,
+  assessments,
+  students,
+  submissions,
+  canManageWeights,
+  courseTitle,
+  courseId,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [configureOpen, setConfigureOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>('points');
+
+  const resolvedTabs = useMemo(
+    () => resolveTabWeights(tabs, assessments),
+    [tabs, assessments],
+  );
+  const showingDefaults = useMemo(
+    () => usingDefaultWeights(tabs, assessments),
+    [tabs, assessments],
+  );
+
+  const tabDisplayValue = (
+    sub: number | null,
+    weight: number,
+  ): number | null => {
+    if (sub === null) return null;
+    return displayMode === 'percent' ? sub * 100 : sub * weight;
+  };
+
+  const allExcludedTabIds = useMemo(() => {
+    const byTab = new Map<number, boolean>();
+    assessments.forEach((a) => {
+      const allExcludedSoFar = byTab.get(a.tabId);
+      byTab.set(a.tabId, (allExcludedSoFar ?? true) && !!a.gradebookExcluded);
+    });
+    return new Set(
+      [...byTab.entries()].filter(([, allExc]) => allExc).map(([id]) => id),
+    );
+  }, [assessments]);
+
+  const totalWeight = resolvedTabs.reduce(
+    (acc, tab) =>
+      acc + (allExcludedTabIds.has(tab.id) ? 0 : tab.gradebookWeight ?? 0),
+    0,
+  );
+  const allWeightsZero = totalWeight === 0;
+
+  const totalDisplayValue = (total: number | null): number | null => {
+    if (total === null) return null;
+    if (displayMode === 'percent') {
+      return totalWeight > 0 ? (total / totalWeight) * 100 : null;
+    }
+    return total;
+  };
+
+  const fmtDisplay = (v: number | null, prec: 0 | 1 | 2): string => {
+    if (v === null) return '—';
+    const s = v.toFixed(prec);
+    return displayMode === 'percent' ? `${s}%` : s;
+  };
+
+  const breakdownDisplayValue = (a: AssessmentContribution): number | null => {
+    if (displayMode === 'percent') {
+      return a.grade === null ? null : gradeRatio(a.grade, a.maxGrade) * 100;
+    }
+    return a.points;
+  };
+
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+  const toggleExpanded = (studentId: number): void =>
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(studentId)) next.delete(studentId);
+      else next.add(studentId);
+      return next;
+    });
+
+  // Widen the sticky Name column while any row's breakdown is open, so long
+  // assessment titles in the breakdown aren't clipped; shrink back when all
+  // rows are collapsed.
+  const nameWidth =
+    expandedIds.size > 0 ? NAME_WIDTH_EXPANDED : NAME_WIDTH_COLLAPSED;
+
+  const breakdownsByStudent = useMemo(
+    () =>
+      new Map(
+        [...expandedIds].map((studentId) => [
+          studentId,
+          computeStudentBreakdown({
+            studentId,
+            tabs: resolvedTabs,
+            assessments,
+            submissions,
+          }),
+        ]),
+      ),
+    [expandedIds, resolvedTabs, assessments, submissions],
+  );
+
+  const row1Ref = useRef<HTMLTableRowElement>(null);
+  const row2Ref = useRef<HTMLTableRowElement>(null);
+  const [row2Top, setRow2Top] = useState(0);
+  const [row3Top, setRow3Top] = useState(0);
+
+  const tabSubheaderLabel = (tab: TabData): string => {
+    if (allExcludedTabIds.has(tab.id)) return t(translations.excluded);
+    const weight = tab.gradebookWeight ?? 0;
+    return displayMode === 'percent'
+      ? t(translations.percentOfGrade, { weight })
+      : t(translations.outOfWeight, { weight });
+  };
+
+  const categoryTabCounts = useMemo(() => {
+    const counts = new Map<number, number>();
+    resolvedTabs.forEach((tab) => {
+      counts.set(tab.categoryId, (counts.get(tab.categoryId) ?? 0) + 1);
+    });
+    return counts;
+  }, [resolvedTabs]);
+
+  const visibleCategories = useMemo(
+    () => categories.filter((cat) => categoryTabCounts.has(cat.id)),
+    [categories, categoryTabCounts],
+  );
+
+  const tabIsCategoryEnd = useMemo(
+    () =>
+      resolvedTabs.map(
+        (tab, i) =>
+          i === resolvedTabs.length - 1 ||
+          tab.categoryId !== resolvedTabs[i + 1].categoryId,
+      ),
+    [resolvedTabs],
+  );
+  const groupEndIf = (cond: boolean): { 'data-group-end'?: true } =>
+    cond ? { 'data-group-end': true } : {};
+
+  useLayoutEffect(() => {
+    const row1 = row1Ref.current;
+    const row2 = row2Ref.current;
+    if (!row1 || !row2) return undefined;
+
+    const measure = (): void => {
+      const h1 = row1.getBoundingClientRect().height;
+      const h2 = row2.getBoundingClientRect().height;
+      setRow2Top(h1);
+      setRow3Top(h1 + h2);
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(row1);
+    observer.observe(row2);
+    return () => observer.disconnect();
+  }, [visibleCategories, resolvedTabs]);
+
+  const rows = useMemo<WeightedRow[]>(
+    () =>
+      computeWeightedRows({
+        students,
+        tabs: resolvedTabs,
+        assessments,
+        submissions,
+      }),
+    [students, resolvedTabs, assessments, submissions],
+  );
+
+  const columnPrecisions = useMemo(() => {
+    const tabPrecs = resolvedTabs.map((tab, idx) =>
+      columnPrecision(
+        rows.map((r) =>
+          tabDisplayValue(r.subtotals[idx], tab.gradebookWeight ?? 0),
+        ),
+      ),
+    );
+    return {
+      tabs: tabPrecs,
+      total: columnPrecision(rows.map((r) => totalDisplayValue(r.total))),
+    };
+  }, [rows, resolvedTabs, displayMode, totalWeight]);
+
+  const hasExternalIds = useMemo(
+    () => students.some((s) => s.externalId != null && s.externalId !== ''),
+    [students],
+  );
+
+  const columns = useMemo<ColumnTemplate<WeightedRow>[]>(() => {
+    const cols: ColumnTemplate<WeightedRow>[] = [
+      {
+        id: 'name',
+        title: t(tableTranslations.name),
+        of: 'name',
+        cell: (row) => row.name,
+        csvDownloadable: true,
+        searchable: true,
+      },
+      {
+        id: 'email',
+        title: t(tableTranslations.email),
+        of: 'email',
+        cell: (row) => row.email,
+        csvDownloadable: true,
+        searchable: true,
+        defaultVisible: false,
+      },
+      {
+        id: 'externalId',
+        title: t(tableTranslations.externalId),
+        of: 'externalId',
+        cell: (row) => row.externalId ?? '',
+        csvDownloadable: true,
+        searchable: true,
+        defaultVisible: hasExternalIds,
+      },
+    ];
+
+    resolvedTabs.forEach((tab, idx) => {
+      const weight = tab.gradebookWeight ?? 0;
+      const prec = columnPrecisions.tabs[idx];
+      cols.push({
+        id: `tab-${tab.id}`,
+        title: tab.title,
+        accessorFn: (row) =>
+          fmtCsv(tabDisplayValue(row.subtotals[idx], weight)),
+        cell: (row) =>
+          fmtDisplay(tabDisplayValue(row.subtotals[idx], weight), prec),
+        csvDownloadable: true,
+      });
+    });
+
+    cols.push({
+      id: 'total',
+      title: t(translations.total),
+      accessorFn: (row) => fmtCsv(totalDisplayValue(row.total)),
+      cell: (row) =>
+        fmtDisplay(totalDisplayValue(row.total), columnPrecisions.total),
+      csvDownloadable: true,
+    });
+
+    return cols;
+  }, [
+    resolvedTabs,
+    t,
+    hasExternalIds,
+    columnPrecisions,
+    displayMode,
+    totalWeight,
+  ]);
+
+  const columnPicker = useMemo(
+    () => ({
+      render: (context: ColumnPickerRenderContext) => (
+        <WeightedGradebookColumnTree {...context} />
+      ),
+      locked: ['name'],
+      triggerLabel: t(translations.selectColumns),
+      dialogTitle: t(translations.dialogTitle),
+      storageKey: `gradebook_weighted_columns_${courseId}`,
+    }),
+    [courseId, t],
+  );
+
+  const {
+    toolbar: toolbarProps,
+    body,
+    pagination,
+  } = useTanStackTableBuilder<WeightedRow>({
+    data: rows,
+    columns,
+    getRowId: (row) => row.studentId.toString(),
+    getRowEqualityData: (row) => row,
+    indexing: { rowSelectable: true },
+    pagination: {
+      rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
+      showAllRows: true,
+    },
+    search: { searchPlaceholder: t(translations.searchStudents) },
+    toolbar: { show: true, keepNative: true },
+    csvDownload: {
+      filename: `${courseTitle}_weighted_gradebook`,
+      showDownloadButton: false,
+    },
+    columnPicker,
+  });
+
+  const toolbar = toolbarProps!;
+
+  const selectedCount = body.selectedCount ?? 0;
+  const directExportLabel = useMemo((): string => {
+    const isPartial = selectedCount > 0 && selectedCount < rows.length;
+    if (isPartial) return t(translations.exportRows, { count: selectedCount });
+    return t(translations.exportButton);
+  }, [selectedCount, rows.length, t]);
+
+  const visibility = toolbar.getColumnVisibility?.() ?? {};
+  const showEmail = (visibility.email ?? false) === true;
+  const showExternalId = (visibility.externalId ?? false) === true;
+  let lastIdentityField: 'name' | 'email' | 'externalId' = 'name';
+  if (showExternalId) lastIdentityField = 'externalId';
+  else if (showEmail) lastIdentityField = 'email';
+
+  const allRowsSelected = body.allFilteredSelected ?? false;
+  const someRowsSelected = body.someFilteredSelected ?? false;
+  const toggleAllRows = (): void => body.toggleAllFiltered?.();
+
+  const totalWeightHeaderLabel =
+    displayMode === 'percent'
+      ? t(translations.percentTotalExact)
+      : t(translations.outOfWeight, { weight: totalWeight });
+
+  return (
+    <div data-testid="gradebook-weighted-table">
+      {!allWeightsZero && !showingDefaults && <ProjectedTotalHint />}
+      <div className="px-5">
+        <Paper elevation={0} sx={{ width: 'fit-content', maxWidth: '100%' }}>
+          <div className="flex items-center gap-3 px-2 py-3">
+            <SearchField
+              onChangeKeyword={toolbar.onSearchKeywordChange}
+              placeholder={toolbar.searchPlaceholder}
+              style={{ flex: 1 }}
+              value={toolbar.searchKeyword ?? ''}
+            />
+            <div className="flex items-center gap-3">
+              <SegmentedSwitch
+                ariaLabel={t(translations.displayMode)}
+                onChange={setDisplayMode}
+                options={[
+                  {
+                    value: 'points',
+                    label: t(translations.displayPoints),
+                    tooltip: t(translations.displayPointsTooltip),
+                  },
+                  {
+                    value: 'percent',
+                    label: t(translations.displayPercent),
+                    tooltip: t(translations.displayPercentTooltip),
+                  },
+                ]}
+                value={displayMode}
+              />
+              {canManageWeights && (
+                <Button
+                  onClick={() => setConfigureOpen(true)}
+                  size="small"
+                  variant="outlined"
+                >
+                  {t(translations.configureWeights)}
+                </Button>
+              )}
+              <Button
+                color="primary"
+                onClick={() => setPickerOpen(true)}
+                size="small"
+                variant="outlined"
+              >
+                {t(translations.selectColumns)}
+              </Button>
+              {toolbar.onDirectExport && (
+                <Tooltip
+                  title={
+                    selectedCount === 0 ? t(translations.exportAllTooltip) : ''
+                  }
+                >
+                  <span>
+                    <Button
+                      color="primary"
+                      endIcon={<Download fontSize="small" />}
+                      onClick={toolbar.onDirectExport}
+                      size="small"
+                      variant="contained"
+                    >
+                      {directExportLabel}
+                    </Button>
+                  </span>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+
+          {showingDefaults && (
+            <Alert severity="info" sx={{ mx: 2, mb: 1 }}>
+              {canManageWeights
+                ? t(translations.defaultWeights)
+                : t(translations.defaultWeightsNoAccess)}
+            </Alert>
+          )}
+          {allWeightsZero && !showingDefaults && (
+            <Alert severity="info" sx={{ mx: 2, mb: 1 }}>
+              {canManageWeights
+                ? t(translations.noWeightsConfigured)
+                : t(translations.noWeightsNoAccess)}
+            </Alert>
+          )}
+          <TableContainer
+            sx={(theme) => ({
+              maxHeight: 'calc(100vh - 22rem)',
+              overflowX: 'auto',
+              borderTop: `1px solid ${theme.palette.grey[400]}`,
+              borderLeft: `1px solid ${theme.palette.grey[400]}`,
+              borderRight: `1px solid ${theme.palette.grey[400]}`,
+            })}
+          >
+            <Table
+              size="small"
+              stickyHeader
+              sx={(theme) => {
+                const line = theme.palette.grey[400];
+                const right = `inset -1px 0 0 ${line}`;
+                const bottom = `inset 0 -1px 0 ${line}`;
+                const groupRight = `inset -2px 0 0 ${line}`;
+                return {
+                  tableLayout: 'fixed',
+                  borderCollapse: 'separate',
+                  borderSpacing: 0,
+                  '& th, & td': {
+                    boxSizing: 'border-box',
+                    border: 0,
+                    boxShadow: `${right}, ${bottom}`,
+                    py: 0.25,
+                    px: 1,
+                    lineHeight: 1.2,
+                    height: 32,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  },
+                  '& [data-group-end]': {
+                    boxShadow: `${groupRight}, ${bottom}`,
+                  },
+                };
+              }}
+            >
+              <colgroup>
+                <col style={{ width: CHECKBOX_WIDTH }} />
+                <col style={{ width: nameWidth }} />
+                {showEmail && <col style={{ width: EMAIL_WIDTH }} />}
+                {showExternalId && <col style={{ width: EXTERNAL_ID_WIDTH }} />}
+                {resolvedTabs.map((tab) => (
+                  <col key={tab.id} style={{ width: TAB_WIDTH }} />
+                ))}
+                <col />
+              </colgroup>
+              <TableHead>
+                <TableRow ref={row1Ref}>
+                  <TableCell
+                    rowSpan={3}
+                    sx={{
+                      position: 'sticky',
+                      left: 0,
+                      zIndex: 5,
+                      bgcolor: 'background.default',
+                      width: CHECKBOX_WIDTH,
+                      minWidth: CHECKBOX_WIDTH,
+                      px: 0,
+                      textAlign: 'center',
+                      verticalAlign: 'middle',
+                    }}
+                  >
+                    <Checkbox
+                      checked={allRowsSelected}
+                      indeterminate={someRowsSelected && !allRowsSelected}
+                      onChange={toggleAllRows}
+                      size="small"
+                    />
+                  </TableCell>
+                  <TableCell
+                    rowSpan={3}
+                    {...groupEndIf(lastIdentityField === 'name')}
+                    sx={{
+                      position: 'sticky',
+                      left: CHECKBOX_WIDTH,
+                      zIndex: 4,
+                      bgcolor: 'background.default',
+                      minWidth: 160,
+                      whiteSpace: 'nowrap',
+                      verticalAlign: 'middle',
+                    }}
+                  >
+                    {t(tableTranslations.name)}
+                  </TableCell>
+                  {showEmail && (
+                    <TableCell
+                      rowSpan={3}
+                      {...groupEndIf(lastIdentityField === 'email')}
+                      sx={{ minWidth: 200, verticalAlign: 'middle' }}
+                    >
+                      {t(tableTranslations.email)}
+                    </TableCell>
+                  )}
+                  {showExternalId && (
+                    <TableCell
+                      rowSpan={3}
+                      {...groupEndIf(lastIdentityField === 'externalId')}
+                      sx={{ minWidth: 160, verticalAlign: 'middle' }}
+                    >
+                      {t(tableTranslations.externalId)}
+                    </TableCell>
+                  )}
+                  {visibleCategories.map((cat) => (
+                    <TableCell
+                      key={cat.id}
+                      align="center"
+                      colSpan={categoryTabCounts.get(cat.id) ?? 1}
+                      data-group-end
+                      sx={{ fontWeight: 600 }}
+                    >
+                      {cat.title}
+                    </TableCell>
+                  ))}
+                  <TableCell
+                    align="center"
+                    rowSpan={2}
+                    sx={{
+                      fontWeight: 600,
+                      minWidth: 120,
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 2,
+                      }}
+                    >
+                      {t(translations.total)}
+                      <Tooltip
+                        title={t(projectedTotalPolicyTranslations.policy)}
+                      >
+                        <IconButton
+                          aria-label={t(
+                            projectedTotalPolicyTranslations.policy,
+                          )}
+                          size="small"
+                          sx={{ p: 0 }}
+                        >
+                          <InfoOutlined fontSize="inherit" />
+                        </IconButton>
+                      </Tooltip>
+                    </span>
+                  </TableCell>
+                </TableRow>
+
+                <TableRow
+                  ref={row2Ref}
+                  sx={{
+                    '& .MuiTableCell-stickyHeader': {
+                      top: row2Top,
+                    },
+                  }}
+                >
+                  {resolvedTabs.map((tab, i) => (
+                    <TableCell
+                      key={tab.id}
+                      align="center"
+                      {...groupEndIf(tabIsCategoryEnd[i])}
+                      sx={{ minWidth: 120, whiteSpace: 'nowrap' }}
+                    >
+                      <Tooltip title={tab.title}>
+                        <span>{tab.title}</span>
+                      </Tooltip>
+                    </TableCell>
+                  ))}
+                </TableRow>
+
+                <TableRow
+                  sx={{ '& .MuiTableCell-stickyHeader': { top: row3Top } }}
+                >
+                  {resolvedTabs.map((tab, i) => (
+                    <TableCell
+                      key={tab.id}
+                      align="center"
+                      {...groupEndIf(tabIsCategoryEnd[i])}
+                      sx={{ bgcolor: 'grey.100' }}
+                    >
+                      {tabSubheaderLabel(tab)}
+                    </TableCell>
+                  ))}
+                  <TableCell align="center" sx={{ bgcolor: 'grey.100' }}>
+                    {totalWeight === 100 ? (
+                      totalWeightHeaderLabel
+                    ) : (
+                      <Tooltip title={t(translations.weightsDoNotSum)}>
+                        <Typography
+                          color="warning.main"
+                          component="span"
+                          fontSize="inherit"
+                        >
+                          {displayMode === 'percent'
+                            ? t(translations.percentTotalWarning, {
+                                weight: totalWeight,
+                              })
+                            : t(translations.outOfWeight, {
+                                weight: totalWeight,
+                              })}
+                        </Typography>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+
+              <TableBody>
+                {body.rows.map((row, idx) => {
+                  const rowProps = body.forEachRow(row, idx);
+                  const studentId = row.original.studentId;
+                  const isExpanded = expandedIds.has(studentId);
+                  return (
+                    <Fragment key={rowProps.id}>
+                      <TableRow>
+                        <TableCell
+                          sx={{
+                            position: 'sticky',
+                            left: 0,
+                            zIndex: 1,
+                            bgcolor: 'background.paper',
+                            width: CHECKBOX_WIDTH,
+                            minWidth: CHECKBOX_WIDTH,
+                            px: 0,
+                            textAlign: 'center',
+                          }}
+                        >
+                          <Checkbox
+                            checked={row.getIsSelected()}
+                            onChange={row.getToggleSelectedHandler()}
+                            size="small"
+                          />
+                        </TableCell>
+                        <TableCell
+                          {...groupEndIf(lastIdentityField === 'name')}
+                          sx={{
+                            position: 'sticky',
+                            left: CHECKBOX_WIDTH,
+                            zIndex: 1,
+                            bgcolor: 'background.paper',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          <IconButton
+                            aria-label={t(
+                              isExpanded
+                                ? translations.collapseRow
+                                : translations.expandRow,
+                              { name: row.original.name },
+                            )}
+                            onClick={() => toggleExpanded(studentId)}
+                            size="small"
+                            sx={{
+                              mr: 0.5,
+                              p: 0.25,
+                            }}
+                          >
+                            {isExpanded ? (
+                              <KeyboardArrowDown fontSize="small" />
+                            ) : (
+                              <KeyboardArrowRight fontSize="small" />
+                            )}
+                          </IconButton>
+                          <Tooltip title={row.original.name}>
+                            <span>{row.original.name}</span>
+                          </Tooltip>
+                        </TableCell>
+                        {showEmail && (
+                          <TableCell
+                            {...groupEndIf(lastIdentityField === 'email')}
+                            sx={{ whiteSpace: 'nowrap' }}
+                          >
+                            <Tooltip title={row.original.email}>
+                              <span>{row.original.email}</span>
+                            </Tooltip>
+                          </TableCell>
+                        )}
+                        {showExternalId && (
+                          <TableCell
+                            {...groupEndIf(lastIdentityField === 'externalId')}
+                            sx={{ whiteSpace: 'nowrap' }}
+                          >
+                            <Tooltip title={row.original.externalId ?? ''}>
+                              <span>{row.original.externalId ?? ''}</span>
+                            </Tooltip>
+                          </TableCell>
+                        )}
+                        {row.original.subtotals.map((subtotal, i) => {
+                          const weight = resolvedTabs[i].gradebookWeight ?? 0;
+                          return (
+                            <TableCell
+                              key={resolvedTabs[i].id}
+                              align="right"
+                              {...groupEndIf(tabIsCategoryEnd[i])}
+                            >
+                              {fmtDisplay(
+                                tabDisplayValue(subtotal, weight),
+                                columnPrecisions.tabs[i],
+                              )}
+                            </TableCell>
+                          );
+                        })}
+                        <TableCell align="right">
+                          {fmtDisplay(
+                            totalDisplayValue(row.original.total),
+                            columnPrecisions.total,
+                          )}
+                        </TableCell>
+                      </TableRow>
+                      {isExpanded &&
+                        (breakdownsByStudent.get(studentId) ?? []).flatMap(
+                          (tb, tabIdx) =>
+                            tb.assessments.map((a) => {
+                              const isExcluded = a.excluded;
+                              const weightText = t(
+                                translations.percentOfGrade,
+                                {
+                                  weight:
+                                    Math.round(a.effectiveWeight * 100) / 100,
+                                },
+                              );
+                              const gradeText =
+                                a.grade === null
+                                  ? `-/${a.maxGrade}`
+                                  : `${a.grade}/${a.maxGrade}`;
+                              return (
+                                <TableRow
+                                  key={`bd-${studentId}-${tb.tabId}-${a.assessmentId}`}
+                                  data-testid={`breakdown-row-${studentId}-${tb.tabId}-${a.assessmentId}`}
+                                  sx={{
+                                    bgcolor: 'grey.50',
+                                    opacity: isExcluded ? 0.6 : 1,
+                                  }}
+                                >
+                                  <TableCell
+                                    sx={{
+                                      position: 'sticky',
+                                      left: 0,
+                                      zIndex: 1,
+                                      bgcolor: 'grey.50',
+                                      width: CHECKBOX_WIDTH,
+                                      minWidth: CHECKBOX_WIDTH,
+                                      px: 0,
+                                    }}
+                                  />
+                                  <TableCell
+                                    {...groupEndIf(
+                                      lastIdentityField === 'name',
+                                    )}
+                                    sx={{
+                                      position: 'sticky',
+                                      left: CHECKBOX_WIDTH,
+                                      zIndex: 1,
+                                      bgcolor: 'grey.50',
+                                      '&&': { pl: 4.5, py: 0.75 },
+                                    }}
+                                  >
+                                    <Tooltip title={a.title}>
+                                      <Typography
+                                        color={
+                                          isExcluded
+                                            ? 'text.disabled'
+                                            : undefined
+                                        }
+                                        fontSize="inherit"
+                                        sx={{
+                                          overflow: 'hidden',
+                                          textOverflow: 'ellipsis',
+                                          whiteSpace: 'nowrap',
+                                        }}
+                                      >
+                                        {a.title}
+                                      </Typography>
+                                    </Tooltip>
+                                    <Typography
+                                      color="text.secondary"
+                                      sx={{
+                                        display: 'block',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                      }}
+                                      variant="caption"
+                                    >
+                                      {`${gradeText} · ${isExcluded ? t(translations.excluded) : weightText}`}
+                                    </Typography>
+                                  </TableCell>
+                                  {showEmail && (
+                                    <TableCell
+                                      {...groupEndIf(
+                                        lastIdentityField === 'email',
+                                      )}
+                                    />
+                                  )}
+                                  {showExternalId && (
+                                    <TableCell
+                                      {...groupEndIf(
+                                        lastIdentityField === 'externalId',
+                                      )}
+                                    />
+                                  )}
+                                  {resolvedTabs.map((tab, i) => {
+                                    const tabCellValue = isExcluded
+                                      ? '—'
+                                      : fmtDisplay(
+                                          breakdownDisplayValue(a),
+                                          columnPrecisions.tabs[i],
+                                        );
+                                    return (
+                                      <TableCell
+                                        key={tab.id}
+                                        align="right"
+                                        {...groupEndIf(tabIsCategoryEnd[i])}
+                                      >
+                                        {i === tabIdx ? tabCellValue : ''}
+                                      </TableCell>
+                                    );
+                                  })}
+                                  <TableCell />
+                                </TableRow>
+                              );
+                            }),
+                        )}
+                    </Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          {pagination && <MuiTablePagination {...pagination} />}
+        </Paper>
+      </div>
+
+      {canManageWeights && (
+        <ConfigureWeightsPrompt
+          assessments={assessments}
+          categories={categories}
+          onClose={() => setConfigureOpen(false)}
+          open={configureOpen}
+          tabs={tabs}
+        />
+      )}
+
+      {toolbar.columnPicker && toolbar.commitColumnVisibility && (
+        <MuiColumnPickerPrompt
+          columnPicker={toolbar.columnPicker}
+          commitColumnVisibility={toolbar.commitColumnVisibility}
+          initialVisibility={toolbar.getColumnVisibility?.() ?? {}}
+          locked={toolbar.columnPicker.locked}
+          onClose={() => setPickerOpen(false)}
+          open={pickerOpen}
+        />
+      )}
+    </div>
+  );
+};
+
+export default WeightedGradebookTable;

--- a/client/app/bundles/course/gradebook/components/WeightedViewHint.tsx
+++ b/client/app/bundles/course/gradebook/components/WeightedViewHint.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Alert, Typography } from '@mui/material';
+
+import { getUserEntity } from 'bundles/users/selectors';
+import Link from 'lib/components/core/Link';
+import { useAppSelector } from 'lib/hooks/store';
+import useDismissibleOnce from 'lib/hooks/useDismissibleOnce';
+import useTranslation from 'lib/hooks/useTranslation';
+
+export const WEIGHTED_VIEW_HINT_KEY = 'gradebook_weighted_view_hint';
+
+const translations = defineMessages({
+  hint: {
+    id: 'course.gradebook.WeightedViewHint.hint',
+    defaultMessage:
+      'Want to set how much each item contributes to students’ total grades? Enable Weighted Total view in {link}.',
+  },
+  settingsLink: {
+    id: 'course.gradebook.WeightedViewHint.settingsLink',
+    defaultMessage: 'Gradebook settings',
+  },
+});
+
+interface Props {
+  courseId: number;
+}
+
+/**
+ * One-time, dismissable nudge shown to managers in the (always-visible) gradebook view
+ * when the weighted view is turned off. It advertises the capability and links to the
+ * setting that enables it, since that setting is otherwise buried in course admin.
+ * Dismissal is remembered per user via localStorage (see useDismissibleOnce).
+ */
+const WeightedViewHint: FC<Props> = ({ courseId }) => {
+  const { t } = useTranslation();
+  const userId = useAppSelector(getUserEntity).id;
+  const { dismissed, dismiss } = useDismissibleOnce(
+    WEIGHTED_VIEW_HINT_KEY,
+    userId,
+  );
+
+  if (dismissed) return null;
+
+  return (
+    <div className="px-5 pt-3">
+      <Alert onClose={dismiss} severity="info">
+        <Typography variant="body2">
+          {t(translations.hint, {
+            link: (
+              <Link
+                to={`/courses/${courseId}/admin/gradebook`}
+                underline="hover"
+              >
+                {t(translations.settingsLink)}
+              </Link>
+            ),
+          })}
+        </Typography>
+      </Alert>
+    </div>
+  );
+};
+
+export default WeightedViewHint;

--- a/client/app/bundles/course/gradebook/computeWeighted.ts
+++ b/client/app/bundles/course/gradebook/computeWeighted.ts
@@ -1,0 +1,319 @@
+// client/app/bundles/course/gradebook/computeWeighted.ts
+import {
+  AssessmentData,
+  StudentData,
+  SubmissionData,
+  TabData,
+} from 'types/course/gradebook';
+
+type GradeEntry = Pick<SubmissionData, 'studentId' | 'assessmentId' | 'grade'>;
+
+export interface WeightedRow {
+  studentId: number;
+  name: string;
+  email: string;
+  externalId: string | null;
+  subtotals: (number | null)[];
+  total: number | null;
+}
+
+export interface AssessmentContribution {
+  assessmentId: number;
+  title: string;
+  grade: number | null;
+  maxGrade: number;
+  points: number; // contribution to this tab's weighted-points cell
+  // Share of the overall grade this assessment carries, in percentage points.
+  // Equal mode: the tab's weight split evenly across its assessments.
+  // Custom mode: the assessment's own configured weight.
+  effectiveWeight: number;
+  excluded: boolean;
+}
+
+export interface TabBreakdown {
+  tabId: number;
+  assessments: AssessmentContribution[];
+}
+
+type GradeLookup = Map<string, number>;
+
+const gradeKey = (studentId: number, assessmentId: number): string =>
+  `${studentId}:${assessmentId}`;
+
+// Fraction earned on an assessment. A maxGrade of 0 (e.g. an ungraded 0-point
+// assignment) would make grade/maxGrade an NaN; coerce that to 0 so it never
+// poisons subtotals, totals or the breakdown.
+export const gradeRatio = (grade: number, maxGrade: number): number =>
+  maxGrade === 0 ? 0 : grade / maxGrade;
+
+// Index submissions by (student, assessment) once: O(submissions).
+const buildGradeLookup = (submissions: GradeEntry[]): GradeLookup => {
+  const lookup: GradeLookup = new Map();
+  submissions.forEach((s) => {
+    if (s.grade != null)
+      lookup.set(gradeKey(s.studentId, s.assessmentId), s.grade);
+  });
+  return lookup;
+};
+
+// Group assessments by tab once: O(assessments).
+const buildAssessmentsByTab = (
+  assessments: AssessmentData[],
+): Map<number, AssessmentData[]> => {
+  const byTab = new Map<number, AssessmentData[]>();
+  assessments.forEach((a) => {
+    const list = byTab.get(a.tabId);
+    if (list) list.push(a);
+    else byTab.set(a.tabId, [a]);
+  });
+  return byTab;
+};
+
+// Equal-weight formula: average of (grade/maxGrade) ratios over INCLUDED assessments.
+// Excluded assessments are dropped from both numerator and count; ungraded included
+// contribute 0. Returns null when no assessment is included.
+const equalSubtotal = (
+  studentId: number,
+  tabAssessments: AssessmentData[],
+  gradeLookup: GradeLookup,
+): number | null => {
+  const included = tabAssessments.filter((a) => !a.gradebookExcluded);
+  if (included.length === 0) return null;
+  const ratios = included.map((a) => {
+    const grade = gradeLookup.get(gradeKey(studentId, a.id));
+    return grade != null ? gradeRatio(grade, a.maxGrade) : 0;
+  });
+  return ratios.reduce((acc, r) => acc + r, 0) / ratios.length;
+};
+
+// Custom-weight formula: Σ(grade_i/maxGrade_i × assessmentWeight_i) / tabWeight over
+// INCLUDED assessments. Returns null if tabWeight=0 or no assessment is included;
+// ungraded included assessments contribute 0.
+const customSubtotal = (
+  studentId: number,
+  tab: TabData,
+  tabAssessments: AssessmentData[],
+  gradeLookup: GradeLookup,
+): number | null => {
+  const tabWeight = tab.gradebookWeight ?? 0;
+  if (tabWeight === 0) return null;
+  let numerator = 0;
+  let hasContributing = false;
+  tabAssessments.forEach((a) => {
+    if (a.gradebookExcluded) return;
+    const grade = gradeLookup.get(gradeKey(studentId, a.id));
+    const assessmentWeight = a.gradebookWeight ?? 0;
+    if (grade != null)
+      numerator += gradeRatio(grade, a.maxGrade) * assessmentWeight;
+    hasContributing = true;
+  });
+  return hasContributing ? numerator / tabWeight : null;
+};
+
+// Single source of truth for the subtotal math, operating on prebuilt indexes.
+const subtotalFromLookup = (
+  studentId: number,
+  tab: TabData,
+  tabAssessments: AssessmentData[] | undefined,
+  gradeLookup: GradeLookup,
+): number | null => {
+  if (!tabAssessments || tabAssessments.length === 0) return null;
+  if (tab.weightMode === 'custom') {
+    return customSubtotal(studentId, tab, tabAssessments, gradeLookup);
+  }
+  return equalSubtotal(studentId, tabAssessments, gradeLookup);
+};
+
+// Weighted, additive total from already-computed subtotals.
+const totalFromSubtotals = (
+  subtotals: (number | null)[],
+  tabs: TabData[],
+): number | null => {
+  let contributingCount = 0;
+  let total = 0;
+  subtotals.forEach((sub, i) => {
+    if (sub == null) return;
+    contributingCount += 1;
+    total += (tabs[i].gradebookWeight ?? 0) * sub;
+  });
+  return contributingCount > 0 ? total : null;
+};
+
+interface SubtotalArgs {
+  studentId: number;
+  tab: TabData;
+  assessments: AssessmentData[];
+  submissions: GradeEntry[];
+}
+
+export const computeTabSubtotal = ({
+  studentId,
+  tab,
+  assessments,
+  submissions,
+}: SubtotalArgs): number | null =>
+  subtotalFromLookup(
+    studentId,
+    tab,
+    assessments.filter((a) => a.tabId === tab.id),
+    buildGradeLookup(submissions),
+  );
+
+interface TotalArgs {
+  studentId: number;
+  tabs: TabData[];
+  assessments: AssessmentData[];
+  submissions: GradeEntry[];
+}
+
+export const computeStudentTotal = ({
+  studentId,
+  tabs,
+  assessments,
+  submissions,
+}: TotalArgs): number | null => {
+  const gradeLookup = buildGradeLookup(submissions);
+  const assessmentsByTab = buildAssessmentsByTab(assessments);
+  const subtotals = tabs.map((tab) =>
+    subtotalFromLookup(
+      studentId,
+      tab,
+      assessmentsByTab.get(tab.id),
+      gradeLookup,
+    ),
+  );
+  return totalFromSubtotals(subtotals, tabs);
+};
+
+export const computeStudentBreakdown = ({
+  studentId,
+  tabs,
+  assessments,
+  submissions,
+}: TotalArgs): TabBreakdown[] => {
+  const gradeLookup = buildGradeLookup(submissions);
+  const assessmentsByTab = buildAssessmentsByTab(assessments);
+  return tabs.map((tab) => {
+    const list = assessmentsByTab.get(tab.id) ?? [];
+    const weight = tab.gradebookWeight ?? 0;
+    const includedCount = list.filter((a) => !a.gradebookExcluded).length;
+
+    const contributions = list.map((a) => {
+      const excluded = !!a.gradebookExcluded;
+      const grade = gradeLookup.get(gradeKey(studentId, a.id)) ?? null;
+      const ratio = grade != null ? gradeRatio(grade, a.maxGrade) : 0;
+      let points: number;
+      let effectiveWeight: number;
+      if (excluded) {
+        points = 0;
+        effectiveWeight = 0;
+      } else if (tab.weightMode === 'custom') {
+        points = ratio * (a.gradebookWeight ?? 0);
+        effectiveWeight = a.gradebookWeight ?? 0;
+      } else {
+        points = includedCount > 0 ? (ratio / includedCount) * weight : 0;
+        effectiveWeight = includedCount > 0 ? weight / includedCount : 0;
+      }
+      return {
+        assessmentId: a.id,
+        title: a.title,
+        grade,
+        maxGrade: a.maxGrade,
+        points,
+        effectiveWeight,
+        excluded,
+      };
+    });
+    return { tabId: tab.id, assessments: contributions };
+  });
+};
+
+interface WeightedRowsArgs {
+  students: StudentData[];
+  tabs: TabData[];
+  assessments: AssessmentData[];
+  submissions: GradeEntry[];
+}
+
+// Batch entry point used by the table: builds the indexes ONCE and reuses them
+// across every student, computing each subtotal a single time.
+export const computeWeightedRows = ({
+  students,
+  tabs,
+  assessments,
+  submissions,
+}: WeightedRowsArgs): WeightedRow[] => {
+  const gradeLookup = buildGradeLookup(submissions);
+  const assessmentsByTab = buildAssessmentsByTab(assessments);
+  return students.map((student) => {
+    const subtotals = tabs.map((tab) =>
+      subtotalFromLookup(
+        student.id,
+        tab,
+        assessmentsByTab.get(tab.id),
+        gradeLookup,
+      ),
+    );
+    return {
+      studentId: student.id,
+      name: student.name,
+      email: student.email,
+      externalId: student.externalId,
+      subtotals,
+      total: totalFromSubtotals(subtotals, tabs),
+    };
+  });
+};
+
+export const sumWeights = (tabs: TabData[]): number =>
+  tabs.reduce((acc, t) => acc + (t.gradebookWeight ?? 0), 0);
+
+const r2 = (n: number): number => Math.round(n * 100) / 100;
+
+// Ids of tabs that have at least one assessment — only these are eligible for a
+// default weight (an empty tab carries no grades, so weighting it is wasted).
+const nonEmptyTabIds = (
+  tabs: TabData[],
+  assessments: Pick<AssessmentData, 'tabId'>[],
+): number[] => {
+  const populated = new Set(assessments.map((a) => a.tabId));
+  return tabs.filter((t) => populated.has(t.id)).map((t) => t.id);
+};
+
+// True when no tab weight has been configured (every weight is 0/null) yet there
+// is at least one tab to weight — i.e. the table is showing the equal-split
+// default rather than an instructor's configuration. Drives the "default weights"
+// banner and dialog pre-fill so both read from one source of truth.
+export const usingDefaultWeights = (
+  tabs: TabData[],
+  assessments: Pick<AssessmentData, 'tabId'>[],
+): boolean =>
+  sumWeights(tabs) === 0 && nonEmptyTabIds(tabs, assessments).length > 0;
+
+// When no weights are configured, distribute 100 equally across non-empty tabs so
+// the weighted view is meaningful out of the box; the last such tab absorbs the
+// rounding remainder so the result sums to exactly 100. Returns the input array
+// unchanged (same reference) once any tab carries a weight, so a real configuration
+// is never overwritten.
+export const resolveTabWeights = (
+  tabs: TabData[],
+  assessments: Pick<AssessmentData, 'tabId'>[],
+): TabData[] => {
+  if (sumWeights(tabs) !== 0) return tabs;
+  const ids = nonEmptyTabIds(tabs, assessments);
+  const n = ids.length;
+  if (n === 0) return tabs;
+  const base = r2(100 / n);
+  const weightById = new Map<number, number>(
+    ids.map((id, i) => [id, i === n - 1 ? r2(100 - base * (n - 1)) : base]),
+  );
+  return tabs.map((tab) =>
+    weightById.has(tab.id)
+      ? {
+          ...tab,
+          gradebookWeight: weightById.get(tab.id),
+          weightMode: tab.weightMode ?? 'equal',
+        }
+      : tab,
+  );
+};

--- a/client/app/bundles/course/gradebook/operations.ts
+++ b/client/app/bundles/course/gradebook/operations.ts
@@ -1,4 +1,5 @@
 import type { Operation } from 'store';
+import type { UpdateWeightsPayload } from 'types/course/gradebook';
 
 import CourseAPI from 'api/course';
 
@@ -8,5 +9,12 @@ const fetchGradebook = (): Operation => async (dispatch) => {
   const response = await CourseAPI.gradebook.index();
   dispatch(actions.saveGradebook(response.data));
 };
+
+export const updateGradebookWeights =
+  (weights: UpdateWeightsPayload['weights']): Operation =>
+  async (dispatch) => {
+    const response = await CourseAPI.gradebook.updateWeights({ weights });
+    dispatch(actions.updateTabWeights(response.data));
+  };
 
 export default fetchGradebook;

--- a/client/app/bundles/course/gradebook/pages/GradebookIndex/index.tsx
+++ b/client/app/bundles/course/gradebook/pages/GradebookIndex/index.tsx
@@ -1,8 +1,8 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState, useTransition } from 'react';
 import { defineMessages } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { PeopleAlt } from '@mui/icons-material';
-import { Typography } from '@mui/material';
+import { Tab, Tabs, Typography } from '@mui/material';
 
 import Page from 'lib/components/core/layouts/Page';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
@@ -13,14 +13,18 @@ import useTranslation from 'lib/hooks/useTranslation';
 import { useCourseContext } from '../../../container/CourseLoader';
 import GradebookTable from '../../components/GradebookTable';
 import GradeLinkHint from '../../components/GradeLinkHint';
+import WeightedGradebookTable from '../../components/WeightedGradebookTable';
+import WeightedViewHint from '../../components/WeightedViewHint';
 import fetchGradebook from '../../operations';
 import {
   getAssessments,
+  getCanManageWeights,
   getCategories,
   getGamificationEnabled,
   getStudents,
   getSubmissions,
   getTabs,
+  getWeightedViewEnabled,
 } from '../../selectors';
 
 const translations = defineMessages({
@@ -40,6 +44,14 @@ const translations = defineMessages({
     id: 'course.gradebook.GradebookIndex.noStudentsHint',
     defaultMessage: 'Grades will appear here once students join the course.',
   },
+  allAssessments: {
+    id: 'course.gradebook.GradebookIndex.allAssessments',
+    defaultMessage: 'All Assessments',
+  },
+  byWeight: {
+    id: 'course.gradebook.GradebookIndex.byWeight',
+    defaultMessage: 'Weighted Total',
+  },
 });
 
 const GradebookIndex: FC = () => {
@@ -48,7 +60,12 @@ const GradebookIndex: FC = () => {
   const { courseTitle } = useCourseContext();
   const { courseId: courseIdParam } = useParams();
   const courseId = parseInt(courseIdParam!, 10);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [isLoading, setIsLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<'all' | 'weighted'>(
+    searchParams.get('view') === 'weighted' ? 'weighted' : 'all',
+  );
+  const [isPending, startTransition] = useTransition();
 
   const assessments = useAppSelector(getAssessments);
   const categories = useAppSelector(getCategories);
@@ -56,6 +73,8 @@ const GradebookIndex: FC = () => {
   const students = useAppSelector(getStudents);
   const submissions = useAppSelector(getSubmissions);
   const gamificationEnabled = useAppSelector(getGamificationEnabled);
+  const weightedViewEnabled = useAppSelector(getWeightedViewEnabled);
+  const canManageWeights = useAppSelector(getCanManageWeights);
 
   useEffect(() => {
     dispatch(fetchGradebook())
@@ -78,27 +97,74 @@ const GradebookIndex: FC = () => {
         </Typography>
       </div>
     );
+  } else if (weightedViewEnabled && viewMode === 'weighted') {
+    content = (
+      <WeightedGradebookTable
+        assessments={assessments}
+        canManageWeights={canManageWeights}
+        categories={categories}
+        courseId={courseId}
+        courseTitle={courseTitle}
+        students={students}
+        submissions={submissions}
+        tabs={tabs}
+      />
+    );
   } else {
     content = (
-      <>
-        <GradeLinkHint />
-        <GradebookTable
-          assessments={assessments}
-          categories={categories}
-          courseId={courseId}
-          courseTitle={courseTitle}
-          gamificationEnabled={gamificationEnabled}
-          students={students}
-          submissions={submissions}
-          tabs={tabs}
-        />
-      </>
+      <GradebookTable
+        assessments={assessments}
+        categories={categories}
+        courseId={courseId}
+        courseTitle={courseTitle}
+        gamificationEnabled={gamificationEnabled}
+        students={students}
+        submissions={submissions}
+        tabs={tabs}
+      />
     );
   }
 
   return (
     <Page title={t(translations.gradebook)} unpadded>
-      {content}
+      {!isLoading && canManageWeights && !weightedViewEnabled && (
+        <WeightedViewHint courseId={courseId} />
+      )}
+      {weightedViewEnabled && !isLoading && students.length > 0 && (
+        <Tabs
+          className="border-only-b-neutral-200"
+          onChange={(_, v: 'all' | 'weighted') =>
+            startTransition(() => {
+              setViewMode(v);
+              setSearchParams(v === 'weighted' ? { view: 'weighted' } : {});
+            })
+          }
+          TabIndicatorProps={{ style: { height: 2 } }}
+          value={viewMode}
+        >
+          <Tab label={t(translations.allAssessments)} value="all" />
+          <Tab label={t(translations.byWeight)} value="weighted" />
+        </Tabs>
+      )}
+      {!isLoading &&
+        students.length > 0 &&
+        !(weightedViewEnabled && viewMode === 'weighted') && <GradeLinkHint />}
+      <div className="relative">
+        {isPending && (
+          <div className="pointer-events-none absolute inset-x-0 top-4 z-10 flex justify-center">
+            <LoadingIndicator.Delayed bare delayedForMS={150} size={32} />
+          </div>
+        )}
+        <div
+          className={
+            isPending
+              ? 'pointer-events-none opacity-50 transition-opacity'
+              : 'transition-opacity'
+          }
+        >
+          {content}
+        </div>
+      </div>
     </Page>
   );
 };

--- a/client/app/bundles/course/gradebook/selectors.ts
+++ b/client/app/bundles/course/gradebook/selectors.ts
@@ -22,3 +22,7 @@ export const getGamificationEnabled = (
   state: AppState,
 ): GradebookState['gamificationEnabled'] =>
   getLocalState(state).gamificationEnabled;
+export const getWeightedViewEnabled = (state: AppState): boolean =>
+  getLocalState(state).weightedViewEnabled;
+export const getCanManageWeights = (state: AppState): boolean =>
+  getLocalState(state).canManageWeights;

--- a/client/app/bundles/course/gradebook/store.ts
+++ b/client/app/bundles/course/gradebook/store.ts
@@ -1,5 +1,8 @@
 import { produce } from 'immer';
-import type { GradebookData } from 'types/course/gradebook';
+import type {
+  GradebookData,
+  UpdateWeightsPayload,
+} from 'types/course/gradebook';
 
 import type {
   AssessmentData,
@@ -10,6 +13,7 @@ import type {
 } from './types';
 
 const SAVE_GRADEBOOK = 'course/gradebook/SAVE_GRADEBOOK';
+const UPDATE_TAB_WEIGHTS = 'course/gradebook/UPDATE_TAB_WEIGHTS';
 
 interface GradebookState {
   categories: CategoryData[];
@@ -18,11 +22,18 @@ interface GradebookState {
   students: StudentData[];
   submissions: SubmissionData[];
   gamificationEnabled: boolean;
+  weightedViewEnabled: boolean;
+  canManageWeights: boolean;
 }
 
 interface SaveGradebookAction {
   type: typeof SAVE_GRADEBOOK;
   payload: GradebookData;
+}
+
+interface UpdateTabWeightsAction {
+  type: typeof UPDATE_TAB_WEIGHTS;
+  payload: UpdateWeightsPayload;
 }
 
 const initialState: GradebookState = {
@@ -32,10 +43,15 @@ const initialState: GradebookState = {
   students: [],
   submissions: [],
   gamificationEnabled: false,
+  weightedViewEnabled: false,
+  canManageWeights: false,
 };
 
 const reducer = produce(
-  (draft: GradebookState, action: SaveGradebookAction) => {
+  (
+    draft: GradebookState,
+    action: SaveGradebookAction | UpdateTabWeightsAction,
+  ) => {
     switch (action.type) {
       case SAVE_GRADEBOOK: {
         draft.categories = action.payload.categories;
@@ -44,6 +60,43 @@ const reducer = produce(
         draft.students = action.payload.students;
         draft.submissions = action.payload.submissions;
         draft.gamificationEnabled = action.payload.gamificationEnabled;
+        draft.weightedViewEnabled = action.payload.weightedViewEnabled;
+        draft.canManageWeights = action.payload.canManageWeights;
+        break;
+      }
+      case UPDATE_TAB_WEIGHTS: {
+        action.payload.weights.forEach(
+          ({
+            tabId,
+            weight,
+            weightMode,
+            assessmentWeights,
+            excludedAssessmentIds,
+          }) => {
+            const tab = draft.tabs.find((t) => t.id === tabId);
+            if (tab) {
+              tab.gradebookWeight = weight;
+              tab.weightMode = weightMode;
+            }
+            const excludedSet = new Set(excludedAssessmentIds ?? []);
+            const tabAssessments = draft.assessments.filter(
+              (a) => a.tabId === tabId,
+            );
+            tabAssessments.forEach((a) => {
+              a.gradebookExcluded = excludedSet.has(a.id);
+            });
+            if (weightMode === 'equal') {
+              tabAssessments.forEach((a) => {
+                a.gradebookWeight = null;
+              });
+            } else if (assessmentWeights) {
+              assessmentWeights.forEach(({ assessmentId, weight: aw }) => {
+                const a = draft.assessments.find((x) => x.id === assessmentId);
+                if (a) a.gradebookWeight = aw;
+              });
+            }
+          },
+        );
         break;
       }
       default:
@@ -57,6 +110,12 @@ export const actions = {
   saveGradebook: (data: GradebookData): SaveGradebookAction => ({
     type: SAVE_GRADEBOOK,
     payload: data,
+  }),
+  updateTabWeights: (
+    payload: UpdateWeightsPayload,
+  ): UpdateTabWeightsAction => ({
+    type: UPDATE_TAB_WEIGHTS,
+    payload,
   }),
 };
 

--- a/client/app/bundles/course/gradebook/types.ts
+++ b/client/app/bundles/course/gradebook/types.ts
@@ -5,4 +5,5 @@ export type {
   StudentData,
   SubmissionData,
   TabData,
+  UpdateWeightsPayload,
 } from 'types/course/gradebook';

--- a/client/app/lib/components/core/buttons/SegmentedSwitch.tsx
+++ b/client/app/lib/components/core/buttons/SegmentedSwitch.tsx
@@ -1,0 +1,222 @@
+import {
+  KeyboardEvent,
+  ReactNode,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Box, ButtonBase, Tooltip } from '@mui/material';
+
+export interface SegmentedSwitchOption<T> {
+  value: T;
+  /** Visible content. Keep it short — one word reads best in this control. */
+  label: ReactNode;
+  /** Optional hint shown on hover/focus of the segment. */
+  tooltip?: ReactNode;
+  /**
+   * Accessible name for the segment. Falls back to `label` when that is a
+   * plain string; supply this when `label` is an icon or other non-text node.
+   */
+  ariaLabel?: string;
+}
+
+interface SegmentedSwitchProps<T> {
+  /** The currently selected option's value. */
+  value: T;
+  /** The options, left to right. Designed for 2 but renders any count. */
+  options: SegmentedSwitchOption<T>[];
+  /** Fired with the next value when a different segment is chosen. */
+  onChange: (value: T) => void;
+  /** Accessible name for the whole control (the radiogroup). */
+  ariaLabel: string;
+  disabled?: boolean;
+  /**
+   * Pass `self-stretch` to grow the switch to a taller row neighbour (e.g. a
+   * small `TextField`), so the two align without hardcoding a height.
+   */
+  className?: string;
+}
+
+// Sized to MUI `size="small"` controls: 13px text, ~30.75px tall. Pixels are
+// resolved through the theme's `pxToRem` so the switch matches its siblings
+// regardless of the app's `htmlFontSize` (Coursemology uses 10, so a hardcoded
+// rem would render ~38% too small). `MIN_HEIGHT` is a floor — `self-stretch`
+// lets the switch grow to match a taller neighbour in the same flex row.
+const FONT_PX = 13;
+const PADDING_X = 1.5;
+const MIN_HEIGHT = 30.75;
+
+/**
+ * A compact, peer-state mode switcher: a pill track with the options side by
+ * side and a single elevated thumb that slides to the active one.
+ *
+ * Unlike a `Switch`, neither option reads as "off" — both are equally valid —
+ * and unlike `ToggleButtonGroup` it stays content-width, so it fits a packed
+ * toolbar or a dense prompt row. Use it when a binary choice has no default
+ * "on" state (e.g. Points vs. Percentage, Equal vs. Custom).
+ */
+const SegmentedSwitch = <T extends string | number>(
+  props: SegmentedSwitchProps<T>,
+): JSX.Element => {
+  const { value, options, onChange, ariaLabel, disabled, className } = props;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [thumb, setThumb] = useState<{ left: number; width: number }>({
+    left: 0,
+    width: 0,
+  });
+
+  const activeIndex = Math.max(
+    0,
+    options.findIndex((o) => o.value === value),
+  );
+
+  useLayoutEffect(() => {
+    const measure = (): void => {
+      const el = optionRefs.current[activeIndex];
+      const container = containerRef.current;
+      if (!el || !container) return;
+      setThumb({
+        left: el.offsetLeft - container.clientLeft,
+        width: el.offsetWidth,
+      });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [activeIndex, options.length]);
+
+  const select = (index: number): void => {
+    const next = options[index];
+    if (next && next.value !== value) onChange(next.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (disabled) return;
+    const last = options.length - 1;
+    let next = activeIndex;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      next = activeIndex === last ? 0 : activeIndex + 1;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      next = activeIndex === 0 ? last : activeIndex - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    select(next);
+    optionRefs.current[next]?.focus();
+  };
+
+  return (
+    <Box
+      ref={containerRef}
+      aria-label={ariaLabel}
+      className={className}
+      onKeyDown={handleKeyDown}
+      role="radiogroup"
+      sx={(theme) => ({
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'stretch',
+        minHeight: MIN_HEIGHT,
+        boxSizing: 'border-box',
+        p: '3px',
+        borderRadius: 999,
+        bgcolor: theme.palette.action.hover,
+        border: `1px solid ${theme.palette.divider}`,
+        opacity: disabled ? 0.5 : 1,
+        pointerEvents: disabled ? 'none' : 'auto',
+      })}
+    >
+      <Box
+        aria-hidden
+        sx={(theme) => ({
+          position: 'absolute',
+          top: '3px',
+          bottom: '3px',
+          left: 0,
+          width: thumb.width,
+          borderRadius: 999,
+          bgcolor: theme.palette.background.paper,
+          boxShadow: theme.shadows[1],
+          opacity: thumb.width === 0 ? 0 : 1,
+          transform: `translateX(${thumb.left}px)`,
+          transition: theme.transitions.create(['transform', 'width'], {
+            duration: 260,
+            easing: 'cubic-bezier(0.34, 1.36, 0.64, 1)',
+          }),
+          zIndex: 0,
+        })}
+      />
+      {options.map((option, index) => {
+        const selected = index === activeIndex;
+        const label =
+          option.ariaLabel ??
+          (typeof option.label === 'string' ? option.label : undefined);
+        const segment = (
+          <ButtonBase
+            ref={(el) => {
+              optionRefs.current[index] = el;
+            }}
+            aria-checked={selected}
+            aria-label={label}
+            disabled={disabled}
+            disableRipple
+            onClick={() => select(index)}
+            role="radio"
+            sx={(theme) => ({
+              position: 'relative',
+              zIndex: 1,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontFamily: 'inherit',
+              fontSize: theme.typography.pxToRem(FONT_PX),
+              height: '100%',
+              fontWeight: selected ? 650 : 550,
+              letterSpacing: '0.01em',
+              color: selected
+                ? theme.palette.text.primary
+                : theme.palette.text.secondary,
+              px: PADDING_X,
+              py: 0,
+              borderRadius: 999,
+              whiteSpace: 'nowrap',
+              transition: theme.transitions.create('color', { duration: 180 }),
+              '&:hover': { color: theme.palette.text.primary },
+              '&:focus-visible': {
+                outline: `2px solid ${theme.palette.primary.main}`,
+                outlineOffset: 2,
+              },
+            })}
+            tabIndex={selected ? 0 : -1}
+          >
+            {option.label}
+          </ButtonBase>
+        );
+
+        return option.tooltip ? (
+          <Tooltip
+            key={String(option.value)}
+            placement="bottom"
+            title={option.tooltip}
+          >
+            {segment}
+          </Tooltip>
+        ) : (
+          <Box
+            key={String(option.value)}
+            component="span"
+            sx={{ display: 'inline-flex' }}
+          >
+            {segment}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default SegmentedSwitch;

--- a/client/app/lib/components/core/buttons/__test__/SegmentedSwitch.test.tsx
+++ b/client/app/lib/components/core/buttons/__test__/SegmentedSwitch.test.tsx
@@ -1,0 +1,131 @@
+import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen, within } from 'test-utils';
+
+import SegmentedSwitch from '../SegmentedSwitch';
+
+// Render synchronously without the real provider's locale-loading spinner
+// (uses the manual mock at lib/components/wrappers/__mocks__/I18nProvider).
+jest.mock('lib/components/wrappers/I18nProvider');
+
+const OPTIONS = [
+  { value: 'points', label: 'Points' },
+  { value: 'percent', label: 'Percentage' },
+] as const;
+
+const setup = (
+  value: 'points' | 'percent',
+  overrides: Partial<
+    Parameters<typeof SegmentedSwitch<'points' | 'percent'>>[0]
+  > = {},
+): { onChange: jest.Mock } => {
+  const onChange = jest.fn();
+  render(
+    <SegmentedSwitch
+      ariaLabel="Display mode"
+      onChange={onChange}
+      options={[...OPTIONS]}
+      value={value}
+      {...overrides}
+    />,
+  );
+  return { onChange };
+};
+
+describe('<SegmentedSwitch />', () => {
+  it('renders a radiogroup with one radio per option, named by ariaLabel', () => {
+    setup('points');
+    const group = screen.getByRole('radiogroup', { name: 'Display mode' });
+    expect(within(group).getAllByRole('radio')).toHaveLength(2);
+    expect(screen.getByRole('radio', { name: 'Points' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: 'Percentage' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks only the selected option aria-checked', () => {
+    setup('percent');
+    expect(screen.getByRole('radio', { name: 'Points' })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+    expect(screen.getByRole('radio', { name: 'Percentage' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('keeps a single tab stop via roving tabindex', () => {
+    setup('points');
+    expect(screen.getByRole('radio', { name: 'Points' })).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
+    expect(screen.getByRole('radio', { name: 'Percentage' })).toHaveAttribute(
+      'tabindex',
+      '-1',
+    );
+  });
+
+  it('falls back to selecting the first option when value matches none', () => {
+    setup('points', { value: 'nonexistent' as 'points' | 'percent' });
+    expect(screen.getByRole('radio', { name: 'Points' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('radio', { name: 'Percentage' })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('fires onChange with the chosen value when an inactive option is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup('points');
+    await user.click(screen.getByRole('radio', { name: 'Percentage' }));
+    expect(onChange).toHaveBeenCalledWith('percent');
+  });
+
+  it('does not fire onChange when the already-active option is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup('points');
+    await user.click(screen.getByRole('radio', { name: 'Points' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows a tooltip on hover for an option that supplies one', async () => {
+    const user = userEvent.setup();
+    setup('points', {
+      options: [
+        { value: 'points', label: 'Points', tooltip: 'Raw points earned' },
+        { value: 'percent', label: 'Percentage' },
+      ],
+    });
+    await user.hover(screen.getByRole('radio', { name: 'Points' }));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Raw points earned',
+    );
+  });
+
+  it('uses an explicit option ariaLabel as the radio accessible name', () => {
+    setup('points', {
+      options: [
+        { value: 'points', label: 'Points', ariaLabel: 'Show as points' },
+        { value: 'percent', label: 'Percentage' },
+      ],
+    });
+    expect(
+      screen.getByRole('radio', { name: 'Show as points' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('radio', { name: 'Points' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables every option and suppresses onChange when disabled', () => {
+    const { onChange } = setup('points', { disabled: true });
+    const percent = screen.getByRole('radio', { name: 'Percentage' });
+    expect(percent).toBeDisabled();
+    fireEvent.click(percent);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/lib/components/wrappers/__mocks__/I18nProvider.tsx
+++ b/client/app/lib/components/wrappers/__mocks__/I18nProvider.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+
+// Manual mock for lib/components/wrappers/I18nProvider. The real provider renders
+// a LoadingIndicator while it async-loads locale messages, so suites that assert
+// synchronously would only ever see the spinner. Activate this synchronous
+// stand-in per-suite with `jest.mock('lib/components/wrappers/I18nProvider')`.
+// It is NOT applied automatically — only when a test opts in — so suites relying
+// on the real provider's loading transition are unaffected.
+const I18nProvider = ({ children }: { children: ReactNode }): JSX.Element => (
+  <IntlProvider defaultLocale="en" locale="en" messages={{}}>
+    {children}
+  </IntlProvider>
+);
+
+export default I18nProvider;

--- a/client/app/routers/course/admin.tsx
+++ b/client/app/routers/course/admin.tsx
@@ -120,6 +120,17 @@ const adminRouter: Translated<RouteObject> = (_) => ({
       }),
     },
     {
+      path: 'gradebook',
+      lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
+        Component: (
+          await import(
+            /* webpackChunkName: 'GradebookSettings' */
+            'course/admin/pages/GradebookSettings'
+          )
+        ).default,
+      }),
+    },
+    {
       path: 'comments',
       lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
         Component: (

--- a/client/app/types/course/admin/gradebook.ts
+++ b/client/app/types/course/admin/gradebook.ts
@@ -1,0 +1,9 @@
+export interface GradebookSettingsData {
+  weightedViewEnabled: boolean;
+}
+
+export interface GradebookSettingsPostData {
+  settings_gradebook_component: {
+    weighted_view_enabled: GradebookSettingsData['weightedViewEnabled'];
+  };
+}

--- a/client/app/types/course/gradebook.ts
+++ b/client/app/types/course/gradebook.ts
@@ -7,6 +7,8 @@ export interface TabData {
   id: number;
   title: string;
   categoryId: number;
+  gradebookWeight?: number;
+  weightMode?: 'equal' | 'custom';
 }
 
 export interface AssessmentData {
@@ -14,6 +16,8 @@ export interface AssessmentData {
   title: string;
   tabId: number;
   maxGrade: number;
+  gradebookWeight?: number | null;
+  gradebookExcluded?: boolean;
 }
 
 export interface StudentData {
@@ -39,4 +43,16 @@ export interface GradebookData {
   students: StudentData[];
   submissions: SubmissionData[];
   gamificationEnabled: boolean;
+  weightedViewEnabled: boolean;
+  canManageWeights: boolean;
+}
+
+export interface UpdateWeightsPayload {
+  weights: {
+    tabId: number;
+    weight: number;
+    weightMode?: 'equal' | 'custom';
+    excludedAssessmentIds?: number[];
+    assessmentWeights?: { assessmentId: number; weight: number }[];
+  }[];
 }

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -9268,5 +9268,164 @@
   },
   "lib.translations.table.column.newExternalId": {
     "defaultMessage": "New External ID"
+  },
+  "course.admin.GradebookSettings.gradebookSettings": {
+    "defaultMessage": "Gradebook settings"
+  },
+  "course.admin.GradebookSettings.weightedViewEnabled": {
+    "defaultMessage": "Enable Weighted Total view"
+  },
+  "course.admin.GradebookSettings.weightedViewEnabledHint": {
+    "defaultMessage": "Enables a \"Weighted Total\" view in the gradebook where staff can configure per-tab weights and see a weighted total column."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.allExcluded": {
+    "defaultMessage": "All assessments in \"{tab}\" are excluded - it contributes nothing to the total."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.allExcludedCount": {
+    "defaultMessage": "All {n} excluded"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.customMode": {
+    "defaultMessage": "Custom"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.customSum": {
+    "defaultMessage": "Assessment weights: {sum} / {total}"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.defaultsHint": {
+    "defaultMessage": "No weights set yet - these are suggested defaults with every tab counting equally. Save to confirm, or adjust below."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionDrop": {
+    "defaultMessage": "In Equal mode, optionally drop each student's N lowest-scoring assessments before averaging."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionExclusion": {
+    "defaultMessage": "Expand a tab to include or exclude individual assessments from grading."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionIntro": {
+    "defaultMessage": "Control how tabs and assessments count toward each student's total grade."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionModes": {
+    "defaultMessage": "Choose Equal (all assessments share the tab's weight) or Custom (set each assessment's share)."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionWeights": {
+    "defaultMessage": "Set each tab's weight - how much it contributes to the total (weights should sum to 100)."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.equalMode": {
+    "defaultMessage": "Equal"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.excluded": {
+    "defaultMessage": "Excluded"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.excludedCount": {
+    "defaultMessage": "{n} excluded"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.includeAssessment": {
+    "defaultMessage": "Include {assessment} in grade"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.modeAria": {
+    "defaultMessage": "{tab} weight mode"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.ofGrade": {
+    "defaultMessage": "{pct}% of grade"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.promptTitle": {
+    "defaultMessage": "Configure contributions"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.saveError": {
+    "defaultMessage": "Failed to save weights. Please try again."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.total": {
+    "defaultMessage": "Total: {sum}%"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.unbalanced": {
+    "defaultMessage": "Assessment weights for \"{tab}\" must sum to its tab total before saving."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.valueTooHigh": {
+    "defaultMessage": "Value must be at most 100"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.valueTooLow": {
+    "defaultMessage": "Value must be at least 0"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.weightsDoNotSum": {
+    "defaultMessage": "Weights do not sum to 100. Saving is allowed; Total may be inaccurate."
+  },
+  "course.gradebook.GradebookIndex.allAssessments": {
+    "defaultMessage": "All Assessments"
+  },
+  "course.gradebook.GradebookIndex.byWeight": {
+    "defaultMessage": "Weighted Total"
+  },
+  "course.gradebook.WeightedGradebookTable.collapseRow": {
+    "defaultMessage": "Collapse {name}"
+  },
+  "course.gradebook.WeightedGradebookTable.configureWeights": {
+    "defaultMessage": "Configure Weights"
+  },
+  "course.gradebook.WeightedGradebookTable.defaultWeights": {
+    "defaultMessage": "Showing default weights - every tab counts equally. Click \"Configure Weights\" to set your own."
+  },
+  "course.gradebook.WeightedGradebookTable.defaultWeightsNoAccess": {
+    "defaultMessage": "Showing default weights - every tab counts equally until weights are configured."
+  },
+  "course.gradebook.WeightedGradebookTable.displayPercent": {
+    "defaultMessage": "Percentage"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPercentTooltip": {
+    "defaultMessage": "What fraction of each tab the student earned. 100% on a tab worth 20% = the student earned all 20 grade points from that tab."
+  },
+  "course.gradebook.WeightedGradebookTable.displayPoints": {
+    "defaultMessage": "Points"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPointsTooltip": {
+    "defaultMessage": "How many grade points each tab contributes. Columns add up to the projected total."
+  },
+  "course.gradebook.WeightedGradebookTable.downloadCsv": {
+    "defaultMessage": "Download as CSV"
+  },
+  "course.gradebook.WeightedGradebookTable.email": {
+    "defaultMessage": "Email"
+  },
+  "course.gradebook.WeightedGradebookTable.excluded": {
+    "defaultMessage": "Excluded"
+  },
+  "course.gradebook.WeightedGradebookTable.expandRow": {
+    "defaultMessage": "Expand {name}"
+  },
+  "course.gradebook.WeightedGradebookTable.name": {
+    "defaultMessage": "Name"
+  },
+  "course.gradebook.WeightedGradebookTable.noWeightsConfigured": {
+    "defaultMessage": "No weights configured - all tab weights are 0. Click \"Configure Weights\" to assign weights."
+  },
+  "course.gradebook.WeightedGradebookTable.noWeightsNoAccess": {
+    "defaultMessage": "No tab weights have been configured yet."
+  },
+  "course.gradebook.WeightedGradebookTable.outOfWeight": {
+    "defaultMessage": "/{weight}"
+  },
+  "course.gradebook.WeightedGradebookTable.percentOfGrade": {
+    "defaultMessage": "{weight}% of grade"
+  },
+  "course.gradebook.WeightedGradebookTable.percentTotalExact": {
+    "defaultMessage": "100% total"
+  },
+  "course.gradebook.WeightedGradebookTable.percentTotalWarning": {
+    "defaultMessage": "{weight}% total"
+  },
+  "course.gradebook.WeightedGradebookTable.weightedTotal": {
+    "defaultMessage": "Weighted Total"
+  },
+  "course.gradebook.WeightedGradebookTable.searchStudents": {
+    "defaultMessage": "Search students"
+  },
+  "course.gradebook.WeightedGradebookTable.weightsDoNotSum": {
+    "defaultMessage": "Weights do not sum to 100. Total may be inaccurate."
+  },
+  "course.gradebook.TotalHint.policy": {
+    "defaultMessage": "Totals count ungraded assessments as 0."
+  },
+  "course.gradebook.WeightedViewHint.hint": {
+    "defaultMessage": "Want to set how much each item contributes to students’ total grades? Enable Weighted Total view in {link}."
+  },
+  "course.gradebook.WeightedViewHint.settingsLink": {
+    "defaultMessage": "Gradebook settings"
   }
 }

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -9253,5 +9253,164 @@
   },
   "lib.translations.table.column.newExternalId": {
     "defaultMessage": "새 외부 ID"
+  },
+  "course.admin.GradebookSettings.gradebookSettings": {
+    "defaultMessage": "성적부 설정"
+  },
+  "course.admin.GradebookSettings.weightedViewEnabled": {
+    "defaultMessage": "가중 성적 보기 사용"
+  },
+  "course.admin.GradebookSettings.weightedViewEnabledHint": {
+    "defaultMessage": "성적부에 \"가중 총점\" 보기를 추가하여 교직원이 탭별 가중치를 설정하고 가중 총점 열을 확인할 수 있습니다."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.allExcluded": {
+    "defaultMessage": "“{tab}”의 모든 평가가 제외되어 총점에 반영되지 않습니다."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.allExcludedCount": {
+    "defaultMessage": "전체 {n}개 제외됨"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.customMode": {
+    "defaultMessage": "사용자 지정"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.customSum": {
+    "defaultMessage": "평가 가중치: {sum} / {total}"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.defaultsHint": {
+    "defaultMessage": "아직 설정된 가중치가 없습니다. 모든 탭이 동일한 비중으로 반영되도록 제안된 기본값입니다. 저장하여 확정하거나 아래에서 조정하세요."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionDrop": {
+    "defaultMessage": "동일 모드에서는 평균을 내기 전에 각 학생의 점수가 가장 낮은 평가 N개를 선택적으로 제외할 수 있습니다."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionExclusion": {
+    "defaultMessage": "탭을 펼쳐 개별 평가를 성적에 포함하거나 제외하세요."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionIntro": {
+    "defaultMessage": "각 탭과 평가가 학생의 총 성적에 어떻게 반영되는지 관리합니다."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionModes": {
+    "defaultMessage": "“동일”（모든 평가가 탭의 가중치를 동일하게 나눔）또는 “사용자 지정”（각 평가의 비중을 설정）을 선택하세요."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionWeights": {
+    "defaultMessage": "각 탭의 가중치, 즉 총 성적에 기여하는 비중을 설정하세요. 가중치 합계는 100이어야 합니다."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.equalMode": {
+    "defaultMessage": "동일"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.excluded": {
+    "defaultMessage": "제외됨"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.excludedCount": {
+    "defaultMessage": "{n}개 제외됨"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.includeAssessment": {
+    "defaultMessage": "{assessment} 성적에 포함"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.modeAria": {
+    "defaultMessage": "{tab} 가중치 모드"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.ofGrade": {
+    "defaultMessage": "성적의 {pct}%"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.promptTitle": {
+    "defaultMessage": "기여도 설정"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.saveError": {
+    "defaultMessage": "가중치를 저장하지 못했습니다. 다시 시도해 주세요."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.total": {
+    "defaultMessage": "합계: {sum}%"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.unbalanced": {
+    "defaultMessage": "저장하기 전에 “{tab}”의 평가 가중치 합계가 해당 탭의 총 가중치와 같아야 합니다."
+  },
+  "course.gradebook.ConfigureWeightsPrompt.valueTooHigh": {
+    "defaultMessage": "값은 최대 100이어야 합니다"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.valueTooLow": {
+    "defaultMessage": "값은 최소 0이어야 합니다"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.weightsDoNotSum": {
+    "defaultMessage": "가중치 합계가 100이 아닙니다. 저장은 가능하지만 총점이 정확하지 않을 수 있습니다."
+  },
+  "course.gradebook.GradebookIndex.allAssessments": {
+    "defaultMessage": "전체 평가"
+  },
+  "course.gradebook.GradebookIndex.byWeight": {
+    "defaultMessage": "가중 총점"
+  },
+  "course.gradebook.WeightedGradebookTable.collapseRow": {
+    "defaultMessage": "{name} 접기"
+  },
+  "course.gradebook.WeightedGradebookTable.configureWeights": {
+    "defaultMessage": "가중치 설정"
+  },
+  "course.gradebook.WeightedGradebookTable.defaultWeights": {
+    "defaultMessage": "기본 가중치를 표시하고 있습니다. 모든 탭이 동일하게 반영됩니다. \"가중치 설정\"을 클릭하여 직접 설정하세요."
+  },
+  "course.gradebook.WeightedGradebookTable.defaultWeightsNoAccess": {
+    "defaultMessage": "기본 가중치를 표시하고 있습니다. 가중치가 설정되기 전까지 모든 탭이 동일하게 반영됩니다."
+  },
+  "course.gradebook.WeightedGradebookTable.displayPercent": {
+    "defaultMessage": "백분율"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPercentTooltip": {
+    "defaultMessage": "학생이 각 탭에서 획득한 비율입니다. 비중이 20%인 탭에서 100%는 해당 탭의 20점을 모두 획득했음을 의미합니다."
+  },
+  "course.gradebook.WeightedGradebookTable.displayPoints": {
+    "defaultMessage": "점수"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPointsTooltip": {
+    "defaultMessage": "각 탭이 기여하는 성적 점수입니다. 각 열의 합이 예상 총점이 됩니다."
+  },
+  "course.gradebook.WeightedGradebookTable.downloadCsv": {
+    "defaultMessage": "CSV로 다운로드"
+  },
+  "course.gradebook.WeightedGradebookTable.email": {
+    "defaultMessage": "이메일"
+  },
+  "course.gradebook.WeightedGradebookTable.excluded": {
+    "defaultMessage": "제외됨"
+  },
+  "course.gradebook.WeightedGradebookTable.expandRow": {
+    "defaultMessage": "{name} 펼치기"
+  },
+  "course.gradebook.WeightedGradebookTable.name": {
+    "defaultMessage": "이름"
+  },
+  "course.gradebook.WeightedGradebookTable.noWeightsConfigured": {
+    "defaultMessage": "설정된 가중치가 없습니다. 모든 탭의 가중치가 0입니다. \"가중치 설정\"을 클릭하여 가중치를 지정하세요."
+  },
+  "course.gradebook.WeightedGradebookTable.noWeightsNoAccess": {
+    "defaultMessage": "아직 탭 가중치가 설정되지 않았습니다."
+  },
+  "course.gradebook.WeightedGradebookTable.outOfWeight": {
+    "defaultMessage": "/{weight}"
+  },
+  "course.gradebook.WeightedGradebookTable.percentOfGrade": {
+    "defaultMessage": "성적의 {weight}%"
+  },
+  "course.gradebook.WeightedGradebookTable.percentTotalExact": {
+    "defaultMessage": "합계 100%"
+  },
+  "course.gradebook.WeightedGradebookTable.percentTotalWarning": {
+    "defaultMessage": "합계 {weight}%"
+  },
+  "course.gradebook.WeightedGradebookTable.weightedTotal": {
+    "defaultMessage": "가중 총점"
+  },
+  "course.gradebook.WeightedGradebookTable.searchStudents": {
+    "defaultMessage": "학생 검색"
+  },
+  "course.gradebook.WeightedGradebookTable.weightsDoNotSum": {
+    "defaultMessage": "가중치 합계가 100이 아닙니다. 총점이 정확하지 않을 수 있습니다."
+  },
+  "course.gradebook.TotalHint.policy": {
+    "defaultMessage": "총점은 채점되지 않은 평가를 0점으로 계산합니다."
+  },
+  "course.gradebook.WeightedViewHint.hint": {
+    "defaultMessage": "가중 총점이 필요하신가요? 각 탭이 학생의 전체 성적에 반영되는 비중을 설정하고 여기에서 가중 총점을 확인할 수 있습니다. {link}에서 활성화하세요."
+  },
+  "course.gradebook.WeightedViewHint.settingsLink": {
+    "defaultMessage": "성적부 설정"
   }
 }

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -9247,5 +9247,164 @@
   },
   "lib.translations.table.column.newExternalId": {
     "defaultMessage": "新外部编号"
+  },
+  "course.admin.GradebookSettings.gradebookSettings": {
+    "defaultMessage": "成绩册设置"
+  },
+  "course.admin.GradebookSettings.weightedViewEnabled": {
+    "defaultMessage": "启用加权成绩视图"
+  },
+  "course.admin.GradebookSettings.weightedViewEnabledHint": {
+    "defaultMessage": "在成绩册中启用“加权总成绩”视图，教职员可以配置各标签页的权重并查看加权总成绩列。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.allExcluded": {
+    "defaultMessage": "“{tab}”中的所有评估均已排除，且不会计入总成绩。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.allExcludedCount": {
+    "defaultMessage": "已排除全部 {n} 个"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.customMode": {
+    "defaultMessage": "自定义"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.customSum": {
+    "defaultMessage": "评估权重：{sum} / {total}"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.defaultsHint": {
+    "defaultMessage": "尚未设置权重。以下为建议默认值，所有标签页均按相同比重计算。保存以确认，或在下方进行调整。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionDrop": {
+    "defaultMessage": "在等权模式下，可选择在求平均分前剔除每位学生得分最低的 N 个评估。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionExclusion": {
+    "defaultMessage": "展开标签页以将个别评估纳入或排除在评分之外。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionIntro": {
+    "defaultMessage": "控制各标签页和评估如何计入每位学生的总成绩。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionModes": {
+    "defaultMessage": "选择“等权”（所有评估平分该标签页的权重）或“自定义”（设置每个评估所占的份额）。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.descriptionWeights": {
+    "defaultMessage": "设置每个标签页的权重，即其对总成绩的贡献比例（权重合计应为 100）。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.equalMode": {
+    "defaultMessage": "等权"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.excluded": {
+    "defaultMessage": "已排除"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.excludedCount": {
+    "defaultMessage": "已排除 {n} 个"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.includeAssessment": {
+    "defaultMessage": "将 {assessment} 计入成绩"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.modeAria": {
+    "defaultMessage": "{tab} 权重模式"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.ofGrade": {
+    "defaultMessage": "占成绩的 {pct}%"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.promptTitle": {
+    "defaultMessage": "配置贡献比例"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.saveError": {
+    "defaultMessage": "保存权重失败。请重试。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.total": {
+    "defaultMessage": "总计：{sum}%"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.unbalanced": {
+    "defaultMessage": "保存前，“{tab}”的评估权重合计必须等于该标签页的总权重。"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.valueTooHigh": {
+    "defaultMessage": "数值最多为 100"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.valueTooLow": {
+    "defaultMessage": "数值至少为 0"
+  },
+  "course.gradebook.ConfigureWeightsPrompt.weightsDoNotSum": {
+    "defaultMessage": "权重合计不为 100。仍可保存；总成绩可能不准确。"
+  },
+  "course.gradebook.GradebookIndex.allAssessments": {
+    "defaultMessage": "全部评估"
+  },
+  "course.gradebook.GradebookIndex.byWeight": {
+    "defaultMessage": "加权总成绩"
+  },
+  "course.gradebook.WeightedGradebookTable.collapseRow": {
+    "defaultMessage": "收起 {name}"
+  },
+  "course.gradebook.WeightedGradebookTable.configureWeights": {
+    "defaultMessage": "配置权重"
+  },
+  "course.gradebook.WeightedGradebookTable.defaultWeights": {
+    "defaultMessage": "正在显示默认权重-所有标签页比重相同。点击“配置权重”进行自定义设置。"
+  },
+  "course.gradebook.WeightedGradebookTable.defaultWeightsNoAccess": {
+    "defaultMessage": "正在显示默认权重-在配置权重之前，所有标签页比重相同。"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPercent": {
+    "defaultMessage": "百分比"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPercentTooltip": {
+    "defaultMessage": "学生在各标签页所获得的比例。在比重为 20% 的标签页获得 100%，即表示学生获得了该标签页的全部 20 个成绩分。"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPoints": {
+    "defaultMessage": "分数"
+  },
+  "course.gradebook.WeightedGradebookTable.displayPointsTooltip": {
+    "defaultMessage": "各标签页贡献的成绩分数。各列相加即为预计总成绩。"
+  },
+  "course.gradebook.WeightedGradebookTable.downloadCsv": {
+    "defaultMessage": "下载为 CSV"
+  },
+  "course.gradebook.WeightedGradebookTable.email": {
+    "defaultMessage": "电子邮件"
+  },
+  "course.gradebook.WeightedGradebookTable.excluded": {
+    "defaultMessage": "已排除"
+  },
+  "course.gradebook.WeightedGradebookTable.expandRow": {
+    "defaultMessage": "展开 {name}"
+  },
+  "course.gradebook.WeightedGradebookTable.name": {
+    "defaultMessage": "姓名"
+  },
+  "course.gradebook.WeightedGradebookTable.noWeightsConfigured": {
+    "defaultMessage": "尚未配置权重-所有标签页的权重均为 0。点击“配置权重”以分配权重。"
+  },
+  "course.gradebook.WeightedGradebookTable.noWeightsNoAccess": {
+    "defaultMessage": "尚未配置任何标签页权重。"
+  },
+  "course.gradebook.WeightedGradebookTable.outOfWeight": {
+    "defaultMessage": "/{weight}"
+  },
+  "course.gradebook.WeightedGradebookTable.percentOfGrade": {
+    "defaultMessage": "占成绩的 {weight}%"
+  },
+  "course.gradebook.WeightedGradebookTable.percentTotalExact": {
+    "defaultMessage": "合计 100%"
+  },
+  "course.gradebook.WeightedGradebookTable.percentTotalWarning": {
+    "defaultMessage": "合计 {weight}%"
+  },
+  "course.gradebook.WeightedGradebookTable.weightedTotal": {
+    "defaultMessage": "加权总成绩"
+  },
+  "course.gradebook.WeightedGradebookTable.searchStudents": {
+    "defaultMessage": "搜索学生"
+  },
+  "course.gradebook.WeightedGradebookTable.weightsDoNotSum": {
+    "defaultMessage": "权重合计不为 100。总成绩可能不准确。"
+  },
+  "course.gradebook.TotalHint.policy": {
+    "defaultMessage": "总成绩将未评分的评估按 0 分计算。"
+  },
+  "course.gradebook.WeightedViewHint.hint": {
+    "defaultMessage": "想要设置每个项目对学生总成绩的占比吗？请在{link}中启用“加权总成绩”视图。"
+  },
+  "course.gradebook.WeightedViewHint.settingsLink": {
+    "defaultMessage": "成绩册设置"
   }
 }

--- a/config/locales/en/activerecord/errors.yml
+++ b/config/locales/en/activerecord/errors.yml
@@ -97,6 +97,7 @@ en:
           autograded_no_partial_answer: 'There are updated answers which have not been re-submitted yet. Please re-submit all answers before finalising your submission.'
         course/assessment/tab:
           deletion: 'the last tab cannot be deleted'
+          custom_weights_mismatch: 'Custom assessment weights must sum to the tab total'
         course/condition:
           attributes:
             conditional:

--- a/config/locales/ko/activerecord/errors.yml
+++ b/config/locales/ko/activerecord/errors.yml
@@ -95,6 +95,7 @@ ko:
           autograded_no_partial_answer: '업데이트된 답변이 아직 다시 제출되지 않았습니다. 제출을 완료하기 전에 모든 답변을 다시 제출하세요.'
         course/assessment/tab:
           deletion: '마지막 탭은 삭제할 수 없습니다'
+          custom_weights_mismatch: '사용자 지정 평가 가중치의 합은 해당 탭의 총점과 같아야 합니다.'
         course/condition:
           attributes:
             conditional:

--- a/config/locales/zh/activerecord/errors.yml
+++ b/config/locales/zh/activerecord/errors.yml
@@ -95,6 +95,7 @@ zh:
           autograded_no_partial_answer: '有一些更新的答案还没有重新提交。请在最后提交前重新提交所有答案。'
         course/assessment/tab:
           deletion: '最后一项无法被删除'
+          custom_weights_mismatch: '自定义评估权重的总和必须等于该标签的总分。'
         course/condition:
           attributes:
             conditional:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,6 +196,9 @@ Rails.application.routes.draw do
         get 'leaderboard' => 'leaderboard_settings#edit'
         patch 'leaderboard' => 'leaderboard_settings#update'
 
+        get 'gradebook' => 'gradebook_settings#edit'
+        patch 'gradebook' => 'gradebook_settings#update'
+
         get 'comments' => 'discussion/topic_settings#edit', as: 'topics'
         patch 'comments' => 'discussion/topic_settings#update'
 
@@ -498,6 +501,7 @@ Rails.application.routes.draw do
 
       resource :gradebook, only: [] do
         get '/' => 'gradebook#index'
+        patch '/weights' => 'gradebook#update_weights'
       end
 
       scope module: :discussion do

--- a/db/migrate/20260611000000_create_gradebook_contribution_tables.rb
+++ b/db/migrate/20260611000000_create_gradebook_contribution_tables.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class CreateGradebookContributionTables < ActiveRecord::Migration[7.2]
+  def change
+    create_table :course_gradebook_tab_contributions do |t|
+      t.references :course, null: false, foreign_key: { to_table: :courses },
+                            index: { name: 'fk__course_gradebook_tab_contributions_course_id' }
+      t.references :tab, null: false,
+                         foreign_key: { to_table: :course_assessment_tabs, on_delete: :cascade },
+                         index: { unique: true,
+                                  name: 'index_course_gradebook_tab_contributions_on_tab_id' }
+      t.decimal :weight, precision: 5, scale: 2, null: false, default: 0
+      t.integer :weight_mode, null: false, default: 0
+
+      t.references :creator, null: false, foreign_key: { to_table: :users },
+                             index: { name: 'fk__course_gradebook_tab_contributions_creator_id' }
+      t.references :updater, null: false, foreign_key: { to_table: :users },
+                             index: { name: 'fk__course_gradebook_tab_contributions_updater_id' }
+      t.timestamps null: false
+    end
+
+    create_table :course_gradebook_assessment_contributions do |t|
+      t.references :assessment, null: false,
+                                foreign_key: { to_table: :course_assessments, on_delete: :cascade },
+                                index: { unique: true,
+                                         name: 'index_cgac_on_assessment_id' }
+      t.decimal :weight, precision: 5, scale: 2, null: true
+      t.boolean :excluded, null: false, default: false
+
+      t.references :creator, null: false, foreign_key: { to_table: :users },
+                             index: { name: 'fk__cgac_creator_id' }
+      t.references :updater, null: false, foreign_key: { to_table: :users },
+                             index: { name: 'fk__cgac_updater_id' }
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_14_052933) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_11_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -854,6 +854,34 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_14_052933) do
     t.index ["course_id"], name: "fk__course_forums_course_id"
     t.index ["creator_id"], name: "fk__course_forums_creator_id"
     t.index ["updater_id"], name: "fk__course_forums_updater_id"
+  end
+
+  create_table "course_gradebook_assessment_contributions", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.decimal "weight", precision: 5, scale: 2
+    t.boolean "excluded", default: false, null: false
+    t.bigint "creator_id", null: false
+    t.bigint "updater_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_cgac_on_assessment_id", unique: true
+    t.index ["creator_id"], name: "fk__cgac_creator_id"
+    t.index ["updater_id"], name: "fk__cgac_updater_id"
+  end
+
+  create_table "course_gradebook_tab_contributions", force: :cascade do |t|
+    t.bigint "course_id", null: false
+    t.bigint "tab_id", null: false
+    t.decimal "weight", precision: 5, scale: 2, default: "0.0", null: false
+    t.integer "weight_mode", default: 0, null: false
+    t.bigint "creator_id", null: false
+    t.bigint "updater_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "fk__course_gradebook_tabcontributions_course_id"
+    t.index ["creator_id"], name: "fk__course_gradebook_tabcontributions_creator_id"
+    t.index ["tab_id"], name: "index_course_gradebook_tabcontributions_on_tab_id", unique: true
+    t.index ["updater_id"], name: "fk__course_gradebook_tabcontributions_updater_id"
   end
 
   create_table "course_group_categories", force: :cascade do |t|
@@ -1915,6 +1943,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_14_052933) do
   add_foreign_key "course_forums", "courses", name: "fk_course_forums_course_id"
   add_foreign_key "course_forums", "users", column: "creator_id", name: "fk_course_forums_creator_id"
   add_foreign_key "course_forums", "users", column: "updater_id", name: "fk_course_forums_updater_id"
+  add_foreign_key "course_gradebook_assessment_contributions", "course_assessments", column: "assessment_id", on_delete: :cascade
+  add_foreign_key "course_gradebook_assessment_contributions", "users", column: "creator_id"
+  add_foreign_key "course_gradebook_assessment_contributions", "users", column: "updater_id"
+  add_foreign_key "course_gradebook_tab_contributions", "course_assessment_tabs", column: "tab_id", on_delete: :cascade
+  add_foreign_key "course_gradebook_tab_contributions", "courses"
+  add_foreign_key "course_gradebook_tab_contributions", "users", column: "creator_id"
+  add_foreign_key "course_gradebook_tab_contributions", "users", column: "updater_id"
   add_foreign_key "course_group_categories", "courses"
   add_foreign_key "course_group_categories", "users", column: "creator_id"
   add_foreign_key "course_group_categories", "users", column: "updater_id"

--- a/spec/controllers/course/admin/gradebook_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/gradebook_settings_controller_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Admin::GradebookSettingsController, type: :controller do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:manager) { create(:course_manager, course: course) }
+    let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
+    let(:student) { create(:course_student, course: course) }
+
+    describe '#edit' do
+      context 'as manager' do
+        render_views
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'returns settings JSON' do
+          get :edit, params: { course_id: course.id }, format: :json
+          expect(response).to have_http_status(:ok)
+          body = JSON.parse(response.body)
+          expect(body).to include('weightedViewEnabled' => false)
+        end
+
+        it 'reflects an already-enabled setting' do
+          ctx = Struct.new(:current_course, :key).new(course, Course::GradebookComponent.key)
+          Course::Settings::GradebookComponent.new(ctx).weighted_view_enabled = true
+          course.save!
+          get :edit, params: { course_id: course.id }, format: :json
+          expect(JSON.parse(response.body)).to include('weightedViewEnabled' => true)
+        end
+      end
+
+      context 'as teaching assistant' do
+        before { controller_sign_in(controller, teaching_assistant.user) }
+
+        it 'is denied' do
+          expect do
+            get :edit, params: { course_id: course.id }, format: :json
+          end.to raise_error(CanCan::AccessDenied)
+        end
+      end
+
+      context 'as student' do
+        before { controller_sign_in(controller, student.user) }
+
+        it 'is denied' do
+          expect do
+            get :edit, params: { course_id: course.id }, format: :json
+          end.to raise_error(CanCan::AccessDenied)
+        end
+      end
+
+      context 'when the gradebook component is disabled' do
+        before do
+          controller_sign_in(controller, manager.user)
+          allow(controller).to receive_message_chain('current_component_host.[]').and_return(nil)
+        end
+
+        it 'raises a component not found error' do
+          expect do
+            get :edit, params: { course_id: course.id }, format: :json
+          end.to raise_error(ComponentNotFoundError)
+        end
+      end
+    end
+
+    describe '#update' do
+      context 'as manager' do
+        render_views
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'updates weighted_view_enabled and returns 200' do
+          patch :update,
+                params: { course_id: course.id,
+                          settings_gradebook_component: { weighted_view_enabled: true } },
+                format: :json
+          expect(response).to have_http_status(:ok)
+          body = JSON.parse(response.body)
+          expect(body).to include('weightedViewEnabled' => true)
+        end
+
+        it 'preserves existing tab gradebook_weights when toggling setting' do
+          category = create(:course_assessment_category, course: course)
+          tab = create(:course_assessment_tab, category: category)
+          contribution = create(:course_gradebook_tab_contribution, tab: tab, course: course, weight: 50)
+
+          patch :update,
+                params: { course_id: course.id,
+                          settings_gradebook_component: { weighted_view_enabled: true } },
+                format: :json
+          expect(contribution.reload.weight).to eq(50)
+
+          patch :update,
+                params: { course_id: course.id,
+                          settings_gradebook_component: { weighted_view_enabled: false } },
+                format: :json
+          expect(contribution.reload.weight).to eq(50)
+        end
+
+        it 'renders errors with 400 when persistence fails' do
+          allow_any_instance_of(Course).to receive(:save).and_return(false)
+          patch :update,
+                params: { course_id: course.id,
+                          settings_gradebook_component: { weighted_view_enabled: true } },
+                format: :json
+          expect(response).to have_http_status(:bad_request)
+          expect(JSON.parse(response.body)).to have_key('errors')
+        end
+
+        it 'raises ParameterMissing when settings_gradebook_component is absent' do
+          expect do
+            patch :update, params: { course_id: course.id }, format: :json
+          end.to raise_error(ActionController::ParameterMissing)
+        end
+
+        it 'ignores attributes outside the permitted set' do
+          patch :update,
+                params: { course_id: course.id,
+                          settings_gradebook_component: {
+                            weighted_view_enabled: true, some_forbidden_attr: 'x'
+                          } },
+                format: :json
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)).to include('weightedViewEnabled' => true)
+        end
+      end
+
+      context 'as teaching assistant' do
+        before { controller_sign_in(controller, teaching_assistant.user) }
+
+        it 'is denied' do
+          expect do
+            patch :update,
+                  params: { course_id: course.id,
+                            settings_gradebook_component: { weighted_view_enabled: true } },
+                  format: :json
+          end.to raise_error(CanCan::AccessDenied)
+        end
+      end
+
+      context 'as student' do
+        let(:student) { create(:course_student, course: course) }
+        before { controller_sign_in(controller, student.user) }
+
+        it 'is denied' do
+          expect do
+            patch :update,
+                  params: { course_id: course.id,
+                            settings_gradebook_component: { weighted_view_enabled: true } },
+                  format: :json
+          end.to raise_error(CanCan::AccessDenied)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/gradebook_controller_spec.rb
+++ b/spec/controllers/course/gradebook_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Course::GradebookController, type: :controller do
     let(:course) { create(:course) }
     let(:student) { create(:course_user, :student, course: course) }
     let(:staff) { create(:course_user, :teaching_assistant, course: course) }
+    let(:manager) { create(:course_user, :manager, course: course) }
 
     describe '#index' do
       render_views
@@ -37,6 +38,13 @@ RSpec.describe Course::GradebookController, type: :controller do
         let(:ta) { create(:course_teaching_assistant, course: course) }
         before { controller_sign_in(controller, ta.user) }
 
+        it { expect { subject }.to raise_error(CanCan::AccessDenied) }
+      end
+
+      context 'when a manager visits the page' do
+        let(:manager) { create(:course_manager, course: course) }
+        before { controller_sign_in(controller, manager.user) }
+
         it { expect(subject).to be_successful }
 
         it 'returns all required top-level keys' do
@@ -48,18 +56,11 @@ RSpec.describe Course::GradebookController, type: :controller do
         end
       end
 
-      context 'when a manager visits the page' do
-        let(:manager) { create(:course_manager, course: course) }
-        before { controller_sign_in(controller, manager.user) }
-
-        it { expect(subject).to be_successful }
-      end
-
       context 'when an observer visits the page' do
         let(:observer) { create(:course_observer, course: course) }
         before { controller_sign_in(controller, observer.user) }
 
-        it { expect(subject).to be_successful }
+        it { expect { subject }.to raise_error(CanCan::AccessDenied) }
       end
 
       context 'with a published assessment and a graded submission' do
@@ -77,7 +78,7 @@ RSpec.describe Course::GradebookController, type: :controller do
 
         before do
           submission.answers.update_all(grade: 5.0, current_answer: true)
-          controller_sign_in(controller, ta.user)
+          controller_sign_in(controller, manager.user)
         end
 
         it 'includes the assessment in the assessments array' do
@@ -129,9 +130,8 @@ RSpec.describe Course::GradebookController, type: :controller do
       end
 
       context 'when a student has an external ID' do
-        let(:ta) { create(:course_teaching_assistant, course: course) }
         let!(:student) { create(:course_student, course: course, external_id: 'EXT-123') }
-        before { controller_sign_in(controller, ta.user) }
+        before { controller_sign_in(controller, manager.user) }
 
         it 'returns the external ID in the students array' do
           subject
@@ -143,7 +143,7 @@ RSpec.describe Course::GradebookController, type: :controller do
       end
 
       context 'with a graded submission where the answer grade is exactly 0' do
-        let(:ta) { create(:course_teaching_assistant, course: course) }
+        let(:manager) { create(:course_manager, course: course) }
         let(:tab) { course.assessment_categories.first.tabs.first }
         let!(:assessment) do
           create(:course_assessment_assessment, :published_with_mcq_question,
@@ -157,7 +157,7 @@ RSpec.describe Course::GradebookController, type: :controller do
 
         before do
           submission.answers.update_all(grade: 0.0, current_answer: true)
-          controller_sign_in(controller, ta.user)
+          controller_sign_in(controller, manager.user)
         end
 
         it 'returns grade 0 (not null) in the submissions array' do
@@ -172,7 +172,7 @@ RSpec.describe Course::GradebookController, type: :controller do
       end
 
       context 'with a graded submission where answer grades are null (blank)' do
-        let(:ta) { create(:course_teaching_assistant, course: course) }
+        let(:manager) { create(:course_manager, course: course) }
         let(:tab) { course.assessment_categories.first.tabs.first }
         let!(:assessment) do
           create(:course_assessment_assessment, :published_with_mcq_question,
@@ -186,7 +186,7 @@ RSpec.describe Course::GradebookController, type: :controller do
 
         before do
           submission.answers.update_all(grade: nil, current_answer: true)
-          controller_sign_in(controller, ta.user)
+          controller_sign_in(controller, manager.user)
         end
 
         it 'returns null grade (not 0) in the submissions array' do
@@ -197,6 +197,237 @@ RSpec.describe Course::GradebookController, type: :controller do
           end
           expect(sub).not_to be_nil
           expect(sub['grade']).to be_nil
+        end
+      end
+    end
+
+    describe 'PATCH update_weights' do
+      let(:manager) { create(:course_manager, course: course) }
+      let(:ta) { create(:course_teaching_assistant, course: course) }
+      let(:student) { create(:course_student, course: course) }
+      let(:category) { create(:course_assessment_category, course: course) }
+      let!(:tab1) { create(:course_assessment_tab, category: category) }
+      let!(:tab2) { create(:course_assessment_tab, category: category) }
+      def weight_for(tab)
+        Course::Gradebook::TabContribution.find_by(tab_id: tab.id)&.weight
+      end
+
+      let(:valid_payload) do
+        { weights: [{ tabId: tab1.id, weight: 60 }, { tabId: tab2.id, weight: 40 }] }
+      end
+
+      context 'as manager' do
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'updates and returns 200' do
+          patch :update_weights, params: { course_id: course.id, **valid_payload }, format: :json
+          expect(response).to have_http_status(:ok)
+          expect(weight_for(tab1)).to eq(60)
+          expect(weight_for(tab2)).to eq(40)
+        end
+
+        it 'accepts sum < 100' do
+          patch :update_weights,
+                params: { course_id: course.id, weights: [tabId: tab1.id, weight: 30] },
+                format: :json
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'accepts sum > 100' do
+          patch :update_weights,
+                params: { course_id: course.id,
+                          weights: [{ tabId: tab1.id, weight: 70 }, { tabId: tab2.id, weight: 70 }] },
+                format: :json
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'rejects negative with 422 and no partial write' do
+          create(:course_gradebook_tab_contribution, tab: tab1, course: course, weight: 10)
+          patch :update_weights,
+                params: { course_id: course.id,
+                          weights: [{ tabId: tab1.id, weight: 50 }, { tabId: tab2.id, weight: -1 }] },
+                format: :json
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(weight_for(tab1)).to eq(10)
+        end
+
+        it 'rejects >100 with 422' do
+          patch :update_weights,
+                params: { course_id: course.id, weights: [tabId: tab1.id, weight: 101] },
+                format: :json
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'rejects foreign tab id with 422' do
+          other_course = create(:course)
+          other_tab = create(:course_assessment_tab,
+                             category: create(:course_assessment_category, course: other_course))
+          patch :update_weights,
+                params: { course_id: course.id, weights: [tabId: other_tab.id, weight: 50] },
+                format: :json
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'treats an omitted weights param as a no-op rather than a 500' do
+          patch :update_weights, params: { course_id: course.id }, format: :json
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)['weights']).to eq([])
+        end
+
+        it 'rounds the echoed weight to 2dp so it matches the stored DECIMAL(5,2)' do
+          patch :update_weights,
+                params: { course_id: course.id, weights: [tabId: tab1.id, weight: 33.333] },
+                format: :json
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)['weights'].first['weight']).to eq(33.33)
+          expect(weight_for(tab1)).to eq(33.33)
+        end
+      end
+
+      context 'as TA' do
+        before { controller_sign_in(controller, ta.user) }
+        it 'is denied' do
+          expect do
+            patch :update_weights, params: { course_id: course.id, **valid_payload }, format: :json
+          end.to raise_error(CanCan::AccessDenied)
+        end
+      end
+
+      context 'as student' do
+        before { controller_sign_in(controller, student.user) }
+        it 'is denied' do
+          expect do
+            patch :update_weights, params: { course_id: course.id, **valid_payload }, format: :json
+          end.to raise_error(CanCan::AccessDenied)
+        end
+      end
+
+      context 'when setting is disabled' do
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'still allows update (storage independent of display)' do
+          patch :update_weights, params: { course_id: course.id, **valid_payload }, format: :json
+          expect(response).to have_http_status(:ok)
+          expect(weight_for(tab1)).to eq(60)
+        end
+      end
+
+      describe '#update_weights with modes' do
+        render_views
+
+        let(:category) { create(:course_assessment_category, course: course) }
+        let(:tab) { create(:course_assessment_tab, category: category) }
+        let!(:a1) { create(:assessment, course: course, tab: tab) }
+        let!(:a2) { create(:assessment, course: course, tab: tab) }
+
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'persists custom mode + assessment weights and echoes them back' do
+          patch :update_weights, as: :json, params: {
+            course_id: course.id,
+            weights: [{
+              tabId: tab.id, weight: '50', weightMode: 'custom',
+              assessmentWeights: [
+                { assessmentId: a1.id, weight: '30' },
+                { assessmentId: a2.id, weight: '20' }
+              ]
+            }]
+          }
+          expect(response).to have_http_status(:ok)
+          body = JSON.parse(response.body)
+          entry = body['weights'].first
+          expect(entry['weightMode']).to eq('custom')
+          expect(entry['assessmentWeights']).to contain_exactly(
+            { 'assessmentId' => a1.id, 'weight' => 30.0 },
+            { 'assessmentId' => a2.id, 'weight' => 20.0 }
+          )
+          expect(a1.reload.gradebook_assessment_contribution.weight).to eq(30.0)
+        end
+
+        it 'returns 422 when custom weights do not sum to the tab total' do
+          patch :update_weights, as: :json, params: {
+            course_id: course.id,
+            weights: [{
+              tabId: tab.id, weight: '50', weightMode: 'custom',
+              assessmentWeights: [{ assessmentId: a1.id, weight: '10' }]
+            }]
+          }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'persists and echoes per-assessment exclusion in equal mode' do
+          patch :update_weights, as: :json, params: {
+            course_id: course.id,
+            weights: [{
+              tabId: tab.id, weight: '50', weightMode: 'equal',
+              excludedAssessmentIds: [a1.id]
+            }]
+          }
+          expect(response).to have_http_status(:ok)
+          expect(a1.reload.gradebook_assessment_contribution.excluded).to eq(true)
+          expect(a2.reload.gradebook_assessment_contribution.excluded).to eq(false)
+          entry = JSON.parse(response.body)['weights'].first
+          expect(entry['excludedAssessmentIds']).to eq([a1.id])
+        end
+      end
+    end
+
+    describe 'GET index — weighted view fields' do
+      render_views
+      let(:manager) { create(:course_manager, course: course) }
+      let(:ta) { create(:course_teaching_assistant, course: course) }
+      let(:category) { create(:course_assessment_category, course: course) }
+      let!(:tab) { create(:course_assessment_tab, category: category) }
+      let!(:contribution) { create(:course_gradebook_tab_contribution, tab: tab, course: course, weight: 30) }
+      let!(:assessment) do
+        create(:course_assessment_assessment, :published_with_mcq_question,
+               course: course, tab: tab)
+      end
+
+      context 'when setting is disabled (default)' do
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'returns weightedViewEnabled false and omits gradebookWeight per tab' do
+          get :index, params: { course_id: course.id }, format: :json
+          body = JSON.parse(response.body)
+          expect(body['weightedViewEnabled']).to eq(false)
+          tab_json = body['tabs'].find { |t| t['id'] == tab.id }
+          expect(tab_json).not_to have_key('gradebookWeight')
+        end
+      end
+
+      context 'when setting is enabled' do
+        before do
+          ctx = Struct.new(:current_course, :key).new(course, Course::GradebookComponent.key)
+          Course::Settings::GradebookComponent.new(ctx).weighted_view_enabled = true
+          course.save!
+        end
+
+        it 'includes weightedViewEnabled true and gradebookWeight per tab for manager' do
+          controller_sign_in(controller, manager.user)
+          get :index, params: { course_id: course.id }, format: :json
+          body = JSON.parse(response.body)
+          expect(body['weightedViewEnabled']).to eq(true)
+          expect(body['canManageWeights']).to eq(true)
+          tab_json = body['tabs'].find { |t| t['id'] == tab.id }
+          expect(tab_json['gradebookWeight']).to eq(30)
+        end
+
+        it 'serializes weightMode on tabs and gradebookWeight on assessments when weighted view is enabled' do
+          controller_sign_in(controller, manager.user)
+          get :index, params: { course_id: course.id }, format: :json
+          body = JSON.parse(response.body)
+          tab_json = body['tabs'].find { |t| t['id'] == tab.id }
+          expect(tab_json).to have_key('weightMode')
+          expect(body['assessments'].first).to have_key('gradebookWeight')
+        end
+
+        it 'serializes gradebookExcluded on assessments when weighted view is enabled' do
+          controller_sign_in(controller, manager.user)
+          get :index, params: { course_id: course.id }, format: :json
+          body = JSON.parse(response.body)
+          expect(body['assessments'].first).to have_key('gradebookExcluded')
+          expect(body['assessments'].first['gradebookExcluded']).to eq(false)
         end
       end
     end

--- a/spec/factories/course_gradebook_assessment_contributions.rb
+++ b/spec/factories/course_gradebook_assessment_contributions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_gradebook_assessment_contribution, class: Course::Gradebook::AssessmentContribution.name do
+    assessment
+    excluded { false }
+  end
+end

--- a/spec/factories/course_gradebook_tab_contributions.rb
+++ b/spec/factories/course_gradebook_tab_contributions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_gradebook_tab_contribution, class: Course::Gradebook::TabContribution.name do
+    association :tab, factory: :course_assessment_tab
+    course { tab.category.course }
+    weight { 0 }
+    weight_mode { :equal }
+  end
+end

--- a/spec/models/course/gradebook/assessment_contribution_spec.rb
+++ b/spec/models/course/gradebook/assessment_contribution_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Gradebook::AssessmentContribution do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:tab) { create(:course_assessment_tab, course: course) }
+    let(:assessment) { create(:assessment, course: course, tab: tab) }
+
+    it 'allows a nil weight (equal mode)' do
+      contribution = build(:course_gradebook_assessment_contribution, assessment: assessment, weight: nil)
+      expect(contribution).to be_valid
+    end
+
+    it 'rejects a negative weight' do
+      contribution = build(:course_gradebook_assessment_contribution, assessment: assessment, weight: -1)
+      expect(contribution).not_to be_valid
+    end
+
+    it 'accepts a non-negative weight' do
+      contribution = build(:course_gradebook_assessment_contribution, assessment: assessment, weight: 0)
+      expect(contribution).to be_valid
+      contribution.weight = 25.5
+      expect(contribution).to be_valid
+    end
+
+    it 'defaults excluded to false' do
+      contribution = create(:course_gradebook_assessment_contribution, assessment: assessment)
+      expect(contribution.excluded).to eq(false)
+    end
+
+    it 'rejects a nil excluded flag' do
+      contribution = build(:course_gradebook_assessment_contribution, assessment: assessment)
+      contribution.excluded = nil
+      expect(contribution).not_to be_valid
+    end
+
+    it 'enforces one row per assessment' do
+      create(:course_gradebook_assessment_contribution, assessment: assessment)
+      duplicate = build(:course_gradebook_assessment_contribution, assessment: assessment)
+      expect(duplicate).not_to be_valid
+    end
+
+    it 'is destroyed when its assessment is destroyed' do
+      create(:course_gradebook_assessment_contribution, assessment: assessment)
+      expect { assessment.destroy! }.to change { described_class.count }.by(-1)
+    end
+  end
+end

--- a/spec/models/course/gradebook/tab_contribution_spec.rb
+++ b/spec/models/course/gradebook/tab_contribution_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Gradebook::TabContribution do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:category) { create(:course_assessment_category, course: course) }
+    let(:tab) { create(:course_assessment_tab, category: category) }
+
+    describe 'validations' do
+      it 'is valid with a tab and matching course' do
+        expect(build(:course_gradebook_tab_contribution, tab: tab, course: course)).to be_valid
+      end
+
+      it 'requires a tab' do
+        contribution = build(:course_gradebook_tab_contribution, tab: tab, course: course)
+        contribution.tab = nil
+        expect(contribution).not_to be_valid
+      end
+
+      it 'enforces one row per tab' do
+        create(:course_gradebook_tab_contribution, tab: tab, course: course)
+        duplicate = build(:course_gradebook_tab_contribution, tab: tab, course: course)
+        expect(duplicate).not_to be_valid
+      end
+
+      it 'rejects a course that does not match the tab course' do
+        contribution = build(:course_gradebook_tab_contribution, tab: tab)
+        contribution.course = create(:course)
+        expect(contribution).not_to be_valid
+      end
+
+      it 'rejects a negative weight' do
+        contribution = build(:course_gradebook_tab_contribution, tab: tab, course: course, weight: -1)
+        expect(contribution).not_to be_valid
+      end
+
+      it 'rejects a weight above 100' do
+        contribution = build(:course_gradebook_tab_contribution, tab: tab, course: course, weight: 101)
+        expect(contribution).not_to be_valid
+      end
+
+      it 'accepts a weight of exactly 100' do
+        contribution = build(:course_gradebook_tab_contribution, tab: tab, course: course, weight: 100)
+        expect(contribution).to be_valid
+      end
+
+      it 'requires a weight_mode' do
+        contribution = build(:course_gradebook_tab_contribution, tab: tab, course: course)
+        contribution.weight_mode = nil
+        expect(contribution).not_to be_valid
+      end
+
+      it 'defaults weight 0, mode equal' do
+        contribution = create(:course_gradebook_tab_contribution, tab: tab, course: course)
+        expect(contribution.weight).to eq(0)
+        expect(contribution.weight_mode).to eq('equal')
+      end
+    end
+
+    describe 'dependent destroy' do
+      it 'is destroyed when its tab is destroyed' do
+        create(:course_assessment_tab, category: category) # sibling so the tab is deletable
+        create(:course_gradebook_tab_contribution, tab: tab, course: course)
+        expect { tab.destroy! }.to change { described_class.count }.by(-1)
+      end
+    end
+
+    describe '.bulk_update' do
+      let(:tab1) { create(:course_assessment_tab, category: category) }
+      let(:tab2) { create(:course_assessment_tab, category: category) }
+
+      def weight_for(tab)
+        described_class.find_by(tab_id: tab.id)&.weight
+      end
+
+      it 'upserts a contribution per given tab' do
+        described_class.bulk_update(
+          course: course,
+          updates: [{ tab_id: tab1.id, weight: 60 }, { tab_id: tab2.id, weight: 40 }]
+        )
+        expect(weight_for(tab1)).to eq(60)
+        expect(weight_for(tab2)).to eq(40)
+        expect(described_class.find_by(tab_id: tab1.id).course_id).to eq(course.id)
+        expect(described_class.where(tab_id: [tab1.id, tab2.id]).count).to eq(2)
+      end
+
+      it 'is a no-op for an empty updates array' do
+        expect do
+          described_class.bulk_update(course: course, updates: [])
+        end.not_to change(described_class, :count)
+      end
+
+      it 'is transactional — an invalid value rolls everything back' do
+        create(:course_gradebook_tab_contribution, tab: tab1, course: course, weight: 10)
+        create(:course_gradebook_tab_contribution, tab: tab2, course: course, weight: 20)
+        expect do
+          described_class.bulk_update(
+            course: course,
+            updates: [{ tab_id: tab1.id, weight: 50 }, { tab_id: tab2.id, weight: 999 }]
+          )
+        end.to raise_error(ActiveRecord::RecordInvalid)
+        expect(weight_for(tab1)).to eq(10)
+        expect(weight_for(tab2)).to eq(20)
+      end
+
+      it 'rejects a foreign tab_id' do
+        other_course = create(:course)
+        other_tab = create(:course_assessment_tab,
+                           category: create(:course_assessment_category, course: other_course))
+        expect do
+          described_class.bulk_update(course: course, updates: [tab_id: other_tab.id, weight: 50])
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context 'with assessments in the tab' do
+        let(:tab) { create(:course_assessment_tab, category: category) }
+        let!(:a1) { create(:assessment, course: course, tab: tab) }
+        let!(:a2) { create(:assessment, course: course, tab: tab) }
+
+        def assessment_weight(assessment)
+          assessment.reload.gradebook_assessment_contribution&.weight
+        end
+
+        def excluded?(assessment)
+          assessment.reload.gradebook_assessment_contribution&.excluded
+        end
+
+        it 'persists custom mode + assessment weights that sum to the tab total' do
+          described_class.bulk_update(
+            course: course,
+            updates: [
+              tab_id: tab.id, weight: 50.0, weight_mode: 'custom',
+              assessment_weights: [
+                { assessment_id: a1.id, weight: 30.0 },
+                { assessment_id: a2.id, weight: 20.0 }
+              ]
+            ]
+          )
+          expect(tab.reload.gradebook_contribution.weight_mode).to eq('custom')
+          expect(assessment_weight(a1)).to eq(30.0)
+          expect(assessment_weight(a2)).to eq(20.0)
+        end
+
+        it 'raises RecordInvalid when custom weights do not sum to the tab total' do
+          expect do
+            described_class.bulk_update(
+              course: course,
+              updates: [
+                tab_id: tab.id, weight: 50.0, weight_mode: 'custom',
+                assessment_weights: [
+                  { assessment_id: a1.id, weight: 30.0 },
+                  { assessment_id: a2.id, weight: 5.0 }
+                ]
+              ]
+            )
+          end.to raise_error(ActiveRecord::RecordInvalid)
+          expect(assessment_weight(a1)).to be_nil # rolled back
+        end
+
+        it 'nulls assessment weights when switching the tab to equal mode' do
+          create(:course_gradebook_assessment_contribution, assessment: a1, weight: 30.0)
+          described_class.bulk_update(
+            course: course,
+            updates: [tab_id: tab.id, weight: 50.0, weight_mode: 'equal']
+          )
+          expect(tab.reload.gradebook_contribution.weight_mode).to eq('equal')
+          expect(assessment_weight(a1)).to be_nil
+        end
+
+        it 'persists per-assessment exclusion in equal mode' do
+          described_class.bulk_update(
+            course: course,
+            updates: [tab_id: tab.id, weight: 50.0, weight_mode: 'equal',
+                      excluded_assessment_ids: [a1.id]]
+          )
+          expect(excluded?(a1)).to eq(true)
+          expect(excluded?(a2)).to eq(false)
+        end
+
+        it 'drops excluded assessments from the custom balance check and keeps their weight' do
+          described_class.bulk_update(
+            course: course,
+            updates: [
+              tab_id: tab.id, weight: 30.0, weight_mode: 'custom',
+              excluded_assessment_ids: [a2.id],
+              assessment_weights: [
+                { assessment_id: a1.id, weight: 30.0 },
+                { assessment_id: a2.id, weight: 20.0 }
+              ]
+            ]
+          )
+          expect(excluded?(a1)).to eq(false)
+          expect(excluded?(a2)).to eq(true)
+          expect(assessment_weight(a2)).to eq(20.0) # retained for restore, not zeroed
+        end
+
+        it 'skips the custom balance check when every assessment is excluded' do
+          expect do
+            described_class.bulk_update(
+              course: course,
+              updates: [
+                tab_id: tab.id, weight: 30.0, weight_mode: 'custom',
+                excluded_assessment_ids: [a1.id, a2.id],
+                assessment_weights: [
+                  { assessment_id: a1.id, weight: 0.0 },
+                  { assessment_id: a2.id, weight: 0.0 }
+                ]
+              ]
+            )
+          end.not_to raise_error
+        end
+
+        it 'raises RecordNotFound when a custom assessment weight targets an assessment outside the tab' do
+          foreign = create(:assessment, course: course)
+          expect do
+            described_class.bulk_update(
+              course: course,
+              updates: [
+                tab_id: tab.id, weight: 50.0, weight_mode: 'custom',
+                assessment_weights: [{ assessment_id: foreign.id, weight: 50.0 }]
+              ]
+            )
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 're-including a previously excluded assessment clears the flag' do
+          create(:course_gradebook_assessment_contribution, assessment: a1, excluded: true)
+          described_class.bulk_update(
+            course: course,
+            updates: [tab_id: tab.id, weight: 50.0, weight_mode: 'equal', excluded_assessment_ids: []]
+          )
+          expect(excluded?(a1)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/gradebook_ability_spec.rb
+++ b/spec/models/course/gradebook_ability_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::GradebookAbilityComponent do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    subject { Ability.new(user, course, course_user) }
+    let(:course) { create(:course) }
+
+    context 'when the user is a Course Manager' do
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
+      it { is_expected.to be_able_to(:read_gradebook, course) }
+      it { is_expected.to be_able_to(:manage_gradebook_weights, course) }
+      it { is_expected.to be_able_to(:manage_gradebook_settings, course) }
+    end
+
+    context 'when the user is a Course Owner' do
+      let(:course_user) { create(:course_owner, course: course) }
+      let(:user) { course_user.user }
+      it { is_expected.to be_able_to(:read_gradebook, course) }
+      it { is_expected.to be_able_to(:manage_gradebook_weights, course) }
+      it { is_expected.to be_able_to(:manage_gradebook_settings, course) }
+    end
+
+    context 'when the user is a Teaching Assistant' do
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
+      it { is_expected.not_to be_able_to(:read_gradebook, course) }
+      it { is_expected.not_to be_able_to(:manage_gradebook_weights, course) }
+      it { is_expected.not_to be_able_to(:manage_gradebook_settings, course) }
+    end
+
+    context 'when the user is a Course Student' do
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
+      it { is_expected.not_to be_able_to(:read_gradebook, course) }
+      it { is_expected.not_to be_able_to(:manage_gradebook_weights, course) }
+      it { is_expected.not_to be_able_to(:manage_gradebook_settings, course) }
+    end
+  end
+end

--- a/spec/models/course/settings/gradebook_component_spec.rb
+++ b/spec/models/course/settings/gradebook_component_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Settings::GradebookComponent do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:settings) do
+      context = OpenStruct.new(current_course: course, key: Course::GradebookComponent.key)
+      Course::Settings::GradebookComponent.new(context)
+    end
+
+    describe '#weighted_view_enabled' do
+      it 'returns false by default' do
+        expect(settings.weighted_view_enabled).to eq(false)
+      end
+    end
+
+    describe '#weighted_view_enabled=' do
+      it 'persists true when set to true' do
+        settings.weighted_view_enabled = true
+        course.save!
+        expect(settings.weighted_view_enabled).to eq(true)
+      end
+
+      it 'persists false when set to false after being true' do
+        settings.weighted_view_enabled = true
+        course.save!
+        settings.weighted_view_enabled = false
+        course.save!
+        expect(settings.weighted_view_enabled).to eq(false)
+      end
+
+      it 'survives a reload into a fresh component instance' do
+        settings.weighted_view_enabled = true
+        course.save!
+        course.reload
+        fresh = Course::Settings::GradebookComponent.new(
+          OpenStruct.new(current_course: course, key: Course::GradebookComponent.key)
+        )
+        expect(fresh.weighted_view_enabled).to eq(true)
+      end
+
+      it 'handles string "1" as truthy' do
+        settings.weighted_view_enabled = '1'
+        expect(settings.weighted_view_enabled).to eq(true)
+      end
+
+      it 'handles string "true" as truthy' do
+        settings.weighted_view_enabled = 'true'
+        expect(settings.weighted_view_enabled).to eq(true)
+      end
+
+      it 'handles string "on" as truthy' do
+        settings.weighted_view_enabled = 'on'
+        expect(settings.weighted_view_enabled).to eq(true)
+      end
+
+      it 'handles string "0" as falsy' do
+        settings.weighted_view_enabled = '0'
+        expect(settings.weighted_view_enabled).to eq(false)
+      end
+
+      it 'handles string "false" as falsy' do
+        settings.weighted_view_enabled = 'false'
+        expect(settings.weighted_view_enabled).to eq(false)
+      end
+
+      it 'handles string "off" as falsy' do
+        settings.weighted_view_enabled = 'off'
+        expect(settings.weighted_view_enabled).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an opt-in weighted gradebook view on top of the base gradebook. Course staff enable it through a new Gradebook settings toggle, then configure per-tab weights in either equal mode (every included assessment counts equally toward the tab subtotal) or custom mode (explicit per-assessment weights that must sum to the tab total). Totals are additive: each tab subtotal is scaled by its weight and the gradebook Total is the literal sum of those subtotals. Staff can exclude individual assessments from totals . A per-student breakdown popover, a points/percentage display toggle, and a projected-total hint complete the view.

## Design decisions

- Weighted view is opt-in per course via a settings toggle - courses that don't want weighting see the existing gradebook unchanged.
- Custom-mode weights are validated server-side to sum (at 2 decimal places) to the tab total, inside a transaction that rolls back on mismatch - prevents partially-saved weight sets that don't add up.
- Exclusion flags are rewritten across the whole tab on every save (excluded ids to true, the rest to false) - avoids stale exclusions when modes change or assessments move.

## Regression prevention

- Backend specs: the tab weight-update pipeline (equal/custom modes, custom sum gate, exclusions, drop-lowest, unknown tab/assessment, transactional rollback), gradebook controller (index JSON plus update_weights authorization and error paths), gradebook ability, and the gradebook settings component.
- Frontend tests: computeWeighted (equal/custom math, exclusions, drop-lowest), GradebookWeightedTable, the configure-weights prompt, weighted column tree, projected-total and weighted-view hints, the store, and the gradebook settings form.
- Manual testing (confirmed by author): enabling and disabling the view, equal and custom weight configuration including the sum gate, per-assessment exclusion, points/percentage toggle, breakdown row expansion, and permission gating for read vs manage.
- Backward compatible: new columns default to non-weighted behaviour (tab weight 0, equal mode, not excluded) and the weighted view stays hidden unless explicitly enabled, so existing gradebook behaviour is unchanged.