### PR TITLE
fix(text-response): fix null handling of old solution evaluation breakdowns

### DIFF
--- a/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
@@ -51,7 +51,7 @@ end
 
 if (
   can_grade || (@assessment.show_rubric_to_students? && @submission.published?)
-) && last_attempt&.auto_grading&.result
+) && last_attempt&.auto_grading&.result&.dig('evaluation_results')
   graded_solutions =
     last_attempt.auto_grading.result['evaluation_results'].index_by do |result|
       result['solution_id']

--- a/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
@@ -83,6 +83,8 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
   const published = workflowState === workflowStates.Published;
 
   const isProgrammingQuestion = question.type === QuestionType.Programming;
+  const isTextResponseAndAutogradable =
+    question.type === QuestionType.TextResponse && question.autogradable;
   const editable = !attempting && graderView;
 
   const isNotGradedAndNotPublished =
@@ -319,9 +321,10 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
           />
         )}
 
-        {editable && isProgrammingQuestion && (
-          <ReevaluateButton questionId={questionId} />
-        )}
+        {editable &&
+          (isProgrammingQuestion || isTextResponseAndAutogradable) && (
+            <ReevaluateButton questionId={questionId} />
+          )}
 
         {editable && isRubricBasedResponseAndAutogradable && (
           <div className="flex flex-row items-center">

--- a/spec/controllers/course/assessment/submission/answer/answers_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/answers_controller_spec.rb
@@ -132,5 +132,66 @@ RSpec.describe Course::Assessment::Submission::Answer::AnswersController do
         end
       end
     end
+
+    context 'when a text-response answer with a rubric is shown to the student' do
+      let(:course) { create(:course, :enrollable) }
+      let(:submitter) { create(:course_student, course: course).user }
+      let(:assessment) do
+        create(:assessment, :published_with_text_response_question, course: course,
+                                                                    show_rubric_to_students: true)
+      end
+      let(:submission) { create(:submission, :published, assessment: assessment, creator: submitter) }
+      let(:answer) { submission.answers.first }
+
+      before do
+        grading = answer.auto_grading || answer.build_auto_grading
+        grading.update!(result: auto_grading_result)
+        controller_sign_in(controller, submitter)
+      end
+
+      describe '#show' do
+        render_views
+        subject do
+          get :show, format: :json, params: {
+            course_id: course, assessment_id: assessment, submission_id: submission, id: answer.id
+          }
+        end
+
+        # Answers graded before spreadsheet formula autograding (commit b6da95a4ad) stored an
+        # auto_grading result without the `evaluation_results` key. Reading it unconditionally
+        # raised a NoMethodError (nil.index_by) when the rubric was shown to students.
+        context 'when the stored result predates evaluation_results' do
+          let(:auto_grading_result) { { 'messages' => [] } }
+
+          it 'renders successfully and omits the solution breakdown' do
+            expect(subject).to have_http_status(:success)
+            json_result = JSON.parse(response.body)
+
+            expect(json_result['fields']).to be_present
+            expect(json_result).not_to have_key('solutionResults')
+          end
+        end
+
+        context 'when the stored result includes evaluation_results' do
+          let(:auto_grading_result) do
+            {
+              'messages' => [],
+              'evaluation_results' => answer.question.specific.solutions.map do |solution|
+                { 'solution_id' => solution.id, 'grade' => solution.grade }
+              end
+            }
+          end
+
+          it 'renders the solution breakdown' do
+            expect(subject).to have_http_status(:success)
+            json_result = JSON.parse(response.body)
+
+            expect(json_result['solutionResults']).to be_present
+            expect(json_result['solutionResults'].map { |result| result['id'] }).
+              to match_array(answer.question.specific.solutions.map(&:id))
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Bug

Rollbar flagged a `NoMethodError: undefined method 'index_by' for nil` when rendering
the text response answer partial
([`_text_response.json.jbuilder`](app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder)).

The `solutionResults` block reads the persisted auto-grading result:

```ruby
last_attempt.auto_grading.result['evaluation_results'].index_by { |result| result['solution_id'] }
```

The `evaluation_results` key was only introduced in commit `b6da95a4ad`
(*"feat(text-response): implement spreadsheet formula autograding"*). Answers graded
**before** that commit have an auto-grading result containing `messages` but **no**
`evaluation_results` key, so the lookup returns `nil` and `.index_by` raises, 500-ing the
answer view.

The guard on the surrounding condition only checked that `result` existed, not that it
contained `evaluation_results`:

```ruby
) && last_attempt&.auto_grading&.result
```

## Remediation

Tighten the guard so the entire `solutionResults` block is skipped when
`evaluation_results` is absent.

We are **not backfilling** existing DB records. Legacy answers simply render without a
grading breakdown; a user can **regrade** the answer to repopulate `evaluation_results`
and restore the breakdown on demand.

The recovery path above depends on a grader being able to re-run autograding, but the
**Re-evaluate Answer** button in
[`QuestionGrade.tsx`](client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx)
was only rendered for programming and autogradable rubric-based-response questions. We extended the button's render condition to also cover autogradable text-response questions.

## Scope check

Audited every `evaluation_results` reference across `app`, `lib`, and `spec`. The jbuilder
is the **only** read-site of the persisted `auto_grading.result['evaluation_results']`
hash. All other references are producer-side (building the results in the grading
services) and cannot be nil in the same way. The sibling `result['messages']` read is
safe — `messages` has existed since the original grading service, so every record has it.

## Tests

Added regression coverage to
[`answers_controller_spec.rb`](spec/controllers/course/assessment/submission/answer/answers_controller_spec.rb)
(the `#show` action renders this jbuilder end-to-end via `render_views`)