### PR TITLE
fix(ui): keep inline-edit table cells on a single row

### DIFF
--- a/client/app/lib/components/form/fields/DataTableInlineEditable/TextField.tsx
+++ b/client/app/lib/components/form/fields/DataTableInlineEditable/TextField.tsx
@@ -28,15 +28,14 @@ const styles = {
     width: '100%',
   },
   displayFieldStyle: {
-    ':not(:hover)': {
-      '& button': {
-        opacity: 0,
-      },
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    '& button': {
+      opacity: 0,
     },
-    ':hover': {
-      '& button': {
-        opacity: 1,
-      },
+    ':hover button': {
+      opacity: 1,
     },
   },
   buttonStyle: { padding: '4px 4px', minWidth: '0px', color: 'inherit' },
@@ -106,18 +105,18 @@ const InlineEditTextField: FC<Props> = (props): JSX.Element | null => {
 
   const renderDisplayField = (
     <Box className={className} sx={styles.displayFieldStyle}>
-      <>
+      <span className="min-w-0 flex-1 truncate" title={controlledVal}>
         {link ? <Link href={link}>{controlledVal}</Link> : controlledVal}
+      </span>
 
-        <IconButton
-          className="inline-edit-button"
-          disabled={disabled}
-          onClick={(): void => setIsEditing(true)}
-          sx={styles.buttonStyle}
-        >
-          <Edit />
-        </IconButton>
-      </>
+      <IconButton
+        className="inline-edit-button shrink-0"
+        disabled={disabled}
+        onClick={(): void => setIsEditing(true)}
+        sx={styles.buttonStyle}
+      >
+        <Edit />
+      </IconButton>
     </Box>
   );
 

--- a/client/app/lib/components/form/fields/DataTableInlineEditable/__test__/TextField.test.tsx
+++ b/client/app/lib/components/form/fields/DataTableInlineEditable/__test__/TextField.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from 'test-utils';
+
+import InlineEditTextField from '../TextField';
+
+describe('<InlineEditTextField /> display field', () => {
+  const renderField = (value: string): void => {
+    render(
+      <InlineEditTextField
+        updateValue={(): void => {}}
+        value={value}
+        variant="standard"
+      />,
+    );
+  };
+
+  it('keeps the value on a single line', async () => {
+    renderField('Carol Chen');
+
+    // `truncate` clips to one line with an ellipsis instead of wrapping,
+    // which is what stops the cell from growing to two rows.
+    expect(await screen.findByText('Carol Chen')).toHaveClass('truncate');
+  });
+
+  it('exposes the full value via title so a clipped value stays recoverable', async () => {
+    renderField('a-very-long-external-id-that-would-be-clipped');
+
+    expect(
+      await screen.findByText('a-very-long-external-id-that-would-be-clipped'),
+    ).toHaveAttribute('title', 'a-very-long-external-id-that-would-be-clipped');
+  });
+
+  it('renders the edit button in a non-shrinking slot so it never wraps', async () => {
+    renderField('Carol Chen');
+
+    // `shrink-0` guarantees the button keeps its width and is never pushed
+    // onto a second row when the column is narrow.
+    expect(await screen.findByRole('button')).toHaveClass('shrink-0');
+  });
+});


### PR DESCRIPTION
## Problem
In Manage Users, the **Name** and **External ID** cells wrapped to two rows when the External ID was edited or the window shrank. The display cell rendered the value as inline text followed by the hover-reveal edit button, which still reserves width at `opacity: 0` — so once value + button exceeded the column width, the text wrapped.

## Fix
Lay the shared `InlineEditTextField` display cell out as a flex row:
- value truncates to one line (full value recoverable via `title`)
- edit button takes a non-shrinking slot, staying clickable at any width without wrapping

One change, inherited by all five `InlineEditTextField` consumers (Manage Users name + external ID, enrol requests, 2 admin tables).

## Tests
New `TextField.test.tsx` covering the single-row contract (truncate / title / non-shrinking button). All consumer suites green.

Old behaviour:
<img width="1280" height="1077" alt="IMAGE 2026-06-15 16:16:30" src="https://github.com/user-attachments/assets/bc292d4f-dafe-4fb0-b1a6-0a4518a20f73" />
