### PR TITLE
fix(invitations): fix bug where nil timeline input in invitations gets rejected

### DIFF
--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -107,7 +107,10 @@ module Course::UserInvitationService::ProcessInvitationConcern
   def build_course_user(user)
     @current_course.course_users.build(user: user[:user], name: user[:name],
                                        role: user[:role], phantom: user[:phantom],
-                                       timeline_algorithm: user[:timeline_algorithm],
+                                       timeline_algorithm: (
+                                         user[:timeline_algorithm].presence ||
+                                           @current_course.default_timeline_algorithm
+                                       ),
                                        external_id: user[:external_id],
                                        creator: @current_user, updater: @current_user)
   end

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -1161,6 +1161,31 @@ RSpec.describe Course::UserInvitationService, type: :service do
         expect(new_course_users.size).to eq(1)
         expect(new_course_users.first.timeline_algorithm).to eq('otot')
       end
+
+      context 'when the form omits timeline_algorithm (nil) on a non-timeline course' do
+        let(:course) do
+          create(:course, default_timeline_algorithm: :fixed,
+                          show_personalized_timeline_features: false)
+        end
+
+        it 'enrolls the existing user successfully without raising a validation error' do
+          result = subject.invite(
+            { '0' => { name: existing_user.name, email: existing_user.email,
+                       role: :student, phantom: false, timeline_algorithm: nil, external_id: nil } }
+          )
+          _, _, new_course_users, = result
+          expect(new_course_users.size).to eq(1)
+        end
+
+        it 'falls back to the course default timeline_algorithm when nil is supplied' do
+          result = subject.invite(
+            { '0' => { name: existing_user.name, email: existing_user.email,
+                       role: :student, phantom: false, timeline_algorithm: nil, external_id: nil } }
+          )
+          _, _, new_course_users, = result
+          expect(new_course_users.first.timeline_algorithm).to eq('fixed')
+        end
+      end
     end
 
     describe '#resend_invitation' do


### PR DESCRIPTION
These tests fail on master branch with the same error. Can catch this regression effectively if it happens again in the future.
<img width="1036" height="656" alt="image" src="https://github.com/user-attachments/assets/1018d55a-8ab0-48ab-b5a7-4ce161008f9a" />
