### PR TITLE
feat(marketplace): typed allow-list gate with open-to-everyone toggle

### DIFF
--- a/app/controllers/system/admin/marketplace_allowlist_rules_controller.rb
+++ b/app/controllers/system/admin/marketplace_allowlist_rules_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+class System::Admin::MarketplaceAllowlistRulesController < System::Admin::Controller
+  load_and_authorize_resource :allowlist_rule,
+                              class: 'Course::Assessment::Marketplace::AllowlistRule',
+                              parent: false
+
+  def index
+    @allowlist_rules = @allowlist_rules.includes(:user, :instance)
+  end
+
+  def create
+    if @allowlist_rule.save
+      # `render partial:` (not `render 'rule'`) — the view is the `_rule` partial. Mirrors
+      # System::Admin::AnnouncementsController#create (`render partial: '.../announcement_data'`).
+      render partial: 'rule', locals: { rule: @allowlist_rule }, status: :ok
+    else
+      render json: { errors: @allowlist_rule.errors.full_messages.to_sentence }, status: :bad_request
+    end
+  end
+
+  def destroy
+    if @allowlist_rule.destroy
+      head :ok
+    else
+      render json: { errors: @allowlist_rule.errors.full_messages.to_sentence }, status: :bad_request
+    end
+  end
+
+  private
+
+  def allowlist_rule_params
+    params.require(:allowlist_rule).permit(:rule_type, :user_id, :instance_id, :email_domain)
+  end
+end

--- a/app/controllers/system/admin/marketplace_allowlist_rules_controller.rb
+++ b/app/controllers/system/admin/marketplace_allowlist_rules_controller.rb
@@ -5,7 +5,10 @@ class System::Admin::MarketplaceAllowlistRulesController < System::Admin::Contro
                               parent: false
 
   def index
-    @allowlist_rules = @allowlist_rules.includes(:user, :instance)
+    # "Everyone" is a page-level mode, not a table row: expose its presence as `@everyone_rule`
+    # and show only the scoped rules in the table.
+    @everyone_rule = @allowlist_rules.rule_type_everyone.first
+    @allowlist_rules = @allowlist_rules.where.not(rule_type: :everyone).includes(:user, :instance)
   end
 
   def create

--- a/app/models/components/course/assessment_marketplace_ability_component.rb
+++ b/app/models/components/course/assessment_marketplace_ability_component.rb
@@ -4,11 +4,25 @@ module Course::AssessmentMarketplaceAbilityComponent
 
   def define_permissions
     allow_admins_publish_to_marketplace if user&.administrator?
-    allow_managers_access_marketplace if course_user&.manager_or_owner?
+    if course_user&.manager_or_owner?
+      if marketplace_visible_to_user?
+        allow_managers_access_marketplace
+      else
+        # `Course::CourseAbilityComponent` grants managers/owners a blanket `can :manage, Course`,
+        # which (CanCan's `:manage` matches any action) would otherwise satisfy
+        # `:access_marketplace` regardless of the allow-list. This component runs after that one
+        # in the `define_permissions` super chain, so a `cannot` here takes precedence.
+        cannot :access_marketplace, Course, id: course.id
+      end
+    end
     super
   end
 
   private
+
+  def marketplace_visible_to_user?
+    user&.administrator? || Course::Assessment::Marketplace::AllowlistRule.grants_access?(user)
+  end
 
   def allow_admins_publish_to_marketplace
     can :publish_to_marketplace, Course::Assessment

--- a/app/models/course/assessment/marketplace/allowlist_rule.rb
+++ b/app/models/course/assessment/marketplace/allowlist_rule.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Course::Assessment::Marketplace::AllowlistRule < ApplicationRecord
-  enum :rule_type, { user: 0, instance: 1, email_domain: 2 }, prefix: true
+  enum :rule_type, { user: 0, instance: 1, email_domain: 2, everyone: 3 }, prefix: true
 
   belongs_to :user, class_name: 'User', inverse_of: false, optional: true
   belongs_to :instance, inverse_of: false, optional: true
@@ -8,17 +8,21 @@ class Course::Assessment::Marketplace::AllowlistRule < ApplicationRecord
   validates :user, presence: true, if: :rule_type_user?
   validates :instance, presence: true, if: :rule_type_instance?
   validates :email_domain, presence: true, if: :rule_type_email_domain?
+  # "Everyone" is the widest rule; only one may exist. Paired with a partial unique index.
+  validates :rule_type, uniqueness: true, if: :rule_type_everyone?
 
   # Whether the marketplace is visible to +user+ per the allow-list. The rules table itself is
   # global (not tenant-scoped), but `user.instance_users` IS tenant-scoped (acts_as_tenant), so
   # in a request an `instance` rule matches only while browsing the allow-listed instance —
   # it grants that instance's users access *there*, not membership-based access everywhere.
+  # An `everyone` rule grants every authenticated user (the `nil` guard still excludes anonymous).
   # @param [User] user
   # @return [Boolean]
   def self.grants_access?(user)
     return false unless user
 
-    rule_type_user.where(user_id: user.id).exists? ||
+    rule_type_everyone.exists? ||
+      rule_type_user.where(user_id: user.id).exists? ||
       rule_type_instance.where(instance_id: user.instance_users.select(:instance_id)).exists? ||
       email_domain_matches?(user)
   end

--- a/app/models/course/assessment/marketplace/allowlist_rule.rb
+++ b/app/models/course/assessment/marketplace/allowlist_rule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class Course::Assessment::Marketplace::AllowlistRule < ApplicationRecord
+  enum :rule_type, { user: 0, instance: 1, email_domain: 2 }, prefix: true
+
+  belongs_to :user, class_name: 'User', inverse_of: false, optional: true
+  belongs_to :instance, inverse_of: false, optional: true
+
+  validates :user, presence: true, if: :rule_type_user?
+  validates :instance, presence: true, if: :rule_type_instance?
+  validates :email_domain, presence: true, if: :rule_type_email_domain?
+
+  # Whether the marketplace is visible to +user+ per the allow-list. Global (non-tenant):
+  # the marketplace is cross-instance, so rules are evaluated without a tenant scope.
+  # @param [User] user
+  # @return [Boolean]
+  def self.grants_access?(user)
+    return false unless user
+
+    rule_type_user.where(user_id: user.id).exists? ||
+      rule_type_instance.where(instance_id: user.instance_users.select(:instance_id)).exists? ||
+      email_domain_matches?(user)
+  end
+
+  # @param [User] user
+  # @return [Boolean]
+  def self.email_domain_matches?(user)
+    domains = user.emails.pluck(:email).filter_map { |e| e.split('@').last&.downcase }.uniq
+    return false if domains.empty?
+
+    rule_type_email_domain.where('LOWER(email_domain) IN (?)', domains).exists?
+  end
+end

--- a/app/models/course/assessment/marketplace/allowlist_rule.rb
+++ b/app/models/course/assessment/marketplace/allowlist_rule.rb
@@ -9,8 +9,10 @@ class Course::Assessment::Marketplace::AllowlistRule < ApplicationRecord
   validates :instance, presence: true, if: :rule_type_instance?
   validates :email_domain, presence: true, if: :rule_type_email_domain?
 
-  # Whether the marketplace is visible to +user+ per the allow-list. Global (non-tenant):
-  # the marketplace is cross-instance, so rules are evaluated without a tenant scope.
+  # Whether the marketplace is visible to +user+ per the allow-list. The rules table itself is
+  # global (not tenant-scoped), but `user.instance_users` IS tenant-scoped (acts_as_tenant), so
+  # in a request an `instance` rule matches only while browsing the allow-listed instance —
+  # it grants that instance's users access *there*, not membership-based access everywhere.
   # @param [User] user
   # @return [Boolean]
   def self.grants_access?(user)

--- a/app/views/system/admin/marketplace_allowlist_rules/_rule.json.jbuilder
+++ b/app/views/system/admin/marketplace_allowlist_rules/_rule.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+json.id rule.id
+json.ruleType rule.rule_type
+json.userId rule.user_id
+json.userName rule.user&.name
+json.instanceId rule.instance_id
+json.instanceName rule.instance&.name
+json.emailDomain rule.email_domain

--- a/app/views/system/admin/marketplace_allowlist_rules/index.json.jbuilder
+++ b/app/views/system/admin/marketplace_allowlist_rules/index.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+json.rules @allowlist_rules do |rule|
+  json.partial! 'rule', rule: rule
+end

--- a/app/views/system/admin/marketplace_allowlist_rules/index.json.jbuilder
+++ b/app/views/system/admin/marketplace_allowlist_rules/index.json.jbuilder
@@ -2,3 +2,4 @@
 json.rules @allowlist_rules do |rule|
   json.partial! 'rule', rule: rule
 end
+json.everyoneRuleId @everyone_rule&.id

--- a/client/app/api/system/Admin.ts
+++ b/client/app/api/system/Admin.ts
@@ -182,7 +182,7 @@ export default class AdminAPI extends BaseSystemAPI {
    * Fetches the marketplace allow-list rules.
    */
   indexMarketplaceAllowlistRules(): Promise<
-    AxiosResponse<{ rules: AllowlistRuleData[] }>
+    AxiosResponse<{ rules: AllowlistRuleData[]; everyoneRuleId: number | null }>
   > {
     return this.client.get(
       `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules`,
@@ -205,6 +205,17 @@ export default class AdminAPI extends BaseSystemAPI {
           email_domain: params.emailDomain,
         },
       },
+    );
+  }
+
+  /**
+   * Opens the marketplace to everyone by creating the single `everyone` allow-list rule.
+   * Returns the created rule; only its `id` is consumed (to later restrict).
+   */
+  openMarketplaceToEveryone(): Promise<AxiosResponse<{ id: number }>> {
+    return this.client.post(
+      `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules`,
+      { allowlist_rule: { rule_type: 'everyone' } },
     );
   }
 

--- a/client/app/api/system/Admin.ts
+++ b/client/app/api/system/Admin.ts
@@ -5,6 +5,10 @@ import {
 } from 'types/course/announcements';
 import { CourseListData } from 'types/system/courses';
 import { InstanceListData, InstancePermissions } from 'types/system/instances';
+import {
+  AllowlistRuleData,
+  AllowlistRuleFormData,
+} from 'types/system/marketplaceAllowlist';
 import { AdminStats, UserListData } from 'types/users';
 
 import BaseSystemAPI from '../Base';
@@ -172,5 +176,44 @@ export default class AdminAPI extends BaseSystemAPI {
    */
   getDeploymentInfo(): Promise<AxiosResponse<DeploymentInfo>> {
     return this.client.get(`${AdminAPI.#urlPrefix}/deployment_info`);
+  }
+
+  /**
+   * Fetches the marketplace allow-list rules.
+   */
+  indexMarketplaceAllowlistRules(): Promise<
+    AxiosResponse<{ rules: AllowlistRuleData[] }>
+  > {
+    return this.client.get(
+      `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules`,
+    );
+  }
+
+  /**
+   * Creates a marketplace allow-list rule.
+   */
+  createMarketplaceAllowlistRule(
+    params: AllowlistRuleFormData,
+  ): Promise<AxiosResponse<AllowlistRuleData>> {
+    return this.client.post(
+      `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules`,
+      {
+        allowlist_rule: {
+          rule_type: params.ruleType,
+          user_id: params.userId,
+          instance_id: params.instanceId,
+          email_domain: params.emailDomain,
+        },
+      },
+    );
+  }
+
+  /**
+   * Deletes a marketplace allow-list rule.
+   */
+  deleteMarketplaceAllowlistRule(id: number): Promise<AxiosResponse> {
+    return this.client.delete(
+      `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules/${id}`,
+    );
   }
 }

--- a/client/app/bundles/system/admin/admin/AdminNavigator.tsx
+++ b/client/app/bundles/system/admin/admin/AdminNavigator.tsx
@@ -5,6 +5,7 @@ import {
   Category,
   Chat,
   Group,
+  Storefront,
 } from '@mui/icons-material';
 
 import useTranslation from 'lib/hooks/useTranslation';
@@ -31,6 +32,10 @@ const translations = defineMessages({
   getHelp: {
     id: 'system.admin.admin.AdminNavigator.getHelp',
     defaultMessage: 'Get Help',
+  },
+  marketplace: {
+    id: 'system.admin.admin.AdminNavigator.marketplace',
+    defaultMessage: 'Marketplace Access',
   },
   systemAdminPanel: {
     id: 'system.admin.admin.AdminNavigator.systemAdminPanel',
@@ -63,6 +68,11 @@ const AdminNavigator = (): JSX.Element => {
           icon: <AutoStories />,
           title: t(translations.courses),
           path: '/admin/courses',
+        },
+        {
+          icon: <Storefront />,
+          title: t(translations.marketplace),
+          path: '/admin/marketplace_allowlist_rules',
         },
         {
           icon: <Chat />,

--- a/client/app/bundles/system/admin/admin/components/MarketplaceAllowlistModeBanner.tsx
+++ b/client/app/bundles/system/admin/admin/components/MarketplaceAllowlistModeBanner.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Alert, Button } from '@mui/material';
+
+import Prompt from 'lib/components/core/dialogs/Prompt';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  openToEveryone: boolean;
+  onOpenToEveryone: () => Promise<void>;
+  onRestrict: () => Promise<void>;
+}
+
+const translations = defineMessages({
+  scopedTitle: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.scopedTitle',
+    defaultMessage: 'Access is limited to the rules below.',
+  },
+  everyoneTitle: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.everyoneTitle',
+    defaultMessage:
+      'The marketplace is open to all course managers. The rules below are preserved but inactive.',
+  },
+  openButton: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.openButton',
+    defaultMessage: 'Open to everyone',
+  },
+  restrictButton: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.restrictButton',
+    defaultMessage: 'Restrict to scoped rules',
+  },
+  openConfirmTitle: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.openConfirmTitle',
+    defaultMessage: 'Open marketplace to everyone?',
+  },
+  openConfirmBody: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.openConfirmBody',
+    defaultMessage:
+      'This makes the marketplace visible to all course managers and owners in every instance. You can restrict it again at any time; your scoped rules are kept.',
+  },
+  restrictConfirmTitle: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.restrictConfirmTitle',
+    defaultMessage: 'Restrict to scoped rules?',
+  },
+  restrictConfirmBody: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.restrictConfirmBody',
+    defaultMessage:
+      'The marketplace will again be limited to the rules below. Managers not covered by a rule will lose access.',
+  },
+  confirmOpen: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.confirmOpen',
+    defaultMessage: 'Open to everyone',
+  },
+  confirmRestrict: {
+    id: 'system.admin.admin.MarketplaceAllowlistModeBanner.confirmRestrict',
+    defaultMessage: 'Restrict',
+  },
+});
+
+const MarketplaceAllowlistModeBanner = ({
+  openToEveryone,
+  onOpenToEveryone,
+  onRestrict,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleConfirm = async (): Promise<void> => {
+    setSubmitting(true);
+    try {
+      await (openToEveryone ? onRestrict() : onOpenToEveryone());
+      setIsConfirmOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Alert
+        action={
+          <Button
+            color="inherit"
+            disabled={submitting}
+            onClick={(): void => setIsConfirmOpen(true)}
+            size="small"
+          >
+            {openToEveryone
+              ? t(translations.restrictButton)
+              : t(translations.openButton)}
+          </Button>
+        }
+        className="mb-4"
+        severity={openToEveryone ? 'success' : 'info'}
+      >
+        {openToEveryone
+          ? t(translations.everyoneTitle)
+          : t(translations.scopedTitle)}
+      </Alert>
+
+      <Prompt
+        onClickPrimary={handleConfirm}
+        onClose={(): void => setIsConfirmOpen(false)}
+        open={isConfirmOpen}
+        primaryColor={openToEveryone ? 'error' : 'primary'}
+        primaryDisabled={submitting}
+        primaryLabel={
+          openToEveryone
+            ? t(translations.confirmRestrict)
+            : t(translations.confirmOpen)
+        }
+        title={
+          openToEveryone
+            ? t(translations.restrictConfirmTitle)
+            : t(translations.openConfirmTitle)
+        }
+      >
+        {openToEveryone
+          ? t(translations.restrictConfirmBody)
+          : t(translations.openConfirmBody)}
+      </Prompt>
+    </>
+  );
+};
+
+export default MarketplaceAllowlistModeBanner;

--- a/client/app/bundles/system/admin/admin/components/forms/MarketplaceAllowlistRuleForm.tsx
+++ b/client/app/bundles/system/admin/admin/components/forms/MarketplaceAllowlistRuleForm.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { MenuItem, TextField } from '@mui/material';
+import {
+  AllowlistRuleFormData,
+  AllowlistRuleType,
+} from 'types/system/marketplaceAllowlist';
+
+import Prompt from 'lib/components/core/dialogs/Prompt';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: AllowlistRuleFormData) => Promise<void>;
+}
+
+const translations = defineMessages({
+  title: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.title',
+    defaultMessage: 'Add marketplace access rule',
+  },
+  ruleType: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.ruleType',
+    defaultMessage: 'Rule type',
+  },
+  typeUser: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.typeUser',
+    defaultMessage: 'Specific user',
+  },
+  typeInstance: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.typeInstance',
+    defaultMessage: 'All users in an instance',
+  },
+  typeEmailDomain: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.typeEmailDomain',
+    defaultMessage: 'All users with an email domain',
+  },
+  userId: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.userId',
+    defaultMessage: 'User ID',
+  },
+  instanceId: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.instanceId',
+    defaultMessage: 'Instance ID',
+  },
+  emailDomain: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.emailDomain',
+    defaultMessage: 'Email domain (e.g. schools.gov.sg)',
+  },
+  add: {
+    id: 'system.admin.admin.MarketplaceAllowlistRuleForm.add',
+    defaultMessage: 'Add',
+  },
+});
+
+const MarketplaceAllowlistRuleForm = ({
+  open,
+  onClose,
+  onSubmit,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [ruleType, setRuleType] = useState<AllowlistRuleType>('email_domain');
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = (): void => {
+    setRuleType('email_domain');
+    setValue('');
+  };
+
+  const handleClose = (): void => {
+    reset();
+    onClose();
+  };
+
+  const buildData = (): AllowlistRuleFormData => {
+    switch (ruleType) {
+      case 'user':
+        return { ruleType, userId: parseInt(value, 10) };
+      case 'instance':
+        return { ruleType, instanceId: parseInt(value, 10) };
+      default:
+        return { ruleType, emailDomain: value.trim() };
+    }
+  };
+
+  const submit = async (): Promise<void> => {
+    setSubmitting(true);
+    await onSubmit(buildData()).finally(() => setSubmitting(false));
+    reset();
+  };
+
+  const valueLabel = {
+    user: t(translations.userId),
+    instance: t(translations.instanceId),
+    email_domain: t(translations.emailDomain),
+  }[ruleType];
+
+  return (
+    <Prompt
+      disabled={submitting || value.trim() === ''}
+      onClickPrimary={submit}
+      onClose={handleClose}
+      open={open}
+      primaryLabel={t(translations.add)}
+      title={t(translations.title)}
+    >
+      <div className="mt-2 space-y-4">
+        <TextField
+          fullWidth
+          label={t(translations.ruleType)}
+          onChange={(e): void => {
+            setRuleType(e.target.value as AllowlistRuleType);
+            setValue('');
+          }}
+          select
+          value={ruleType}
+        >
+          <MenuItem value="user">{t(translations.typeUser)}</MenuItem>
+          <MenuItem value="instance">{t(translations.typeInstance)}</MenuItem>
+          <MenuItem value="email_domain">
+            {t(translations.typeEmailDomain)}
+          </MenuItem>
+        </TextField>
+
+        <TextField
+          fullWidth
+          label={valueLabel}
+          onChange={(e): void => setValue(e.target.value)}
+          type={ruleType === 'email_domain' ? 'text' : 'number'}
+          value={value}
+        />
+      </div>
+    </Prompt>
+  );
+};
+
+export default MarketplaceAllowlistRuleForm;

--- a/client/app/bundles/system/admin/admin/components/forms/MarketplaceAllowlistRuleForm.tsx
+++ b/client/app/bundles/system/admin/admin/components/forms/MarketplaceAllowlistRuleForm.tsx
@@ -99,8 +99,9 @@ const MarketplaceAllowlistRuleForm = ({
 
   return (
     <Prompt
-      disabled={submitting || value.trim() === ''}
+      cancelDisabled={submitting}
       onClickPrimary={submit}
+      primaryDisabled={submitting || value.trim() === ''}
       onClose={handleClose}
       open={open}
       primaryLabel={t(translations.add)}

--- a/client/app/bundles/system/admin/admin/components/tables/MarketplaceAllowlistTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/MarketplaceAllowlistTable.tsx
@@ -1,0 +1,103 @@
+import { defineMessages } from 'react-intl';
+import { AllowlistRuleData } from 'types/system/marketplaceAllowlist';
+
+import DeleteButton from 'lib/components/core/buttons/DeleteButton';
+import Table, { ColumnTemplate } from 'lib/components/table';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  rules: AllowlistRuleData[];
+  onDelete: (id: number) => Promise<void>;
+}
+
+const translations = defineMessages({
+  colType: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.colType',
+    defaultMessage: 'Type',
+  },
+  colTarget: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.colTarget',
+    defaultMessage: 'Grants access to',
+  },
+  colActions: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.colActions',
+    defaultMessage: 'Actions',
+  },
+  typeUser: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.typeUser',
+    defaultMessage: 'User',
+  },
+  typeInstance: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.typeInstance',
+    defaultMessage: 'Instance',
+  },
+  typeEmailDomain: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.typeEmailDomain',
+    defaultMessage: 'Email domain',
+  },
+  deleteConfirm: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.deleteConfirm',
+    defaultMessage: 'Remove this marketplace access rule?',
+  },
+  empty: {
+    id: 'system.admin.admin.MarketplaceAllowlistTable.empty',
+    defaultMessage:
+      'No access rules yet. The marketplace is hidden from everyone except system administrators.',
+  },
+});
+
+const MarketplaceAllowlistTable = ({ rules, onDelete }: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  const typeLabels: Record<AllowlistRuleData['ruleType'], string> = {
+    user: t(translations.typeUser),
+    instance: t(translations.typeInstance),
+    email_domain: t(translations.typeEmailDomain),
+  };
+
+  const targetOf = (rule: AllowlistRuleData): string => {
+    switch (rule.ruleType) {
+      case 'user':
+        return rule.userName ?? `#${rule.userId}`;
+      case 'instance':
+        return rule.instanceName ?? `#${rule.instanceId}`;
+      default:
+        return rule.emailDomain ?? '';
+    }
+  };
+
+  const columns: ColumnTemplate<AllowlistRuleData>[] = [
+    {
+      of: 'ruleType',
+      title: t(translations.colType),
+      cell: (rule) => typeLabels[rule.ruleType],
+    },
+    {
+      id: 'target',
+      title: t(translations.colTarget),
+      cell: (rule) => targetOf(rule),
+    },
+    {
+      id: 'actions',
+      title: t(translations.colActions),
+      cell: (rule) => (
+        <DeleteButton
+          confirmMessage={t(translations.deleteConfirm)}
+          disabled={false}
+          onClick={(): Promise<void> => onDelete(rule.id)}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      columns={columns}
+      data={rules}
+      getRowId={(rule): string => rule.id.toString()}
+      renderEmpty={t(translations.empty)}
+    />
+  );
+};
+
+export default MarketplaceAllowlistTable;

--- a/client/app/bundles/system/admin/admin/components/tables/MarketplaceAllowlistTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/MarketplaceAllowlistTable.tsx
@@ -8,6 +8,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 interface Props {
   rules: AllowlistRuleData[];
   onDelete: (id: number) => Promise<void>;
+  disabled?: boolean;
 }
 
 const translations = defineMessages({
@@ -46,7 +47,11 @@ const translations = defineMessages({
   },
 });
 
-const MarketplaceAllowlistTable = ({ rules, onDelete }: Props): JSX.Element => {
+const MarketplaceAllowlistTable = ({
+  rules,
+  onDelete,
+  disabled = false,
+}: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const typeLabels: Record<AllowlistRuleData['ruleType'], string> = {
@@ -83,7 +88,7 @@ const MarketplaceAllowlistTable = ({ rules, onDelete }: Props): JSX.Element => {
       cell: (rule) => (
         <DeleteButton
           confirmMessage={t(translations.deleteConfirm)}
-          disabled={false}
+          disabled={disabled}
           onClick={(): Promise<void> => onDelete(rule.id)}
         />
       ),
@@ -91,12 +96,14 @@ const MarketplaceAllowlistTable = ({ rules, onDelete }: Props): JSX.Element => {
   ];
 
   return (
-    <Table
-      columns={columns}
-      data={rules}
-      getRowId={(rule): string => rule.id.toString()}
-      renderEmpty={t(translations.empty)}
-    />
+    <div className={disabled ? 'opacity-50' : undefined}>
+      <Table
+        columns={columns}
+        data={rules}
+        getRowId={(rule): string => rule.id.toString()}
+        renderEmpty={t(translations.empty)}
+      />
+    </div>
   );
 };
 

--- a/client/app/bundles/system/admin/admin/pages/MarketplaceAllowlistIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/MarketplaceAllowlistIndex.tsx
@@ -1,0 +1,109 @@
+import { FC, useEffect, useState } from 'react';
+import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
+import {
+  AllowlistRuleData,
+  AllowlistRuleFormData,
+} from 'types/system/marketplaceAllowlist';
+
+import SystemAPI from 'api/system';
+import AddButton from 'lib/components/core/buttons/AddButton';
+import Page from 'lib/components/core/layouts/Page';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import toast from 'lib/hooks/toast';
+
+import MarketplaceAllowlistRuleForm from '../components/forms/MarketplaceAllowlistRuleForm';
+import MarketplaceAllowlistTable from '../components/tables/MarketplaceAllowlistTable';
+
+type Props = WrappedComponentProps;
+
+const translations = defineMessages({
+  header: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.header',
+    defaultMessage: 'Marketplace Access',
+  },
+  addRule: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.addRule',
+    defaultMessage: 'Add rule',
+  },
+  fetchFailure: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.fetchFailure',
+    defaultMessage: 'Failed to load marketplace access rules.',
+  },
+  createSuccess: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.createSuccess',
+    defaultMessage: 'Access rule added.',
+  },
+  createFailure: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.createFailure',
+    defaultMessage: 'Failed to add access rule.',
+  },
+  deleteSuccess: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.deleteSuccess',
+    defaultMessage: 'Access rule removed.',
+  },
+  deleteFailure: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.deleteFailure',
+    defaultMessage: 'Failed to remove access rule.',
+  },
+});
+
+const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [rules, setRules] = useState<AllowlistRuleData[]>([]);
+
+  useEffect(() => {
+    SystemAPI.admin
+      .indexMarketplaceAllowlistRules()
+      .then((response) => setRules(response.data.rules))
+      .catch(() => toast.error(intl.formatMessage(translations.fetchFailure)))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleCreate = async (data: AllowlistRuleFormData): Promise<void> => {
+    try {
+      const response =
+        await SystemAPI.admin.createMarketplaceAllowlistRule(data);
+      setRules((current) => [...current, response.data]);
+      toast.success(intl.formatMessage(translations.createSuccess));
+      setIsFormOpen(false);
+    } catch {
+      toast.error(intl.formatMessage(translations.createFailure));
+    }
+  };
+
+  const handleDelete = async (id: number): Promise<void> => {
+    try {
+      await SystemAPI.admin.deleteMarketplaceAllowlistRule(id);
+      setRules((current) => current.filter((rule) => rule.id !== id));
+      toast.success(intl.formatMessage(translations.deleteSuccess));
+    } catch {
+      toast.error(intl.formatMessage(translations.deleteFailure));
+    }
+  };
+
+  if (isLoading) return <LoadingIndicator />;
+
+  return (
+    <Page title={intl.formatMessage(translations.header)}>
+      <AddButton
+        className="float-right"
+        fixed
+        id="add-allowlist-rule-button"
+        onClick={(): void => setIsFormOpen(true)}
+      >
+        {intl.formatMessage(translations.addRule)}
+      </AddButton>
+
+      <MarketplaceAllowlistTable onDelete={handleDelete} rules={rules} />
+
+      <MarketplaceAllowlistRuleForm
+        onClose={(): void => setIsFormOpen(false)}
+        onSubmit={handleCreate}
+        open={isFormOpen}
+      />
+    </Page>
+  );
+};
+
+export default injectIntl(MarketplaceAllowlistIndex);

--- a/client/app/bundles/system/admin/admin/pages/MarketplaceAllowlistIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/MarketplaceAllowlistIndex.tsx
@@ -12,6 +12,7 @@ import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import toast from 'lib/hooks/toast';
 
 import MarketplaceAllowlistRuleForm from '../components/forms/MarketplaceAllowlistRuleForm';
+import MarketplaceAllowlistModeBanner from '../components/MarketplaceAllowlistModeBanner';
 import MarketplaceAllowlistTable from '../components/tables/MarketplaceAllowlistTable';
 
 type Props = WrappedComponentProps;
@@ -45,20 +46,42 @@ const translations = defineMessages({
     id: 'system.admin.admin.MarketplaceAllowlistIndex.deleteFailure',
     defaultMessage: 'Failed to remove access rule.',
   },
+  openSuccess: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.openSuccess',
+    defaultMessage: 'Marketplace opened to all course managers.',
+  },
+  openFailure: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.openFailure',
+    defaultMessage: 'Failed to open the marketplace to everyone.',
+  },
+  restrictSuccess: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.restrictSuccess',
+    defaultMessage: 'Marketplace restricted to the scoped rules.',
+  },
+  restrictFailure: {
+    id: 'system.admin.admin.MarketplaceAllowlistIndex.restrictFailure',
+    defaultMessage: 'Failed to restrict the marketplace.',
+  },
 });
 
 const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [rules, setRules] = useState<AllowlistRuleData[]>([]);
+  const [everyoneRuleId, setEveryoneRuleId] = useState<number | null>(null);
 
   useEffect(() => {
     SystemAPI.admin
       .indexMarketplaceAllowlistRules()
-      .then((response) => setRules(response.data.rules))
+      .then((response) => {
+        setRules(response.data.rules);
+        setEveryoneRuleId(response.data.everyoneRuleId ?? null);
+      })
       .catch(() => toast.error(intl.formatMessage(translations.fetchFailure)))
       .finally(() => setIsLoading(false));
   }, []);
+
+  const openToEveryone = everyoneRuleId !== null;
 
   const handleCreate = async (data: AllowlistRuleFormData): Promise<void> => {
     try {
@@ -82,12 +105,34 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
     }
   };
 
+  const handleOpenToEveryone = async (): Promise<void> => {
+    try {
+      const response = await SystemAPI.admin.openMarketplaceToEveryone();
+      setEveryoneRuleId(response.data.id);
+      toast.success(intl.formatMessage(translations.openSuccess));
+    } catch {
+      toast.error(intl.formatMessage(translations.openFailure));
+    }
+  };
+
+  const handleRestrict = async (): Promise<void> => {
+    if (everyoneRuleId === null) return;
+    try {
+      await SystemAPI.admin.deleteMarketplaceAllowlistRule(everyoneRuleId);
+      setEveryoneRuleId(null);
+      toast.success(intl.formatMessage(translations.restrictSuccess));
+    } catch {
+      toast.error(intl.formatMessage(translations.restrictFailure));
+    }
+  };
+
   if (isLoading) return <LoadingIndicator />;
 
   return (
     <Page title={intl.formatMessage(translations.header)}>
       <AddButton
         className="float-right"
+        disabled={openToEveryone}
         fixed
         id="add-allowlist-rule-button"
         onClick={(): void => setIsFormOpen(true)}
@@ -95,7 +140,17 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
         {intl.formatMessage(translations.addRule)}
       </AddButton>
 
-      <MarketplaceAllowlistTable onDelete={handleDelete} rules={rules} />
+      <MarketplaceAllowlistModeBanner
+        onOpenToEveryone={handleOpenToEveryone}
+        onRestrict={handleRestrict}
+        openToEveryone={openToEveryone}
+      />
+
+      <MarketplaceAllowlistTable
+        disabled={openToEveryone}
+        onDelete={handleDelete}
+        rules={rules}
+      />
 
       <MarketplaceAllowlistRuleForm
         onClose={(): void => setIsFormOpen(false)}

--- a/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceAllowlistIndex.test.tsx
+++ b/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceAllowlistIndex.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { createMockAdapter } from 'mocks/axiosMock';
-import { fireEvent, render, waitFor } from 'test-utils';
+import { fireEvent, render, waitFor, within } from 'test-utils';
 
 import SystemAPI from 'api/system';
 
@@ -10,6 +10,7 @@ const mock = createMockAdapter(SystemAPI.admin.client);
 beforeEach(() => mock.reset());
 
 const INDEX_URL = '/admin/marketplace_allowlist_rules';
+const EMAIL_DOMAIN = 'schools.gov.sg';
 const RULES = [
   {
     id: 1,
@@ -18,7 +19,7 @@ const RULES = [
     userName: null,
     instanceId: null,
     instanceName: null,
-    emailDomain: 'schools.gov.sg',
+    emailDomain: EMAIL_DOMAIN,
   },
 ];
 
@@ -26,7 +27,7 @@ it('renders the allow-list rules from the API', async () => {
   mock.onGet(INDEX_URL).reply(200, { rules: RULES });
   const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
 
-  await waitFor(() => expect(page.getByText('schools.gov.sg')).toBeVisible());
+  await waitFor(() => expect(page.getByText(EMAIL_DOMAIN)).toBeVisible());
 });
 
 it('creates an email-domain rule from the add dialog', async () => {
@@ -65,13 +66,81 @@ it('deletes a rule after confirmation', async () => {
   mock.onDelete(`${INDEX_URL}/1`).reply(200);
 
   const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
-  await waitFor(() => expect(page.getByText('schools.gov.sg')).toBeVisible());
+  await waitFor(() => expect(page.getByText(EMAIL_DOMAIN)).toBeVisible());
 
   fireEvent.click(page.getByTestId('DeleteIconButton'));
   fireEvent.click(page.getByRole('button', { name: 'Delete' }));
 
   await waitFor(() => expect(mock.history.delete).toHaveLength(1));
   await waitFor(() =>
-    expect(page.queryByText('schools.gov.sg')).not.toBeInTheDocument(),
+    expect(page.queryByText(EMAIL_DOMAIN)).not.toBeInTheDocument(),
   );
+});
+
+it('opens the marketplace to everyone from the banner', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: null });
+  mock.onPost(INDEX_URL).reply(200, { id: 99 });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(page.getByText(EMAIL_DOMAIN)).toBeVisible());
+
+  // Scoped state: banner offers "Open to everyone".
+  fireEvent.click(page.getByRole('button', { name: 'Open to everyone' }));
+
+  // Confirm inside the dialog (its primary button shares the label, so scope to the dialog).
+  const dialog = page.getByRole('dialog');
+  fireEvent.click(
+    within(dialog).getByRole('button', { name: 'Open to everyone' }),
+  );
+
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  expect(JSON.parse(mock.history.post[0].data)).toEqual({
+    allowlist_rule: { rule_type: 'everyone' },
+  });
+  await waitFor(() =>
+    expect(
+      page.getByText(
+        'The marketplace is open to all course managers. The rules below are preserved but inactive.',
+      ),
+    ).toBeVisible(),
+  );
+});
+
+it('restricts the marketplace to scoped rules from the banner', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: 42 });
+  mock.onDelete(`${INDEX_URL}/42`).reply(200);
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() =>
+    expect(
+      page.getByText(
+        'The marketplace is open to all course managers. The rules below are preserved but inactive.',
+      ),
+    ).toBeVisible(),
+  );
+
+  fireEvent.click(
+    page.getByRole('button', { name: 'Restrict to scoped rules' }),
+  );
+  const dialog = page.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Restrict' }));
+
+  await waitFor(() => expect(mock.history.delete).toHaveLength(1));
+  expect(mock.history.delete[0].url).toBe(`${INDEX_URL}/42`);
+  await waitFor(() =>
+    expect(
+      page.getByText('Access is limited to the rules below.'),
+    ).toBeVisible(),
+  );
+});
+
+it('disables adding and removing rules while the marketplace is open to everyone', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: 42 });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(page.getByText(EMAIL_DOMAIN)).toBeVisible());
+
+  // Open-to-everyone means the scoped rules are preserved but inactive: no add, no delete.
+  expect(page.getByRole('button', { name: 'Add rule' })).toBeDisabled();
+  expect(page.getByTestId('DeleteIconButton')).toBeDisabled();
 });

--- a/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceAllowlistIndex.test.tsx
+++ b/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceAllowlistIndex.test.tsx
@@ -1,0 +1,77 @@
+import userEvent from '@testing-library/user-event';
+import { createMockAdapter } from 'mocks/axiosMock';
+import { fireEvent, render, waitFor } from 'test-utils';
+
+import SystemAPI from 'api/system';
+
+import MarketplaceAllowlistIndex from '../MarketplaceAllowlistIndex';
+
+const mock = createMockAdapter(SystemAPI.admin.client);
+beforeEach(() => mock.reset());
+
+const INDEX_URL = '/admin/marketplace_allowlist_rules';
+const RULES = [
+  {
+    id: 1,
+    ruleType: 'email_domain',
+    userId: null,
+    userName: null,
+    instanceId: null,
+    instanceName: null,
+    emailDomain: 'schools.gov.sg',
+  },
+];
+
+it('renders the allow-list rules from the API', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES });
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+
+  await waitFor(() => expect(page.getByText('schools.gov.sg')).toBeVisible());
+});
+
+it('creates an email-domain rule from the add dialog', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: [] });
+  mock.onPost(INDEX_URL).reply(200, {
+    id: 2,
+    ruleType: 'email_domain',
+    userId: null,
+    userName: null,
+    instanceId: null,
+    instanceName: null,
+    emailDomain: 'nus.edu.sg',
+  });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(mock.history.get).toHaveLength(1));
+
+  fireEvent.click(page.getByText('Add rule'));
+  // Rule type defaults to Email domain; fill the value field. (Search fields need userEvent —
+  // see client/CLAUDE-testing.md; a plain TextField accepts userEvent.type too.)
+  await userEvent.type(
+    page.getByLabelText('Email domain (e.g. schools.gov.sg)'),
+    'nus.edu.sg',
+  );
+  fireEvent.click(page.getByRole('button', { name: 'Add' }));
+
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  expect(JSON.parse(mock.history.post[0].data)).toEqual({
+    allowlist_rule: { rule_type: 'email_domain', email_domain: 'nus.edu.sg' },
+  });
+  await waitFor(() => expect(page.getByText('nus.edu.sg')).toBeVisible());
+});
+
+it('deletes a rule after confirmation', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES });
+  mock.onDelete(`${INDEX_URL}/1`).reply(200);
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(page.getByText('schools.gov.sg')).toBeVisible());
+
+  fireEvent.click(page.getByTestId('DeleteIconButton'));
+  fireEvent.click(page.getByRole('button', { name: 'Delete' }));
+
+  await waitFor(() => expect(mock.history.delete).toHaveLength(1));
+  await waitFor(() =>
+    expect(page.queryByText('schools.gov.sg')).not.toBeInTheDocument(),
+  );
+});

--- a/client/app/routers/courseless/systemAdmin.tsx
+++ b/client/app/routers/courseless/systemAdmin.tsx
@@ -68,6 +68,17 @@ const systemAdminRouter: Translated<RouteObject> = (_) => ({
       }),
     },
     {
+      path: 'marketplace_allowlist_rules',
+      lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
+        Component: (
+          await import(
+            /* webpackChunkName: 'MarketplaceAllowlistIndex' */
+            'bundles/system/admin/admin/pages/MarketplaceAllowlistIndex'
+          )
+        ).default,
+      }),
+    },
+    {
       path: 'get_help',
       lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
         Component: (

--- a/client/app/types/system/marketplaceAllowlist.ts
+++ b/client/app/types/system/marketplaceAllowlist.ts
@@ -1,0 +1,18 @@
+export type AllowlistRuleType = 'user' | 'instance' | 'email_domain';
+
+export interface AllowlistRuleData {
+  id: number;
+  ruleType: AllowlistRuleType;
+  userId: number | null;
+  userName: string | null;
+  instanceId: number | null;
+  instanceName: string | null;
+  emailDomain: string | null;
+}
+
+export interface AllowlistRuleFormData {
+  ruleType: AllowlistRuleType;
+  userId?: number;
+  instanceId?: number;
+  emailDomain?: string;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
       get '/' => 'admin#index'
       get 'deployment_info' => 'admin#deployment_info'
       resources :announcements, only: [:index, :create, :update, :destroy]
+      resources :marketplace_allowlist_rules, only: [:index, :create, :destroy]
       resources :instances, only: [:index, :create, :update, :destroy]
       resources :users, only: [:index, :update, :destroy]
       resources :courses, only: [:index, :destroy]

--- a/db/migrate/20260707000003_create_course_assessment_marketplace_allowlist_rules.rb
+++ b/db/migrate/20260707000003_create_course_assessment_marketplace_allowlist_rules.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class CreateCourseAssessmentMarketplaceAllowlistRules < ActiveRecord::Migration[7.2]
+  def change
+    create_table :course_assessment_marketplace_allowlist_rules do |t|
+      t.integer :rule_type, null: false
+      t.references :user, foreign_key: { to_table: :users }, null: true, index: true
+      t.references :instance, foreign_key: true, null: true, index: true
+      t.string :email_domain, null: true
+      t.timestamps
+    end
+    add_index :course_assessment_marketplace_allowlist_rules, :email_domain
+  end
+end

--- a/db/migrate/20260716000001_add_everyone_uniqueness_to_marketplace_allowlist_rules.rb
+++ b/db/migrate/20260716000001_add_everyone_uniqueness_to_marketplace_allowlist_rules.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class AddEveryoneUniquenessToMarketplaceAllowlistRules < ActiveRecord::Migration[7.2]
+  def change
+    # `everyone` is rule_type == 3 (enum below). A partial unique index enforces at most one such row,
+    # the DB-level backstop for the model's `uniqueness` validation (repo rule: pair the two).
+    add_index :course_assessment_marketplace_allowlist_rules, :rule_type,
+              unique: true, where: 'rule_type = 3',
+              name: 'index_marketplace_allowlist_rules_one_everyone'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_07_000003) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_16_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -295,6 +295,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_07_000003) do
     t.datetime "updated_at", null: false
     t.index ["email_domain"], name: "idx_on_email_domain_6577b88d4e"
     t.index ["instance_id"], name: "idx_on_instance_id_77af5cff27"
+    t.index ["rule_type"], name: "index_marketplace_allowlist_rules_one_everyone", unique: true, where: "(rule_type = 3)"
     t.index ["user_id"], name: "index_course_assessment_marketplace_allowlist_rules_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_07_000002) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -284,6 +284,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_07_000002) do
     t.index ["listing_id", "destination_course_id"], name: "index_cama_on_listing_id_and_destination_course_id"
     t.index ["listing_id"], name: "fk__course_assessment_marketplace_adoptions_listing_id"
     t.index ["updater_id"], name: "fk__cama_updater_id"
+  end
+
+  create_table "course_assessment_marketplace_allowlist_rules", force: :cascade do |t|
+    t.integer "rule_type", null: false
+    t.bigint "user_id"
+    t.bigint "instance_id"
+    t.string "email_domain"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_domain"], name: "idx_on_email_domain_6577b88d4e"
+    t.index ["instance_id"], name: "idx_on_instance_id_77af5cff27"
+    t.index ["user_id"], name: "index_course_assessment_marketplace_allowlist_rules_on_user_id"
   end
 
   create_table "course_assessment_marketplace_listings", force: :cascade do |t|
@@ -1956,6 +1968,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_07_000002) do
   add_foreign_key "course_assessment_marketplace_adoptions", "courses", column: "destination_course_id", name: "fk_cama_destination_course_id", on_delete: :cascade
   add_foreign_key "course_assessment_marketplace_adoptions", "users", column: "creator_id", name: "fk_course_assessment_marketplace_adoptions_creator_id"
   add_foreign_key "course_assessment_marketplace_adoptions", "users", column: "updater_id", name: "fk_course_assessment_marketplace_adoptions_updater_id"
+  add_foreign_key "course_assessment_marketplace_allowlist_rules", "instances"
+  add_foreign_key "course_assessment_marketplace_allowlist_rules", "users"
   add_foreign_key "course_assessment_marketplace_listings", "course_assessments", column: "assessment_id", name: "fk_course_assessment_marketplace_listings_assessment_id", on_delete: :cascade
   add_foreign_key "course_assessment_marketplace_listings", "users", column: "creator_id", name: "fk_course_assessment_marketplace_listings_creator_id"
   add_foreign_key "course_assessment_marketplace_listings", "users", column: "publisher_id", name: "fk_course_assessment_marketplace_listings_publisher_id"

--- a/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
+++ b/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
     before { controller_sign_in(controller, manager.user) }
 
     describe 'GET #index' do
+      before { create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: manager.user) }
+
       let!(:published) { create(:course_assessment_marketplace_listing, published: true) }
       let!(:unpublished) { create(:course_assessment_marketplace_listing, published: false) }
 
@@ -110,6 +112,8 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
       # propagating (controller specs bypass_rescue by default — see spec/support/controller_exceptions.rb).
       run_rescue
 
+      before { create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: manager.user) }
+
       with_active_job_queue_adapter(:test) do
         let!(:listing) { create(:course_assessment_marketplace_listing, published: true) }
         let!(:tab) { course.assessment_categories.first.tabs.first }
@@ -150,6 +154,8 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
       # `run_rescue` re-enables handle_access_denied so a denied preview renders 403 rather than
       # propagating (controller specs bypass_rescue by default — see spec/support/controller_exceptions.rb).
       run_rescue
+
+      before { create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: manager.user) }
 
       let!(:listing) do
         assessment = create(:assessment, course: create(:course))
@@ -196,6 +202,7 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
       ActsAsTenant.with_tenant(home_instance) do
         course = create(:course)
         manager = create(:course_manager, course: course)
+        create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: manager.user)
         controller_sign_in(controller, manager.user)
         # Point the request at the home instance's host so `deduce_tenant` resolves it (this
         # describe is outside `with_tenant`, which would otherwise set the host header for us).

--- a/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
+++ b/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
@@ -69,6 +69,41 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
         end
       end
     end
+    describe 'GET #index visibility gate' do
+      subject { get :index, params: { course_id: course.id, format: :json } }
+
+      context 'when the manager is not on the allow-list' do
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'denies access' do
+          expect { subject }.to raise_exception(CanCan::AccessDenied)
+        end
+      end
+
+      context 'when an allow-list rule matches the manager' do
+        before do
+          create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: manager.user)
+          controller_sign_in(controller, manager.user)
+        end
+
+        it 'permits access' do
+          expect { subject }.not_to raise_exception
+        end
+      end
+
+      context 'when the user is a system administrator' do
+        let(:admin) { create(:administrator) }
+        before do
+          create(:course_manager, course: course, user: admin)
+          controller_sign_in(controller, admin)
+        end
+
+        it 'permits access without an allow-list rule' do
+          expect { subject }.not_to raise_exception
+        end
+      end
+    end
+
     describe 'POST #duplicate' do
       # `have_enqueued_job` requires the :test adapter; the test env defaults to :background_thread.
       # `run_rescue` re-enables handle_access_denied so AccessDenied renders 403 rather than

--- a/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
+++ b/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
     describe 'GET #index visibility gate' do
       subject { get :index, params: { course_id: course.id, format: :json } }
 
+      # The suite runs with `use_transactional_fixtures = false` (see spec/rails_helper.rb), so rows
+      # persist across examples/runs. `:everyone` is a DB-enforced singleton (one row allowed), so any
+      # leftover row here would either block a later `create(:everyone)` with a uniqueness error or
+      # spuriously widen access in a sibling example. Mirrors the cleanup in
+      # spec/models/course/assessment/marketplace/allowlist_rule_spec.rb.
+      before { Course::Assessment::Marketplace::AllowlistRule.delete_all }
+
       context 'when the manager is not on the allow-list' do
         before { controller_sign_in(controller, manager.user) }
 
@@ -102,6 +109,29 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
 
         it 'permits access without an allow-list rule' do
           expect { subject }.not_to raise_exception
+        end
+      end
+
+      context "when an 'everyone' rule exists" do
+        before do
+          create(:course_assessment_marketplace_allowlist_rule, :everyone)
+          controller_sign_in(controller, manager.user)
+        end
+
+        it 'permits a manager who has no matching scoped rule' do
+          expect { subject }.not_to raise_exception
+        end
+      end
+
+      context "when an 'everyone' rule exists but the user is a student" do
+        let(:student) { create(:course_student, course: course).user }
+        before do
+          create(:course_assessment_marketplace_allowlist_rule, :everyone)
+          controller_sign_in(controller, student)
+        end
+
+        it 'still denies a non-manager (the manager gate holds)' do
+          expect { subject }.to raise_exception(CanCan::AccessDenied)
         end
       end
     end

--- a/spec/controllers/course/assessment/marketplace/questions_controller_spec.rb
+++ b/spec/controllers/course/assessment/marketplace/questions_controller_spec.rb
@@ -35,7 +35,10 @@ RSpec.describe Course::Assessment::Marketplace::QuestionsController, type: :cont
     let(:destination_course) { create(:course) }
     let(:manager) { create(:course_manager, course: destination_course).user }
 
-    before { controller_sign_in(controller, manager) }
+    before do
+      create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: manager)
+      controller_sign_in(controller, manager)
+    end
 
     it 'serializes the question across instances' do
       get :show, as: :json, params: {

--- a/spec/controllers/course/assessment_marketplace_component_spec.rb
+++ b/spec/controllers/course/assessment_marketplace_component_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe Course::AssessmentMarketplaceComponent do
 
     context 'when the user can access the marketplace (course manager)' do
       let(:user) { create(:course_manager, course: course).user }
-      before { controller_sign_in(controller, user) }
+      before do
+        create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: user)
+        controller_sign_in(controller, user)
+      end
 
       it 'exposes an admin sidebar item pointing at the marketplace' do
         item = subject.sidebar_items.find { |i| i[:key] == :admin_marketplace }

--- a/spec/controllers/system/admin/marketplace_allowlist_rules_controller_spec.rb
+++ b/spec/controllers/system/admin/marketplace_allowlist_rules_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe System::Admin::MarketplaceAllowlistRulesController, type: :controller do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:admin) { create(:administrator) }
+    before { controller_sign_in(controller, admin) }
+
+    describe 'POST #create' do
+      subject do
+        post :create, format: :json, params: {
+          allowlist_rule: { rule_type: 'email_domain', email_domain: 'schools.gov.sg' }
+        }
+      end
+
+      it 'creates an email-domain rule' do
+        expect { subject }.
+          to change { Course::Assessment::Marketplace::AllowlistRule.count }.by(1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'GET #index' do
+      render_views
+      # This suite runs with `use_transactional_fixtures = false` and no DatabaseCleaner, so rows
+      # created by earlier local runs of this factory persist in the dev/test DB; scope to a clean
+      # slate here so the size assertion below is deterministic.
+      before do
+        Course::Assessment::Marketplace::AllowlistRule.delete_all
+        create(:course_assessment_marketplace_allowlist_rule, :for_email_domain)
+      end
+
+      it 'lists the rules' do
+        get :index, format: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['rules'].size).to eq(1)
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      let!(:rule) { create(:course_assessment_marketplace_allowlist_rule, :for_email_domain) }
+
+      it 'removes the rule' do
+        expect { delete :destroy, format: :json, params: { id: rule.id } }.
+          to change { Course::Assessment::Marketplace::AllowlistRule.count }.by(-1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'authorization' do
+      run_rescue
+
+      it 'forbids a non-administrator' do
+        controller_sign_in(controller, create(:user))
+        get :index, format: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/controllers/system/admin/marketplace_allowlist_rules_controller_spec.rb
+++ b/spec/controllers/system/admin/marketplace_allowlist_rules_controller_spec.rb
@@ -39,6 +39,55 @@ RSpec.describe System::Admin::MarketplaceAllowlistRulesController, type: :contro
       end
     end
 
+    describe 'GET #index everyone-mode reporting' do
+      render_views
+      before do
+        Course::Assessment::Marketplace::AllowlistRule.delete_all
+        create(:course_assessment_marketplace_allowlist_rule, :for_email_domain)
+      end
+
+      it 'reports everyoneRuleId null and lists only scoped rules when no everyone rule exists' do
+        get :index, format: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['everyoneRuleId']).to be_nil
+        expect(response.parsed_body['rules'].size).to eq(1)
+      end
+
+      it 'reports everyoneRuleId and excludes the everyone rule from the list' do
+        everyone = create(:course_assessment_marketplace_allowlist_rule, :everyone)
+        get :index, format: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['everyoneRuleId']).to eq(everyone.id)
+        expect(response.parsed_body['rules'].map { |r| r['ruleType'] }).not_to include('everyone')
+        expect(response.parsed_body['rules'].size).to eq(1)
+      end
+    end
+
+    describe "POST #create with rule_type 'everyone'" do
+      before { Course::Assessment::Marketplace::AllowlistRule.delete_all }
+
+      it 'opens the marketplace to everyone' do
+        expect do
+          post :create, format: :json, params: { allowlist_rule: { rule_type: 'everyone' } }
+        end.to change { Course::Assessment::Marketplace::AllowlistRule.rule_type_everyone.count }.by(1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'rejects a second everyone rule' do
+        create(:course_assessment_marketplace_allowlist_rule, :everyone)
+        expect do
+          post :create, format: :json, params: { allowlist_rule: { rule_type: 'everyone' } }
+        end.not_to(change { Course::Assessment::Marketplace::AllowlistRule.count })
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'surfaces the uniqueness error when rejected' do
+        create(:course_assessment_marketplace_allowlist_rule, :everyone)
+        post :create, format: :json, params: { allowlist_rule: { rule_type: 'everyone' } }
+        expect(response.parsed_body['errors']).to include('already been taken')
+      end
+    end
+
     describe 'DELETE #destroy' do
       let!(:rule) { create(:course_assessment_marketplace_allowlist_rule, :for_email_domain) }
 

--- a/spec/factories/course_assessment_marketplace_allowlist_rules.rb
+++ b/spec/factories/course_assessment_marketplace_allowlist_rules.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_marketplace_allowlist_rule,
+          class: 'Course::Assessment::Marketplace::AllowlistRule' do
+    trait :for_user do
+      rule_type { :user }
+      association :user
+    end
+    trait :for_instance do
+      rule_type { :instance }
+      association :instance
+    end
+    trait :for_email_domain do
+      rule_type { :email_domain }
+      email_domain { 'schools.gov.sg' }
+    end
+  end
+end

--- a/spec/factories/course_assessment_marketplace_allowlist_rules.rb
+++ b/spec/factories/course_assessment_marketplace_allowlist_rules.rb
@@ -14,5 +14,8 @@ FactoryBot.define do
       rule_type { :email_domain }
       email_domain { 'schools.gov.sg' }
     end
+    trait :everyone do
+      rule_type { :everyone }
+    end
   end
 end

--- a/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
+++ b/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Marketplace::AllowlistRule, type: :model do
+  let!(:instance) { Instance.default }
+
+  before do
+    Course::Assessment::Marketplace::AllowlistRule.delete_all
+    User::Email.delete_all
+  end
+
+  with_tenant(:instance) do
+    describe 'validations' do
+      it 'requires user for a user rule' do
+        rule = build(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: nil)
+        expect(rule).not_to be_valid
+        expect(rule.errors[:user]).to be_present
+      end
+
+      it 'requires email_domain for an email_domain rule' do
+        rule = build(:course_assessment_marketplace_allowlist_rule,
+                     rule_type: :email_domain, email_domain: nil)
+        expect(rule).not_to be_valid
+        expect(rule.errors[:email_domain]).to be_present
+      end
+    end
+
+    describe '.grants_access?' do
+      it 'is false for a nil user' do
+        expect(described_class.grants_access?(nil)).to be(false)
+      end
+
+      it 'is false when no rule matches' do
+        user = create(:user)
+        create(:course_assessment_marketplace_allowlist_rule, :for_email_domain,
+               email_domain: 'nomatch.example')
+        expect(described_class.grants_access?(user)).to be(false)
+      end
+
+      it 'matches an explicit user rule' do
+        user = create(:user)
+        create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: user)
+        expect(described_class.grants_access?(user)).to be(true)
+      end
+
+      it 'matches an instance rule when the user belongs to that instance' do
+        user = create(:user)
+        create(:course_assessment_marketplace_allowlist_rule, rule_type: :instance, instance: instance)
+        expect(described_class.grants_access?(user)).to be(true)
+      end
+
+      it 'matches an email-domain rule case-insensitively' do
+        user_email = create(:user_email, email: 'testuser@Schools.GOV.sg')
+        user = user_email.user
+        create(:course_assessment_marketplace_allowlist_rule, :for_email_domain,
+               email_domain: 'schools.gov.sg')
+        expect(described_class.grants_access?(user)).to be(true)
+      end
+
+      it 'does not match a different email domain' do
+        user_email = create(:user_email, email: 'testuser@other.edu')
+        user = user_email.user
+        create(:course_assessment_marketplace_allowlist_rule, :for_email_domain,
+               email_domain: 'schools.gov.sg')
+        expect(described_class.grants_access?(user)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
+++ b/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe Course::Assessment::Marketplace::AllowlistRule, type: :model do
         expect(rule).not_to be_valid
         expect(rule.errors[:email_domain]).to be_present
       end
+
+      it 'requires instance for an instance rule' do
+        rule = build(:course_assessment_marketplace_allowlist_rule, rule_type: :instance, instance: nil)
+        expect(rule).not_to be_valid
+        expect(rule.errors[:instance]).to be_present
+      end
+
+      it 'is valid as an everyone rule with no target fields' do
+        rule = build(:course_assessment_marketplace_allowlist_rule, :everyone)
+        expect(rule).to be_valid
+      end
+
+      it 'allows only one everyone rule' do
+        create(:course_assessment_marketplace_allowlist_rule, :everyone)
+        duplicate = build(:course_assessment_marketplace_allowlist_rule, :everyone)
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:rule_type]).to be_present
+      end
     end
 
     describe '.grants_access?' do
@@ -74,6 +92,17 @@ RSpec.describe Course::Assessment::Marketplace::AllowlistRule, type: :model do
         create(:course_assessment_marketplace_allowlist_rule, :for_email_domain,
                email_domain: 'schools.gov.sg')
         expect(described_class.grants_access?(user)).to be(false)
+      end
+
+      it 'matches any user when an everyone rule exists' do
+        user = create(:user)
+        create(:course_assessment_marketplace_allowlist_rule, :everyone)
+        expect(described_class.grants_access?(user)).to be(true)
+      end
+
+      it 'is false for a nil user even when an everyone rule exists' do
+        create(:course_assessment_marketplace_allowlist_rule, :everyone)
+        expect(described_class.grants_access?(nil)).to be(false)
       end
     end
   end

--- a/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
+++ b/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Course::Assessment::Marketplace::AllowlistRule, type: :model do
         expect(described_class.grants_access?(user)).to be(true)
       end
 
+      it 'does not match an instance rule for another instance under the current tenant' do
+        user = create(:user)
+        other_instance = create(:instance)
+        ActsAsTenant.with_tenant(other_instance) { InstanceUser.create!(user: user) }
+        create(:course_assessment_marketplace_allowlist_rule, rule_type: :instance,
+                                                              instance: other_instance)
+        # `user.instance_users` is tenant-scoped (acts_as_tenant), so an instance rule grants
+        # access only while browsing the allow-listed instance — membership elsewhere is invisible.
+        expect(described_class.grants_access?(user)).to be(false)
+      end
+
       it 'matches an email-domain rule case-insensitively' do
         user_email = create(:user_email, email: 'testuser@Schools.GOV.sg')
         user = user_email.user

--- a/spec/models/course/assessment_marketplace_ability_spec.rb
+++ b/spec/models/course/assessment_marketplace_ability_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Course::Assessment::Marketplace, type: :model do
     context 'when the user is a course manager' do
       let(:course_user) { create(:course_manager, course: course) }
       let(:user) { course_user.user }
+      before { create(:course_assessment_marketplace_allowlist_rule, rule_type: :user, user: user) }
 
       it { is_expected.to be_able_to(:access_marketplace, course) }
       it { is_expected.not_to be_able_to(:publish_to_marketplace, build(:assessment)) }


### PR DESCRIPTION
## Summary

Marketplace visibility is currently all-or-nothing, which blocks a staged rollout. This PR gates the marketplace behind a global typed allow-list: course managers/owners only see it if a rule matches them (specific user, whole instance, or email domain), while system administrators always retain access. It adds a self-serve System::Admin page to manage the rules, and a deliberate, reversible "open to everyone" mode that opens the marketplace to all course managers everywhere in one action without discarding the scoped rules built up during the staged rollout.

## Design decisions

- Rules live in one global (non tenant-scoped) table with a typed `rule_type` enum (user / instance / email_domain / everyone) - a single pool keeps administration in one place, and instance rules still scope per-instance naturally because the match goes through `user.instance_users`, which is tenant-scoped at query time
- "Open to everyone" is a fourth rule type rather than a separate settings flag - enable inserts one `everyone` row, disable deletes it, so scoped rules survive a temporary opening untouched and the existing create/destroy endpoints are reused with no new routes
- The admin page surfaces everyone-mode as a page-level banner + toggle instead of a fourth table row - while open, the scoped table renders dimmed with add/delete disabled, making both the active mode and its reversibility obvious at a glance
- At most one `everyone` row, enforced by a model uniqueness validation paired with a partial unique DB index

## Regression prevention

- Model specs cover: per-type presence validations, the single-everyone-rule constraint, and `grants_access?` matching for user rules, instance rules (including per-instance scoping under the current tenant), case-insensitive email-domain rules, the everyone rule, and nil-user denial
- Controller specs cover: the visibility gate (manager denied without a matching rule, allowed with one or under everyone, sysadmin bypass with zero rules, students still denied even under everyone), admin CRUD, everyone-mode JSON reporting (`everyoneRuleId`, everyone row excluded from the scoped list), and rejection of a second everyone rule with 400
- Frontend tests cover: the rules table and add/delete flows, the open-to-everyone and restrict confirm flows (request payloads and banner copy transitions), and disabled add/delete controls while open
- Manually tested end to end: gate hidden for non-allow-listed managers (sidebar and direct URL), each rule type granting access, per-instance scoping, sysadmin bypass, students never gaining access, admin page CRUD and empty state, open-to-everyone and restrict round trip with scoped rules preserved, and double-open rejection
- Behaviour change for existing users is intentional: managers lose marketplace access until allow-listed (or the marketplace is opened to everyone); system administrators are unaffected