### PR TITLE
perf(webpack): generate gzip, brotli compressed bundles

### DIFF
--- a/client/webpack.prod.js
+++ b/client/webpack.prod.js
@@ -2,6 +2,8 @@ const { merge } = require('webpack-merge');
 const TerserPlugin = require('terser-webpack-plugin');
 const MomentTimezoneDataPlugin = require('moment-timezone-data-webpack-plugin');
 const ImageMinimizerPlugin = require('image-minimizer-webpack-plugin');
+const CompressionPlugin = require('compression-webpack-plugin');
+const zlib = require('zlib');
 
 const common = require('./webpack.common');
 
@@ -66,6 +68,20 @@ module.exports = merge(common, {
       minimizer: {
         implementation: ImageMinimizerPlugin.svgoMinify,
       },
+    }),
+    new CompressionPlugin({
+      test: /\.(js|css|html|svg|png)$/,
+      algorithm: 'gzip',
+    }),
+    new CompressionPlugin({
+      algorithm: 'brotliCompress',
+      test: /\.(js|css|html|svg|png)$/,
+      compressionOptions: {
+        params: {
+          [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+        },
+      },
+      threshold: 10240,
     }),
   ],
 });


### PR DESCRIPTION
Contains changes cherry-picked from https://github.com/Coursemology/coursemology2/pull/7889; continuation of https://github.com/Coursemology/coursemology2/pull/7942

Commits already merged: 35 / 36
Commits included in this PR: 1 / 36
Commits rejected: 1 / 36
Commits remaining: 0 / 36

> ### Compression
> 
> The final touch is adding gzip and Brotli compressions which brings down the total bundle size to 3.55 MB. The NGINX server needs to be updated to serve gzip and Brotli bundles with [`gzip_static on;`](https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html) and [`brotli_static on;`](https://www.getpagespeed.com/server-setup/nginx/brotli-static).
> 

>[!CAUTION]
>Generally, never think that compression is an acceptable answer to large bundle sizes, especially if they are bundles that we write and can control. For chunks that are just inevitably large, e.g., CKEditor, Ace, react-dom, it's okay to rely on compression. But generally, always think about how your codes will be bundled as you're writing them and/or how they & existing ones can be optimised.
>
>We should be solving the root cause of large bundle sizes before relying on compression. Compression is just an icing on the cake.