### PR TITLE
feat(marketplace): duplicate listings into current course

### DIFF
--- a/app/controllers/course/assessment/marketplace/listings_controller.rb
+++ b/app/controllers/course/assessment/marketplace/listings_controller.rb
@@ -19,9 +19,35 @@ class Course::Assessment::Marketplace::ListingsController < Course::Assessment::
     end
   end
 
+  def duplicate
+    listings = authorized_listings
+    job = Course::Assessment::Marketplace::DuplicationJob.perform_later(
+      # `presence` first: an omitted tab (the sidebar entry point) must stay nil so the job lets the
+      # duplication fall back to the destination course's first tab, rather than looking for tab 0.
+      listings.map(&:id), current_course, duplicate_params[:destination_tab_id].presence&.to_i,
+      current_user: current_user
+    ).job
+    render partial: 'jobs/submitted', locals: { job: job }
+  end
+
   private
 
   def authorize_access!
     authorize!(:access_marketplace, current_course)
+  end
+
+  def authorized_listings
+    listings = ActsAsTenant.without_tenant do
+      Course::Assessment::Marketplace::Listing.published.where(id: duplicate_params[:listing_ids]).includes(:assessment)
+    end
+    raise CanCan::AccessDenied if listings.empty?
+
+    listings.each { |listing| authorize!(:duplicate_from_marketplace, listing.assessment) }
+    authorize!(:duplicate_to, current_course)
+    listings
+  end
+
+  def duplicate_params
+    params.permit(:destination_tab_id, listing_ids: [])
   end
 end

--- a/app/jobs/course/assessment/marketplace/duplication_job.rb
+++ b/app/jobs/course/assessment/marketplace/duplication_job.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+class Course::Assessment::Marketplace::DuplicationJob < ApplicationJob
+  include TrackableJob
+  include Rails.application.routes.url_helpers
+
+  queue_as :duplication
+
+  protected
+
+  def perform_tracked(listing_ids, destination_course, destination_tab_id, options = {})
+    current_user = options[:current_user]
+    ActsAsTenant.without_tenant do
+      listings = Course::Assessment::Marketplace::Listing.published.where(id: listing_ids)
+      target_tab = find_tab(destination_course, destination_tab_id)
+      last_copy = nil
+      listings.each do |listing|
+        # The adoption row is written by the duplication service itself, which tracks every copy of a
+        # listed assessment regardless of the path that produced it. See
+        # `Course::Duplication::BaseService#record_marketplace_adoptions`.
+        last_copy = duplicate_listing(listing, destination_course, current_user)
+        reparent_into_tab(last_copy, target_tab)
+      end
+      redirect_to assessments_url(destination_course, target_tab || last_copy&.tab)
+    end
+  end
+
+  private
+
+  # @return [Course::Assessment::Tab, nil] The requested tab, or nil when no tab was requested or
+  #   the requested one does not belong to the destination course.
+  def find_tab(destination_course, destination_tab_id)
+    return nil unless destination_tab_id
+
+    destination_course.assessment_categories.
+      flat_map(&:tabs).find { |tab| tab.id == destination_tab_id }
+  end
+
+  def duplicate_listing(listing, destination_course, current_user)
+    source = listing.assessment
+    Course::Duplication::ObjectDuplicationService.duplicate_objects(
+      source.course, destination_course, source, current_user: current_user
+    )
+  end
+
+  def reparent_into_tab(copy, target_tab)
+    return unless target_tab && copy.tab_id != target_tab.id
+
+    copy.tab = target_tab
+    copy.folder.parent = target_tab.category.folder
+    copy.save!
+  end
+
+  # Points at the tab the copies actually landed in. No tab is requested from the sidebar entry
+  # point, and a requested tab may not belong to the destination course -- in both cases the
+  # duplication picks the destination's default tab, and the redirect has to follow it there
+  # instead of naming a tab (and its category) that the user cannot open.
+  def assessments_url(destination_course, tab)
+    redirect_category_id = tab&.category_id || destination_course.assessment_categories.first.id
+    course_assessments_url(destination_course,
+                           category: redirect_category_id,
+                           tab: tab&.id,
+                           host: destination_course.instance.host)
+  end
+end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -250,6 +250,28 @@ class Course::Assessment < ApplicationRecord
     questions.any?(&:csv_downloadable?)
   end
 
+  # Records +duplicate+, a copy of this assessment, as an adoption of this assessment's marketplace
+  # listing. Every copy of a listed assessment is an adoption, whichever duplication path produced
+  # it, so this is called by the duplication services rather than by the marketplace's own job.
+  #
+  # The listing itself is never carried over -- +initialize_duplicate+ below does not duplicate the
+  # +marketplace_listing+ association -- so a copy always starts out unlisted.
+  #
+  # @param [Course::Assessment] duplicate The saved copy of this assessment.
+  # @param [Course] destination_course The course the copy was duplicated into.
+  # @param [User] current_user The user who triggered the duplication.
+  def record_marketplace_adoption(duplicate, destination_course, current_user)
+    return unless marketplace_listing&.published?
+
+    Course::Assessment::Marketplace::Adoption.create!(
+      listing: marketplace_listing,
+      destination_course: destination_course,
+      duplicated_assessment: duplicate,
+      creator: current_user,
+      updater: current_user
+    )
+  end
+
   def initialize_duplicate(duplicator, other) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     copy_attributes(other, duplicator)
     target_tab = initialize_duplicate_tab(duplicator, other)

--- a/app/services/course/duplication/base_service.rb
+++ b/app/services/course/duplication/base_service.rb
@@ -29,4 +29,31 @@ class Course::Duplication::BaseService
   def initialize_duplicator(*)
     raise NotImplementedError, 'To be implemented by specific duplication service.'
   end
+
+  # Hands every duplicated assessment its own copy so it can record a marketplace adoption. Copies
+  # made outside +Course::Assessment::Marketplace::DuplicationJob+ -- selected object duplications
+  # and full course duplications that happen to carry a listed assessment along -- are adoptions
+  # too, and the listing has to know about them to reach every course holding a copy.
+  #
+  # This sweep lives in the duplication service rather than in a model's +after_duplicate_save+
+  # hook because that hook only runs for the top-level objects of an object duplication, and never
+  # at all during a course duplication -- both of which are paths this has to cover. The per-copy
+  # rule itself belongs to the assessment: see +Course::Assessment#record_marketplace_adoption+.
+  #
+  # Must be called inside the duplication transaction, after the duplicates have been saved.
+  def record_marketplace_adoptions
+    destination_course = @options[:destination_course] || duplicator.options[:destination_course]
+    return unless destination_course
+
+    duplicated_assessment_pairs.each do |source, duplicate|
+      source.record_marketplace_adoption(duplicate, destination_course, @options[:current_user])
+    end
+  end
+
+  # @return [Hash] Source-to-duplicate pairs for every assessment this duplication produced.
+  def duplicated_assessment_pairs
+    duplicator.duplicated_objects.select do |source, duplicate|
+      source.is_a?(Course::Assessment) && duplicate&.persisted?
+    end
+  end
 end

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -73,6 +73,7 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
 
         update_course_settings(new_course, source_course)
         update_sidebar_settings(duplicator, new_course, source_course)
+        record_marketplace_adoptions
 
         # As per carrierwave v2.1.0, carrierwave image mounter that retains uploaded file as a cache
         # is reset upon reload (in our case it is new_course.reload).

--- a/app/services/course/duplication/object_duplication_service.rb
+++ b/app/services/course/duplication/object_duplication_service.rb
@@ -45,6 +45,9 @@ class Course::Duplication::ObjectDuplicationService < Course::Duplication::BaseS
       duplicated = duplicator.duplicate(objects)
       before_save(objects, duplicated)
       save_success = duplicated.respond_to?(:save) ? duplicated.save : duplicated.all?(&:save)
+      # Recorded before `after_save` so that a failure here rolls the transaction back before the
+      # models' post-duplication callbacks have run, rather than undoing their work afterwards.
+      record_marketplace_adoptions if save_success
       after_save_success = save_success && after_save(objects, duplicated)
       raise ActiveRecord::Rollback unless after_save_success
 

--- a/client/app/api/course/Marketplace.ts
+++ b/client/app/api/course/Marketplace.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios';
+import { JobSubmitted } from 'types/jobs';
 
 import { MarketplaceListing } from 'course/marketplace/types';
 
@@ -25,5 +26,15 @@ export default class MarketplaceAPI extends BaseCourseAPI {
     AxiosResponse<{ listings: MarketplaceListing[]; canAccess: boolean }>
   > {
     return this.client.get(this.#urlPrefix);
+  }
+
+  duplicate(
+    listingIds: number[],
+    destinationTabId: number | null,
+  ): Promise<AxiosResponse<JobSubmitted>> {
+    return this.client.post(`${this.#urlPrefix}/listings/duplicate`, {
+      listing_ids: listingIds,
+      ...(destinationTabId ? { destination_tab_id: destinationTabId } : {}),
+    });
   }
 }

--- a/client/app/bundles/course/marketplace/components/DuplicateConfirmation.tsx
+++ b/client/app/bundles/course/marketplace/components/DuplicateConfirmation.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { JobStatus } from 'types/jobs';
+
+import Prompt, { PromptText } from 'lib/components/core/dialogs/Prompt';
+import { pollJobRequest } from 'lib/helpers/jobHelpers';
+import toast from 'lib/hooks/toast';
+
+import { duplicateListings } from '../operations';
+import translations from '../translations';
+import { MarketplaceListing } from '../types';
+
+const JOB_POLL_INTERVAL_MS = 2000;
+
+interface Props {
+  listings: Pick<MarketplaceListing, 'id' | 'title'>[];
+  destinationTabId: number | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+const DuplicateConfirmation = ({
+  listings,
+  destinationTabId,
+  open,
+  onClose,
+}: Props): JSX.Element => {
+  const { formatMessage: t } = useIntl();
+  const [submitting, setSubmitting] = useState(false);
+  const [jobUrl, setJobUrl] = useState<string | null>(null);
+  const pollingRef = useRef(false);
+
+  const n = listings.length;
+
+  const confirm = async (): Promise<void> => {
+    setSubmitting(true);
+    try {
+      const url = await duplicateListings(
+        listings.map((l) => l.id),
+        destinationTabId,
+      );
+      setJobUrl(url);
+    } catch {
+      // The request never reached the queue, so there is no job to poll. Releasing `submitting`
+      // here is what keeps the prompt usable for a retry instead of disabled for good.
+      toast.error(t(translations.duplicateFailed, { n }));
+      setSubmitting(false);
+    }
+  };
+
+  // The poller lives with the component that started the job, so unmounting or navigating away
+  // tears it down. `pollingRef` stops a slow response from stacking up overlapping requests.
+  useEffect(() => {
+    if (!jobUrl) return undefined;
+
+    const finish = (succeeded: boolean): void => {
+      setJobUrl(null);
+      setSubmitting(false);
+      if (succeeded) {
+        toast.success(t(translations.duplicateStarted, { n }));
+        onClose();
+      } else {
+        toast.error(t(translations.duplicateFailed, { n }));
+      }
+    };
+
+    const interval = setInterval(() => {
+      if (pollingRef.current) return;
+      pollingRef.current = true;
+      pollJobRequest(jobUrl)
+        .then((response) => {
+          if (response.status === JobStatus.completed) finish(true);
+          else if (response.status === JobStatus.errored) finish(false);
+        })
+        .catch(() => finish(false))
+        .finally(() => {
+          pollingRef.current = false;
+        });
+    }, JOB_POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [jobUrl, n]);
+
+  return (
+    <Prompt
+      disabled={submitting}
+      onClickPrimary={confirm}
+      onClose={onClose}
+      open={open}
+      primaryLabel={t(translations.duplicateConfirm)}
+      title={t(translations.duplicateTitle, { n })}
+    >
+      <PromptText>{t(translations.duplicateBody, { n })}</PromptText>
+    </Prompt>
+  );
+};
+
+export default DuplicateConfirmation;

--- a/client/app/bundles/course/marketplace/components/__test__/DuplicationConfirmation.test.tsx
+++ b/client/app/bundles/course/marketplace/components/__test__/DuplicationConfirmation.test.tsx
@@ -1,0 +1,65 @@
+import { createMockAdapter } from 'mocks/axiosMock';
+import { fireEvent, render, waitFor } from 'test-utils';
+
+import CourseAPI from 'api/course';
+
+import DuplicateConfirmation from '../DuplicateConfirmation';
+
+const mock = createMockAdapter(CourseAPI.marketplace.client);
+beforeEach(() => mock.reset());
+
+const listings = [{ id: 1, title: 'Recursion Drills' }];
+const url = `/courses/${global.courseId}/marketplace/listings/duplicate`;
+
+it('posts a duplication request with the destination tab on confirm', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  const page = render(
+    <DuplicateConfirmation
+      destinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+    listing_ids: [1],
+    destination_tab_id: 42,
+  });
+});
+
+it('omits destination_tab_id when entered without a tab (sidebar entry)', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  const page = render(
+    <DuplicateConfirmation
+      destinationTabId={null}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  const body = JSON.parse(mock.history.post[0].data);
+  expect(body).toMatchObject({ listing_ids: [1] });
+  expect(body).not.toHaveProperty('destination_tab_id'); // backend then defaults to the first tab
+});
+
+// A request that never reaches the queue leaves no job to poll, so nothing else can re-enable the
+// prompt: the confirm button has to come back by itself for the user to be able to retry.
+it('re-enables the prompt when the request itself fails', async () => {
+  mock.onPost(url).reply(500);
+  const page = render(
+    <DuplicateConfirmation
+      destinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+  const button = await page.findByRole('button', { name: /Duplicate/ });
+  fireEvent.click(button);
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  await waitFor(() => expect(button).not.toBeDisabled());
+});

--- a/client/app/bundles/course/marketplace/operations.ts
+++ b/client/app/bundles/course/marketplace/operations.ts
@@ -6,3 +6,17 @@ export const fetchListings = async (): Promise<MarketplaceListing[]> => {
   const response = await CourseAPI.marketplace.index();
   return response.data.listings as MarketplaceListing[];
 };
+
+// Returns the URL of the duplication job to poll. Polling is deliberately left to the caller: it
+// has to be started and torn down by the component that owns the flow, so that navigating away
+// cannot leave an orphaned poller behind.
+export const duplicateListings = async (
+  listingIds: number[],
+  destinationTabId: number | null,
+): Promise<string> => {
+  const response = await CourseAPI.marketplace.duplicate(
+    listingIds,
+    destinationTabId,
+  );
+  return response.data.jobUrl;
+};

--- a/client/app/bundles/course/marketplace/pages/MarketplaceIndex/MarketplaceTable.tsx
+++ b/client/app/bundles/course/marketplace/pages/MarketplaceIndex/MarketplaceTable.tsx
@@ -56,7 +56,9 @@ const MarketplaceTable = ({ listings, onDuplicate }: Props): JSX.Element => {
           <Link opensInNewTab to={l.previewUrl}>
             {t(translations.preview)}
           </Link>
-          {/* Row-level Duplicate button wired in Task 18 */}
+          <button onClick={(): void => onDuplicate([l])} type="button">
+            {t(translations.duplicateConfirm)}
+          </button>
         </>
       ),
     },

--- a/client/app/bundles/course/marketplace/pages/MarketplaceIndex/index.tsx
+++ b/client/app/bundles/course/marketplace/pages/MarketplaceIndex/index.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useIntl } from 'react-intl';
+import { useSearchParams } from 'react-router-dom';
 
 import Page from 'lib/components/core/layouts/Page';
 import Preload from 'lib/components/wrappers/Preload';
 
+import DuplicateConfirmation from '../../components/DuplicateConfirmation';
 import { fetchListings } from '../../operations';
 import translations from '../../translations';
 import { MarketplaceListing } from '../../types';
@@ -12,6 +14,8 @@ import MarketplaceTable from './MarketplaceTable';
 
 const MarketplaceIndex = (): JSX.Element => {
   const { formatMessage: t } = useIntl();
+  const [params] = useSearchParams();
+  const destinationTabId = parseInt(params.get('from_tab') ?? '', 10) || null;
   const [pending, setPending] = useState<MarketplaceListing[]>([]);
 
   return (
@@ -19,6 +23,12 @@ const MarketplaceIndex = (): JSX.Element => {
       {(listings): JSX.Element => (
         <Page title={t(translations.pageTitle)}>
           <MarketplaceTable listings={listings} onDuplicate={setPending} />
+          <DuplicateConfirmation
+            destinationTabId={destinationTabId}
+            listings={pending}
+            onClose={(): void => setPending([])}
+            open={pending.length > 0}
+          />
         </Page>
       )}
     </Preload>

--- a/client/app/bundles/course/marketplace/translations.ts
+++ b/client/app/bundles/course/marketplace/translations.ts
@@ -84,4 +84,28 @@ export default defineMessages({
     defaultMessage:
       '{n, plural, one {Duplicate # assessment} other {Duplicate # assessments}}',
   },
+  duplicateTitle: {
+    id: 'course.marketplace.duplicateTitle',
+    defaultMessage:
+      'Duplicate assessment{n, plural, one {} other {s}} to your course?',
+  },
+  duplicateBody: {
+    id: 'course.marketplace.duplicateBody',
+    defaultMessage:
+      '{n, plural, one {This assessment will be copied to your course.} other {These # assessments will be copied to your course.}}',
+  },
+  duplicateConfirm: {
+    id: 'course.marketplace.duplicateConfirm',
+    defaultMessage: 'Duplicate',
+  },
+  duplicateStarted: {
+    id: 'course.marketplace.duplicateStarted',
+    defaultMessage:
+      '{n, plural, one {Duplicating assessment} other {Duplicating assessments}} started.',
+  },
+  duplicateFailed: {
+    id: 'course.marketplace.duplicateFailed',
+    defaultMessage:
+      '{n, plural, one {Duplicating assessment} other {Duplicating assessments}} failed.',
+  },
 });

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -6137,6 +6137,21 @@
   "course.marketplace.duplicateN": {
     "defaultMessage": "{n, plural, one {Duplicate # assessment} other {Duplicate # assessments}}"
   },
+  "course.marketplace.duplicateTitle": {
+    "defaultMessage": "Duplicate assessment{n, plural, one {} other {s}} to your course?"
+  },
+  "course.marketplace.duplicateBody": {
+    "defaultMessage": "{n, plural, one {This assessment will be copied to your course.} other {These # assessments will be copied to your course.}}"
+  },
+  "course.marketplace.duplicateConfirm": {
+    "defaultMessage": "Duplicate"
+  },
+  "course.marketplace.duplicateStarted": {
+    "defaultMessage": "{n, plural, one {Duplicating assessment} other {Duplicating assessments}} started."
+  },
+  "course.marketplace.duplicateFailed": {
+    "defaultMessage": "{n, plural, one {Duplicating assessment} other {Duplicating assessments}} failed."
+  },
   "course.material.folders.DownloadFolderButton.downloadFolderErrorMessage": {
     "defaultMessage": "Download has failed. Please try again later."
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -6101,6 +6101,21 @@
   "course.marketplace.duplicateN": {
     "defaultMessage": "{n}개 평가 복제"
   },
+  "course.marketplace.duplicateTitle": {
+    "defaultMessage": "평가 {n}개를 내 강좌로 복제하시겠습니까?"
+  },
+  "course.marketplace.duplicateBody": {
+    "defaultMessage": "{n, plural, one {이 평가가 내 강좌로 복사됩니다.} other {이 평가 #개가 내 강좌로 복사됩니다.}}"
+  },
+  "course.marketplace.duplicateConfirm": {
+    "defaultMessage": "복제"
+  },
+  "course.marketplace.duplicateStarted": {
+    "defaultMessage": "{n, plural, one {평가 복제가} other {평가 복제가}} 시작되었습니다."
+  },
+  "course.marketplace.duplicateFailed": {
+    "defaultMessage": "{n, plural, one {평가 복제에} other {평가 복제에}} 실패했습니다."
+  },
   "course.material.folders.DownloadFolderButton.downloadFolderErrorMessage": {
     "defaultMessage": "다운로드에 실패했습니다. 나중에 다시 시도하세요."
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -6095,6 +6095,21 @@
   "course.marketplace.duplicateN": {
     "defaultMessage": "复制 {n} 个评估"
   },
+  "course.marketplace.duplicateTitle": {
+    "defaultMessage": "要将 {n} 个评估复制到你的课程吗？"
+  },
+  "course.marketplace.duplicateBody": {
+    "defaultMessage": "{n, plural, one {此评估将被复制到你的课程。} other {这 # 个评估将被复制到你的课程。}}"
+  },
+  "course.marketplace.duplicateConfirm": {
+    "defaultMessage": "复制"
+  },
+  "course.marketplace.duplicateStarted": {
+    "defaultMessage": "{n, plural, one {评估复制} other {评估复制}}已开始。"
+  },
+  "course.marketplace.duplicateFailed": {
+    "defaultMessage": "{n, plural, one {评估复制} other {评估复制}}失败。"
+  },
   "course.material.folders.DownloadFolderButton.downloadFolderErrorMessage": {
     "defaultMessage": "下载失败。请稍后再试。"
   },

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -2,6 +2,12 @@
 class Duplicator
   attr_reader :options, :mode
 
+  # @!attribute [r] duplicated_objects
+  #   Maps each duplicated source object to its duplicate, or to +nil+ if the source was excluded.
+  #   Duplication services use this to run bookkeeping over everything a duplication produced.
+  #   @return [Hash]
+  attr_reader :duplicated_objects
+
   # Create an instance of Duplicator to track duplicated objects.
   #
   # Options are used to store information that persists across duplication of objects.

--- a/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
+++ b/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
         expect(row).to include('title', 'questionCount', 'adoptions', 'previewUrl', 'duplicateUrl')
       end
 
+      it 'reports the live distinct-course adoption count' do
+        listing = create(:course_assessment_marketplace_listing, published: true)
+        create(:course_assessment_marketplace_adoption, listing: listing, destination_course: create(:course))
+        get :index, params: { course_id: course, format: :json }
+        row = response.parsed_body['listings'].find { |l| l['id'] == listing.id }
+        expect(row['adoptions']).to eq(1)
+      end
+
       it 'reports the actual question count for a listing (not the 0 fallback)' do
         assessment_with_questions = create(:assessment, :with_mcq_question, question_count: 3, course: course)
         listing = create(:course_assessment_marketplace_listing, published: true, assessment: assessment_with_questions)
@@ -44,6 +52,55 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
           expect do
             get :index, params: { course_id: course, format: :json }
           end.to raise_exception(CanCan::AccessDenied)
+        end
+      end
+    end
+    describe 'POST #duplicate' do
+      # `have_enqueued_job` requires the :test adapter; the test env defaults to :background_thread.
+      # `run_rescue` re-enables handle_access_denied so AccessDenied renders 403 rather than
+      # propagating (controller specs bypass_rescue by default — see spec/support/controller_exceptions.rb).
+      run_rescue
+
+      with_active_job_queue_adapter(:test) do
+        let!(:listing) { create(:course_assessment_marketplace_listing, published: true) }
+        let!(:tab) { course.assessment_categories.first.tabs.first }
+
+        it 'enqueues a duplication job with the destination course + tab' do
+          expect do
+            post :duplicate, params: {
+              course_id: course, listing_ids: [listing.id], destination_tab_id: tab.id, format: :json
+            }
+          end.to have_enqueued_job(Course::Assessment::Marketplace::DuplicationJob).
+            with([listing.id], course, tab.id, current_user: manager.user)
+          expect(response.parsed_body['jobUrl']).to be_present
+        end
+
+        it 'enqueues a nil tab when none is given, so the job falls back to the default tab' do
+          expect do
+            post :duplicate, params: { course_id: course, listing_ids: [listing.id], format: :json }
+          end.to have_enqueued_job(Course::Assessment::Marketplace::DuplicationJob).
+            with([listing.id], course, nil, current_user: manager.user)
+        end
+
+        context 'when the listing is unpublished' do
+          let!(:listing) { create(:course_assessment_marketplace_listing, published: false) }
+          it 'is forbidden and enqueues nothing' do
+            expect do
+              post :duplicate, params: {
+                course_id: course, listing_ids: [listing.id], destination_tab_id: tab.id, format: :json
+              }
+            end.not_to have_enqueued_job(Course::Assessment::Marketplace::DuplicationJob)
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context 'when no matching published listing exists (empty/unknown ids)' do
+          it 'is forbidden (renders 403 on the empty set)' do
+            post :duplicate, params: {
+              course_id: course, listing_ids: [-1], destination_tab_id: tab.id, format: :json
+            }
+            expect(response).to have_http_status(:forbidden)
+          end
         end
       end
     end

--- a/spec/jobs/course/assessment/marketplace/duplication_job_spec.rb
+++ b/spec/jobs/course/assessment/marketplace/duplication_job_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Marketplace::DuplicationJob, type: :job do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:source_course) { create(:course) }
+    let(:source_assessment) { create(:assessment, :with_mcq_question, course: source_course) }
+    let(:listing) { create(:course_assessment_marketplace_listing, assessment: source_assessment, published: true) }
+    let(:destination_course) { create(:course) }
+    let(:destination_tab) { destination_course.assessment_categories.first.tabs.first }
+    let(:user) { create(:administrator) }
+
+    def run
+      described_class.perform_now([listing.id], destination_course, destination_tab.id, current_user: user)
+    end
+
+    it 'duplicates the assessment into the destination course' do
+      expect { run }.to change { destination_course.assessments.count }.by(1)
+    end
+
+    it 'lands the copy in the chosen tab' do
+      run
+      copy = destination_course.assessments.order(:created_at).last
+      expect(copy.tab_id).to eq(destination_tab.id)
+    end
+
+    it 'writes an adoption row for the copy' do
+      expect { run }.to change { Course::Assessment::Marketplace::Adoption.count }.by(1)
+      adoption = Course::Assessment::Marketplace::Adoption.last
+      expect(adoption.listing).to eq(listing)
+      expect(adoption.destination_course).to eq(destination_course)
+    end
+
+    it 'counts the same destination course only once across two duplications' do
+      run
+      run
+      expect(listing.reload.adoption_count).to eq(1)
+    end
+
+    it 'skips unpublished listings (job re-filters `.published`)' do
+      listing.update!(published: false)
+      expect { run }.not_to change(destination_course.assessments, :count)
+      # Relative, not `Adoption.count == 0`: the duplication path commits outside the example's
+      # transaction (rows persist across runs), so only the delta from `run` is meaningful here.
+      expect { run }.not_to change(Course::Assessment::Marketplace::Adoption, :count)
+    end
+
+    it 'duplicates every listing when given several ids' do
+      other = create(:course_assessment_marketplace_listing,
+                     assessment: create(:assessment, :with_mcq_question, course: source_course), published: true)
+      expect do
+        described_class.perform_now([listing.id, other.id], destination_course, destination_tab.id, current_user: user)
+      end.to change { destination_course.assessments.count }.by(2).
+        and change { Course::Assessment::Marketplace::Adoption.count }.by(2)
+    end
+
+    # Grandchildren-excluded: an adoption is written for copies of a *listed* assessment, and a copy
+    # is never itself listed, so duplicating an already-adopted copy writes no second-generation
+    # adoption.
+    it 'does not write an adoption for an ordinary ObjectDuplicationService copy' do
+      run
+      copy = destination_course.assessments.order(:created_at).last
+      third_course = create(:course)
+      expect do
+        Course::Duplication::ObjectDuplicationService.duplicate_objects(
+          destination_course, third_course, copy, current_user: user
+        )
+      end.not_to change(Course::Assessment::Marketplace::Adoption, :count)
+    end
+
+    # The sidebar entry point sends no tab, and a tab from another course can be sent by an
+    # out-of-date URL. Neither may leave the redirect pointing at a tab the user cannot open.
+    describe 'when the requested tab is absent or foreign' do
+      def run_with_tab(tab_id)
+        job = described_class.new([listing.id], destination_course, tab_id, current_user: user)
+        job.perform_now
+        job.job
+      end
+
+      let(:default_tab) { destination_course.assessment_categories.first.tabs.first }
+
+      it 'lands the copy in the default tab and redirects there when no tab is given' do
+        job = run_with_tab(nil)
+        copy = destination_course.assessments.order(:created_at).last
+        expect(copy.tab_id).to eq(default_tab.id)
+        expect(job.redirect_to).to include("tab=#{default_tab.id}", "category=#{default_tab.category_id}")
+      end
+
+      it 'ignores a tab belonging to another course' do
+        foreign_tab = create(:course).assessment_categories.first.tabs.first
+        job = run_with_tab(foreign_tab.id)
+        copy = destination_course.assessments.order(:created_at).last
+        expect(copy.tab_id).to eq(default_tab.id)
+        expect(job.redirect_to).not_to include("tab=#{foreign_tab.id}")
+      end
+    end
+
+    it 'redirects to the requested tab and its own category' do
+      job = described_class.new([listing.id], destination_course, destination_tab.id, current_user: user)
+      job.perform_now
+      expect(job.job.redirect_to).to include("tab=#{destination_tab.id}", "category=#{destination_tab.category_id}")
+    end
+
+    describe 'the listing is not itself duplicated' do
+      # Force the listing before the `expect` blocks below: `run` would otherwise create it lazily
+      # inside the block and register as a listing-count change of its own.
+      before { listing }
+
+      it 'does not create a second listing row' do
+        expect { run }.not_to change(Course::Assessment::Marketplace::Listing, :count)
+      end
+
+      it 'leaves the duplicated copy unlisted' do
+        run
+        copy = destination_course.assessments.order(:created_at).last
+        expect(copy.marketplace_listing).to be_nil
+      end
+
+      it 'holds the listing count steady while adoptions accumulate' do
+        other_course = create(:course)
+        expect do
+          run
+          described_class.perform_now([listing.id], other_course,
+                                      other_course.assessment_categories.first.tabs.first.id,
+                                      current_user: user)
+        end.to change { listing.reload.adoption_count }.from(0).to(2).
+          and not_change(Course::Assessment::Marketplace::Listing, :count)
+      end
+    end
+
+    # A listed assessment can leave its course by paths that do not go through this job: an
+    # instructor duplicating selected objects, or a full course duplication that carries the
+    # listed assessment along. Those copies must obey the same two rules as the job's copies --
+    # the listing stays singular, and the destination course is recorded as an adopter.
+    describe 'manual duplication of a listed assessment' do
+      let(:manual_destination) { create(:course) }
+
+      before { listing }
+
+      def duplicate_selected_objects
+        Course::Duplication::ObjectDuplicationService.duplicate_objects(
+          source_course, manual_destination, source_assessment, current_user: user
+        )
+      end
+
+      def duplicate_whole_course
+        Course::Duplication::CourseDuplicationService.duplicate_course(
+          source_course, current_user: user, new_title: "#{source_course.title} copy"
+        )
+      end
+
+      context 'when duplicating selected objects' do
+        it 'does not create a second listing row' do
+          expect { duplicate_selected_objects }.not_to change(Course::Assessment::Marketplace::Listing, :count)
+        end
+
+        it 'leaves the manual copy unlisted' do
+          copy = duplicate_selected_objects
+          expect(copy.marketplace_listing).to be_nil
+        end
+
+        it 'records the destination course as an adopter' do
+          copy = nil
+          expect { copy = duplicate_selected_objects }.
+            to change(Course::Assessment::Marketplace::Adoption, :count).by(1)
+          adoption = Course::Assessment::Marketplace::Adoption.order(:id).last
+          expect(adoption.listing).to eq(listing)
+          expect(adoption.destination_course).to eq(manual_destination)
+          expect(adoption.duplicated_assessment).to eq(copy)
+        end
+      end
+
+      context 'when duplicating the whole course' do
+        it 'does not create a second listing row' do
+          expect { duplicate_whole_course }.not_to change(Course::Assessment::Marketplace::Listing, :count)
+        end
+
+        it 'leaves the copied assessment unlisted' do
+          new_course = duplicate_whole_course
+          expect(new_course.assessments.map(&:marketplace_listing)).to all(be_nil)
+        end
+
+        it 'records the new course as an adopter' do
+          new_course = nil
+          expect { new_course = duplicate_whole_course }.
+            to change(Course::Assessment::Marketplace::Adoption, :count).by(1)
+          adoption = Course::Assessment::Marketplace::Adoption.order(:id).last
+          expect(adoption.listing).to eq(listing)
+          expect(adoption.destination_course).to eq(new_course)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- add DuplicationJob: copies listings into a course tab, writes adoption
- add bulk duplicate endpoint enqueuing the job for selected listings
- add DuplicateConfirmation modal with row + bulk triggers, job polling
- add MarketplaceAPI.duplicate and duplicateListings poll operation
- serialize and assert live distinct-course adoption count in index