### PR TITLE
feat(marketplace): destination tab picker and completion feedback

### DIFF
--- a/app/controllers/course/assessment/marketplace/listings_controller.rb
+++ b/app/controllers/course/assessment/marketplace/listings_controller.rb
@@ -32,6 +32,7 @@ class Course::Assessment::Marketplace::ListingsController < Course::Assessment::
 
       @assessment = @listing.assessment
       authorize!(:preview_in_marketplace, @assessment)
+      @destination_tabs = destination_tabs
       render 'show'
     end
   end

--- a/app/views/course/assessment/marketplace/listings/show.json.jbuilder
+++ b/app/views/course/assessment/marketplace/listings/show.json.jbuilder
@@ -3,6 +3,15 @@ json.id @assessment.id
 json.title @assessment.title
 json.description format_ckeditor_rich_text(@assessment.description)
 
+# The current course's category/tab structure, so the duplicate confirmation dialog can offer the
+# destination tab picker from the listing detail page (the listing itself lives in another course).
+json.destinationTabs @destination_tabs do |tab|
+  json.id tab[:id]
+  json.title tab[:title]
+  json.categoryId tab[:category_id]
+  json.categoryTitle tab[:category_title]
+end
+
 json.gradingMode @assessment.autograded? ? 'autograded' : 'manual'
 json.baseExp @assessment.base_exp if @assessment.base_exp > 0
 json.bonusExp @assessment.time_bonus_exp if @assessment.time_bonus_exp > 0

--- a/client/app/bundles/course/duplication/components/TypeBadge/index.tsx
+++ b/client/app/bundles/course/duplication/components/TypeBadge/index.tsx
@@ -45,15 +45,18 @@ const translations: Record<DuplicableItemType, MessageDescriptor> =
     },
   });
 
-const TypeBadge: FC<{ text?: string; itemType: DuplicableItemType }> = ({
-  text,
-  itemType,
-}) => {
+const TypeBadge: FC<{
+  text?: string;
+  itemType: DuplicableItemType;
+  dense?: boolean;
+}> = ({ text, itemType, dense = false }) => {
   const { t } = useTranslation();
 
   return (
     <Typography
-      className="px-2 py-1 border border-solid rounded-md mr-3"
+      className={`px-2 ${
+        dense ? 'py-0.5' : 'py-1'
+      } border border-solid rounded-md mr-3`}
       fontWeight="inherit"
       variant="caption"
     >

--- a/client/app/bundles/course/marketplace/components/DestinationTabPicker.tsx
+++ b/client/app/bundles/course/marketplace/components/DestinationTabPicker.tsx
@@ -1,0 +1,93 @@
+import { FC } from 'react';
+import {
+  Card,
+  CardContent,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+} from '@mui/material';
+
+import TypeBadge from 'course/duplication/components/TypeBadge';
+
+import { DestinationTab } from '../types';
+
+interface Group {
+  categoryId: number;
+  categoryTitle: string;
+  tabs: DestinationTab[];
+}
+
+interface DestinationTabPickerProps {
+  tabs: DestinationTab[];
+  value: number | null;
+  onChange: (tabId: number) => void;
+}
+
+// Group tabs by category in first-seen order (the controller already emits categories then their
+// tabs in display order, so this preserves that without re-sorting). Robust to a category's tabs
+// arriving non-contiguously.
+const groupByCategory = (tabs: DestinationTab[]): Group[] => {
+  const groups: Group[] = [];
+  const indexByCategory = new Map<number, number>();
+  tabs.forEach((tab) => {
+    const existing = indexByCategory.get(tab.categoryId);
+    if (existing === undefined) {
+      indexByCategory.set(tab.categoryId, groups.length);
+      groups.push({
+        categoryId: tab.categoryId,
+        categoryTitle: tab.categoryTitle,
+        tabs: [tab],
+      });
+    } else {
+      groups[existing].tabs.push(tab);
+    }
+  });
+  return groups;
+};
+
+const DestinationTabPicker: FC<DestinationTabPickerProps> = ({
+  tabs,
+  value,
+  onChange,
+}) => {
+  const groups = groupByCategory(tabs);
+
+  return (
+    <Card>
+      <CardContent className="overflow-y-auto" style={{ maxHeight: 320 }}>
+        <RadioGroup
+          onChange={(e): void => onChange(Number(e.target.value))}
+          value={value != null ? String(value) : ''}
+        >
+          {groups.map((group) => (
+            <div
+              key={`category_${group.categoryId}`}
+              className="flex flex-col items-start"
+            >
+              <div className="flex items-center py-2 text-xl font-bold">
+                <TypeBadge dense itemType="CATEGORY" />
+                {group.categoryTitle}
+              </div>
+              {group.tabs.map((tab) => (
+                <FormControlLabel
+                  key={`tab_${tab.id}`}
+                  className="ml-4 text-xl"
+                  control={<Radio className="py-0 px-2" />}
+                  label={
+                    <span className="flex items-center text-xl font-bold">
+                      <TypeBadge dense itemType="TAB" />
+                      {tab.title}
+                    </span>
+                  }
+                  value={String(tab.id)}
+                />
+              ))}
+            </div>
+          ))}
+        </RadioGroup>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DestinationTabPicker;

--- a/client/app/bundles/course/marketplace/components/DuplicateConfirmation.tsx
+++ b/client/app/bundles/course/marketplace/components/DuplicateConfirmation.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
+import { Tooltip } from 'react-tooltip';
 import { Card, CardContent, ListSubheader } from '@mui/material';
 import { JobStatus } from 'types/jobs';
 
-import DuplicationAssessmentTree from 'course/duplication/components/DuplicationAssessmentTree';
+import TypeBadge from 'course/duplication/components/TypeBadge';
+import UnpublishedIcon from 'course/duplication/components/UnpublishedIcon';
 import Prompt from 'lib/components/core/dialogs/Prompt';
 import Link from 'lib/components/core/Link';
 import { pollJobRequest } from 'lib/helpers/jobHelpers';
@@ -11,26 +13,26 @@ import useTranslation from 'lib/hooks/useTranslation';
 
 import { duplicateListings } from '../operations';
 import translations from '../translations';
-import { MarketplaceListing } from '../types';
+import { DestinationTab, MarketplaceListing } from '../types';
+
+import DestinationTabPicker from './DestinationTabPicker';
 
 const JOB_POLL_INTERVAL_MS = 2000;
 
 interface Props {
   listings: Pick<MarketplaceListing, 'id' | 'title'>[];
-  destinationTabId: number | null;
+  destinationTabs: DestinationTab[];
+  initialDestinationTabId: number | null;
   destinationCourse: { title: string; url: string };
-  destinationCategory: { id: number; title: string } | null;
-  destinationTab: { id: number; title: string } | null;
   open: boolean;
   onClose: () => void;
 }
 
 const DuplicateConfirmation = ({
   listings,
-  destinationTabId,
+  destinationTabs,
+  initialDestinationTabId,
   destinationCourse,
-  destinationCategory,
-  destinationTab,
   open,
   onClose,
 }: Props): JSX.Element => {
@@ -41,12 +43,41 @@ const DuplicateConfirmation = ({
 
   const n = listings.length;
 
+  // Default selection is the `from_tab` the user launched from when it names a real tab in this
+  // course; otherwise fall back to the course's first tab (if any). When the course has no tabs,
+  // the selection stays null and the backend applies its own default.
+  const resolveInitial = (): number | null => {
+    if (
+      initialDestinationTabId != null &&
+      destinationTabs.some((tab) => tab.id === initialDestinationTabId)
+    ) {
+      return initialDestinationTabId;
+    }
+    return destinationTabs[0]?.id ?? null;
+  };
+
+  const [selectedTabId, setSelectedTabId] = useState<number | null>(
+    resolveInitial(),
+  );
+
+  // The pages keep this component mounted and only flip `open`, so `selectedTabId` outlives a close
+  // — re-seed it each time the dialog opens, or a tab the user picked and then walked away from
+  // would still be selected next time.
+  //
+  // Deps are `[open]` on purpose. Adding `destinationTabs` would compare it by identity, so any
+  // parent re-render passing a fresh array would re-fire this and reset the radio out from under a
+  // user mid-decision. Reopening is the only moment the selection should be re-seeded.
+  useEffect(() => {
+    if (!open) return;
+    setSelectedTabId(resolveInitial());
+  }, [open]);
+
   const confirm = async (): Promise<void> => {
     setSubmitting(true);
     try {
       const url = await duplicateListings(
         listings.map((l) => l.id),
-        destinationTabId,
+        selectedTabId,
       );
       setJobUrl(url);
     } catch {
@@ -62,11 +93,25 @@ const DuplicateConfirmation = ({
   useEffect(() => {
     if (!jobUrl) return undefined;
 
-    const finish = (succeeded: boolean): void => {
+    // Called only once the job has finished, so this reports what already happened. `redirectUrl`
+    // points at the destination tab; it is optional on JobCompleted, so the link is conditional.
+    const finish = (succeeded: boolean, redirectUrl?: string): void => {
       setJobUrl(null);
       setSubmitting(false);
       if (succeeded) {
-        toast.success(t(translations.duplicateStarted, { n }));
+        toast.success(
+          <>
+            {t(translations.duplicateCompleted, { n })}
+            {redirectUrl && (
+              <>
+                {' '}
+                <Link href={redirectUrl}>
+                  {t(translations.viewDuplicatedAssessment)}
+                </Link>
+              </>
+            )}
+          </>,
+        );
         onClose();
       } else {
         toast.error(t(translations.duplicateFailed, { n }));
@@ -78,7 +123,8 @@ const DuplicateConfirmation = ({
       pollingRef.current = true;
       pollJobRequest(jobUrl)
         .then((response) => {
-          if (response.status === JobStatus.completed) finish(true);
+          if (response.status === JobStatus.completed)
+            finish(true, response.redirectUrl);
           else if (response.status === JobStatus.errored) finish(false);
         })
         .catch(() => finish(false))
@@ -92,10 +138,12 @@ const DuplicateConfirmation = ({
 
   return (
     <Prompt
+      cancelColor="secondary"
       disabled={submitting}
       onClickPrimary={confirm}
       onClose={onClose}
       open={open}
+      primaryColor="primary"
       primaryLabel={t(translations.duplicateConfirm)}
       title={t(translations.confirmationQuestion)}
     >
@@ -111,16 +159,32 @@ const DuplicateConfirmation = ({
       </Card>
 
       <ListSubheader disableSticky>
-        {t(translations.assessmentsHeading)}
+        {t(translations.pickDestinationTab)}
       </ListSubheader>
-      <DuplicationAssessmentTree
-        nodes={[
-          {
-            category: destinationCategory,
-            tabs: [{ tab: destinationTab, assessments: listings }],
-          },
-        ]}
+      <DestinationTabPicker
+        onChange={setSelectedTabId}
+        tabs={destinationTabs}
+        value={selectedTabId}
       />
+
+      <ListSubheader disableSticky>{t(translations.duplicating)}</ListSubheader>
+      <Card>
+        <CardContent>
+          {listings.map((listing) => (
+            <div
+              key={listing.id}
+              className="flex items-center py-1 text-xl font-bold"
+            >
+              <TypeBadge dense itemType="ASSESSMENT" />
+              <UnpublishedIcon tooltipId="itemUnpublished" />
+              {listing.title}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      <Tooltip id="itemUnpublished" style={{ fontSize: '1.4rem' }}>
+        {t(translations.itemUnpublished)}
+      </Tooltip>
     </Prompt>
   );
 };

--- a/client/app/bundles/course/marketplace/components/__test__/DestinationTabPicker.test.tsx
+++ b/client/app/bundles/course/marketplace/components/__test__/DestinationTabPicker.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render } from 'test-utils';
+
+import DestinationTabPicker from '../DestinationTabPicker';
+
+const tabs = [
+  { id: 10, title: 'Tutorials', categoryId: 1, categoryTitle: 'Week 3' },
+  { id: 11, title: 'Problem Sets', categoryId: 1, categoryTitle: 'Week 3' },
+  { id: 20, title: 'Lab', categoryId: 2, categoryTitle: 'Week 4' },
+];
+
+it('renders an empty radio group when there are no tabs', async () => {
+  const page = render(
+    <DestinationTabPicker onChange={jest.fn()} tabs={[]} value={null} />,
+  );
+
+  expect(await page.findByRole('radiogroup')).toBeEmptyDOMElement();
+});
+
+it('groups tabs under one header per category and renders a radio per tab', async () => {
+  const page = render(
+    <DestinationTabPicker onChange={jest.fn()} tabs={tabs} value={11} />,
+  );
+
+  // I18nProvider (TypeBadge uses it) async-loads messages, so await the first query.
+  expect(await page.findByText('Week 3')).toBeVisible();
+  expect(page.getByText('Week 4')).toBeVisible();
+  // The two Week 3 tabs share a single header.
+  expect(page.getAllByText('Week 3')).toHaveLength(1);
+  expect(page.getAllByRole('radio')).toHaveLength(3);
+  // Headers are badged as categories, radios as tabs. RTL's text matcher only sees an element's
+  // direct text-node children, so TypeBadge's Typography matches 'Category'/'Tab' on its own.
+  expect(page.getAllByText('Category')).toHaveLength(2);
+  expect(page.getAllByText('Tab')).toHaveLength(3);
+});
+
+// The fixture is interleaved AND in descending categoryId order, so first-seen order and any
+// sorted order disagree — the flat `tabs` fixture above cannot tell them apart.
+it('groups a category under its first-seen header when its tabs arrive non-contiguously', async () => {
+  const interleavedTabs = [
+    { id: 20, title: 'Lab', categoryId: 2, categoryTitle: 'Week 4' },
+    { id: 10, title: 'Tutorials', categoryId: 1, categoryTitle: 'Week 3' },
+    { id: 21, title: 'Recitation', categoryId: 2, categoryTitle: 'Week 4' },
+  ];
+
+  const page = render(
+    <DestinationTabPicker
+      onChange={jest.fn()}
+      tabs={interleavedTabs}
+      value={null}
+    />,
+  );
+
+  // Week 4's two tabs are split by a Week 3 tab, but still share one header.
+  expect(await page.findAllByText('Week 4')).toHaveLength(1);
+  expect(page.getAllByText('Week 3')).toHaveLength(1);
+  // Week 4 is seen first, so its group (and both its tabs) comes first.
+  expect(
+    page.getAllByRole('radio').map((radio) => radio.getAttribute('value')),
+  ).toEqual(['20', '21', '10']);
+});
+
+it('marks the tab whose id equals value as checked', async () => {
+  const page = render(
+    <DestinationTabPicker onChange={jest.fn()} tabs={tabs} value={11} />,
+  );
+
+  expect(
+    await page.findByRole('radio', { name: /Problem Sets/ }),
+  ).toBeChecked();
+  expect(page.getByRole('radio', { name: /Tutorials/ })).not.toBeChecked();
+  expect(page.getByRole('radio', { name: /Lab/ })).not.toBeChecked();
+});
+
+it('checks no tab when value is null', async () => {
+  const page = render(
+    <DestinationTabPicker onChange={jest.fn()} tabs={tabs} value={null} />,
+  );
+
+  expect(await page.findAllByRole('radio')).toHaveLength(3);
+  page
+    .getAllByRole('radio')
+    .forEach((radio) => expect(radio).not.toBeChecked());
+});
+
+it('fires onChange with the numeric tab id when another tab is chosen', async () => {
+  const onChange = jest.fn();
+  const page = render(
+    <DestinationTabPicker onChange={onChange} tabs={tabs} value={11} />,
+  );
+
+  fireEvent.click(await page.findByRole('radio', { name: /Lab/ }));
+
+  expect(onChange).toHaveBeenCalledWith(20);
+});
+
+it('does not move the selection itself when a tab is clicked', async () => {
+  const page = render(
+    <DestinationTabPicker onChange={jest.fn()} tabs={tabs} value={11} />,
+  );
+
+  fireEvent.click(await page.findByRole('radio', { name: /Lab/ }));
+
+  // Controlled: the parent still says 11, so the checkmark must not move.
+  expect(page.getByRole('radio', { name: /Problem Sets/ })).toBeChecked();
+  expect(page.getByRole('radio', { name: /Lab/ })).not.toBeChecked();
+});

--- a/client/app/bundles/course/marketplace/components/__test__/DuplicationConfirmation.test.tsx
+++ b/client/app/bundles/course/marketplace/components/__test__/DuplicationConfirmation.test.tsx
@@ -1,67 +1,241 @@
 import { createMockAdapter } from 'mocks/axiosMock';
 import { fireEvent, render, waitFor } from 'test-utils';
+import TestApp from 'utilities/TestApp';
 
+import GlobalAPI from 'api';
 import CourseAPI from 'api/course';
+import toast from 'lib/hooks/toast';
 
 import DuplicateConfirmation from '../DuplicateConfirmation';
 
-const mock = createMockAdapter(CourseAPI.marketplace.client);
-beforeEach(() => mock.reset());
+// The toast message is a ReactNode (it carries a link), so capture it and render it rather than
+// mounting a ToastContainer.
+jest.mock('lib/hooks/toast', () => ({ success: jest.fn(), error: jest.fn() }));
 
-const listings = [{ id: 1, title: 'Recursion Drills' }];
+const mock = createMockAdapter(CourseAPI.marketplace.client);
+// pollJob polls the *jobs* endpoint, which lives on a different axios client to the marketplace API.
+const jobsMock = createMockAdapter(GlobalAPI.jobs.client);
+
+beforeEach(() => {
+  mock.reset();
+  jobsMock.reset();
+  jest.clearAllMocks();
+});
+
+const LISTING_TITLE = 'Recursion Drills';
+const listings = [{ id: 1, title: LISTING_TITLE }];
 const url = `/courses/${global.courseId}/marketplace/listings/duplicate`;
 const course = { title: 'Enrollable Course', url: '/courses/4' };
+const REDIRECT_URL = '/courses/4/assessments?category=5&tab=42';
+const destinationTabs = [
+  { id: 41, title: 'Tutorials', categoryId: 5, categoryTitle: 'Missions' },
+  { id: 42, title: 'Assignments', categoryId: 5, categoryTitle: 'Missions' },
+];
 
-it('shows the destination course and assessment tree with real names', async () => {
+const props = {
+  destinationCourse: course,
+  destinationTabs,
+  initialDestinationTabId: 42,
+  listings,
+  onClose: jest.fn(),
+};
+
+const successToastTexts = (): string[] =>
+  (toast.success as unknown as jest.Mock).mock.calls.map(([message]) => {
+    if (typeof message === 'string') return message;
+
+    const children = (message as { props?: { children?: unknown } }).props
+      ?.children;
+    if (Array.isArray(children)) {
+      return children.filter((child) => typeof child === 'string').join('');
+    }
+
+    return typeof children === 'string' ? children : '';
+  });
+
+it('forgets an abandoned selection and re-seeds the initial tab when reopened', async () => {
+  const page = render(<DuplicateConfirmation {...props} open />);
+
+  expect(await page.findByRole('radio', { name: /Assignments/ })).toBeChecked();
+
+  // The user picks a different tab, then dismisses the dialog without confirming.
+  fireEvent.click(page.getByRole('radio', { name: /Tutorials/ }));
+  expect(page.getByRole('radio', { name: /Tutorials/ })).toBeChecked();
+
+  // The page keeps this component mounted and only flips `open`, so `selectedTabId` outlives the
+  // close — which is the entire reason the re-seeding effect exists.
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp>
+      <DuplicateConfirmation {...props} open={false} />
+    </TestApp>,
+  );
+
+  page.rerender(
+    <TestApp>
+      <DuplicateConfirmation {...props} open />
+    </TestApp>,
+  );
+
+  // Reopening starts from the tab the user launched from, not the choice they walked away from.
+  expect(await page.findByRole('radio', { name: /Assignments/ })).toBeChecked();
+  expect(page.getByRole('radio', { name: /Tutorials/ })).not.toBeChecked();
+});
+
+it('keeps the user’s selection across a re-render while the dialog stays open', async () => {
+  const page = render(<DuplicateConfirmation {...props} open />);
+
+  fireEvent.click(await page.findByRole('radio', { name: /Tutorials/ }));
+  expect(page.getByRole('radio', { name: /Tutorials/ })).toBeChecked();
+
+  // A parent re-render must not re-seed the selection out from under the user mid-decision.
+  page.rerender(
+    <TestApp>
+      <DuplicateConfirmation {...props} open />
+    </TestApp>,
+  );
+
+  expect(await page.findByRole('radio', { name: /Tutorials/ })).toBeChecked();
+  expect(page.getByRole('radio', { name: /Assignments/ })).not.toBeChecked();
+});
+
+it('shows the destination course, the tab picker, and the duplicating list', async () => {
   const page = render(
     <DuplicateConfirmation
-      destinationCategory={{ id: 5, title: 'Missions' }}
       destinationCourse={course}
-      destinationTab={{ id: 42, title: 'Assignments' }}
-      destinationTabId={42}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
       listings={listings}
       onClose={jest.fn()}
       open
     />,
   );
 
-  // I18nProvider shows a LoadingIndicator until locale messages async-load;
-  // await the first query to render past it, then the rest are synchronous.
-  expect(await page.findByText('Enrollable Course')).toBeVisible();
+  // I18nProvider shows a LoadingIndicator until locale messages async-load; await the first query
+  // to render past it, then the rest are synchronous.
+  expect(await page.findByText('Duplicate items?')).toBeVisible();
+
+  expect(page.getByText('Destination Course')).toBeVisible();
+  expect(page.getByRole('link', { name: 'Enrollable Course' })).toHaveAttribute(
+    'href',
+    '/courses/4',
+  );
+
+  expect(page.getByText('Pick destination tab')).toBeVisible();
   expect(page.getByText('Missions')).toBeVisible();
+  expect(page.getByText('Tutorials')).toBeVisible();
   expect(page.getByText('Assignments')).toBeVisible();
-  expect(page.getByText('Recursion Drills')).toBeVisible();
-  // The old raw-key bug must not recur.
-  expect(
-    page.queryByText('course.marketplace.duplicateTitle'),
-  ).not.toBeInTheDocument();
+
+  expect(page.getByText('Duplicating')).toBeVisible();
+  expect(page.getByText(LISTING_TITLE)).toBeVisible();
 });
 
-it('falls back to Default placeholders when entered without a tab', async () => {
+it('stacks destination tabs vertically with large category and tab text', async () => {
   const page = render(
     <DuplicateConfirmation
-      destinationCategory={null}
       destinationCourse={course}
-      destinationTab={null}
-      destinationTabId={null}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
       listings={listings}
       onClose={jest.fn()}
       open
     />,
   );
 
-  expect(await page.findByText('Default Category')).toBeVisible();
-  expect(page.getByText('Default Tab')).toBeVisible();
+  expect(await page.findByText('Duplicate items?')).toBeVisible();
+
+  expect(page.getByText('Missions').closest('div')).toHaveClass('text-xl');
+
+  const assignments = page.getByRole('radio', { name: /Assignments/ });
+  const tutorials = page.getByRole('radio', { name: /Tutorials/ });
+
+  expect(assignments.closest('label')?.parentElement).toHaveClass(
+    'flex',
+    'flex-col',
+    'items-start',
+  );
+  expect(assignments.closest('label')).toHaveClass('text-xl');
+  expect(tutorials.closest('label')).toHaveClass('text-xl');
+}, 10000);
+
+// Pins the ⊘ icon and its wiring to the tooltip. NOT the tooltip copy: react-tooltip v5 renders
+// nothing until shown, and hovering the anchor does not mount its content under jsdom (verified —
+// `fireEvent.mouseEnter` + `findByText` on the message times out). So assert the wiring, which is
+// what a dropped `tooltipId` or a dropped <Tooltip> would break.
+it('badges each item as an assessment and marks it as arriving unpublished', async () => {
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  expect(await page.findByText(LISTING_TITLE)).toBeVisible();
+  expect(page.getByText('Assessment')).toBeVisible();
+  expect(page.getByTestId('BlockIcon')).toHaveAttribute(
+    'data-tooltip-id',
+    'itemUnpublished',
+  );
 });
 
-it('posts a duplication request with the destination tab on confirm', async () => {
+it('pre-selects the tab the user came from', async () => {
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  expect(await page.findByRole('radio', { name: /Assignments/ })).toBeChecked();
+  expect(page.getByRole('radio', { name: /Tutorials/ })).not.toBeChecked();
+});
+
+it('falls back to the first tab when the initial id is not a real tab', async () => {
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={999}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  expect(await page.findByRole('radio', { name: /Tutorials/ })).toBeChecked();
+  expect(page.getByRole('radio', { name: /Assignments/ })).not.toBeChecked();
+});
+
+it('falls back to the first tab when entered without a from_tab', async () => {
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={null}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  expect(await page.findByRole('radio', { name: /Tutorials/ })).toBeChecked();
+});
+
+it('posts the pre-selected destination tab on confirm', async () => {
   mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
   const page = render(
     <DuplicateConfirmation
-      destinationCategory={{ id: 5, title: 'Missions' }}
       destinationCourse={course}
-      destinationTab={{ id: 42, title: 'Assignments' }}
-      destinationTabId={42}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
       listings={listings}
       onClose={jest.fn()}
       open
@@ -75,25 +249,249 @@ it('posts a duplication request with the destination tab on confirm', async () =
   });
 });
 
-it('omits destination_tab_id when entered without a tab (sidebar entry)', async () => {
+it('posts the newly chosen tab after the user changes the selection', async () => {
   mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
   const page = render(
     <DuplicateConfirmation
-      destinationCategory={null}
       destinationCourse={course}
-      destinationTab={null}
-      destinationTabId={null}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
       listings={listings}
       onClose={jest.fn()}
       open
     />,
   );
-  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+
+  fireEvent.click(await page.findByRole('radio', { name: /Tutorials/ }));
+  fireEvent.click(page.getByRole('button', { name: /Duplicate/ }));
+
   await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+    listing_ids: [1],
+    destination_tab_id: 41,
+  });
+});
+
+it('omits the destination tab entirely when the course has no tabs to pick from', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={[]}
+      initialDestinationTabId={null}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  expect(await page.findByText('Recursion Drills')).toBeVisible();
+  expect(page.queryAllByRole('radio')).toHaveLength(0);
+
+  fireEvent.click(page.getByRole('button', { name: /Duplicate/ }));
+
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+
   const body = JSON.parse(mock.history.post[0].data);
   expect(body).toMatchObject({ listing_ids: [1] });
-  expect(body).not.toHaveProperty('destination_tab_id'); // backend then defaults to the first tab
+  // There is no tab to name, so the key must be absent and the backend picks its own default.
+  expect(body).not.toHaveProperty('destination_tab_id');
 });
+
+it('duplicates every selected listing and pluralises the completion toast', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  jobsMock.onGet('/jobs/9').reply(200, { status: 'completed' });
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={[
+        { id: 1, title: LISTING_TITLE },
+        { id: 2, title: 'Graph Traversals' },
+      ]}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  expect(await page.findByText(LISTING_TITLE)).toBeVisible();
+  expect(page.getByText('Graph Traversals')).toBeVisible();
+
+  fireEvent.click(page.getByRole('button', { name: /Duplicate/ }));
+
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+    listing_ids: [1, 2],
+  });
+
+  await waitFor(
+    () => expect(successToastTexts()).toContain('Assessments duplicated.'),
+    { timeout: 6000 },
+  );
+}, 10000);
+
+// The toast fires from pollJob's COMPLETION callback, so it must not claim the work has merely
+// "started" — and it must surface the redirectUrl that callback receives, which the dialog used to
+// throw away, leaving the user with no idea where the duplicate landed.
+it('reports completion and links to where the assessment landed', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  jobsMock
+    .onGet('/jobs/9')
+    .reply(200, { status: 'completed', redirectUrl: REDIRECT_URL });
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+
+  // pollJob polls every 2s — longer than waitFor's 1s default.
+  await waitFor(() => expect(toast.success).toHaveBeenCalled(), {
+    timeout: 6000,
+  });
+
+  const message = (toast.success as unknown as jest.Mock).mock.calls[0][0];
+  const toasted = render(<div>{message}</div>);
+
+  expect(await toasted.findByText(/Assessment duplicated\./)).toBeVisible();
+  expect(toasted.queryByText(/started/i)).not.toBeInTheDocument();
+  expect(
+    toasted.getByRole('link', { name: 'View assessment' }),
+  ).toHaveAttribute('href', REDIRECT_URL);
+}, 10000);
+
+it('closes itself once the duplication completes', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  jobsMock
+    .onGet('/jobs/9')
+    .reply(200, { status: 'completed', redirectUrl: REDIRECT_URL });
+  const onClose = jest.fn();
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={onClose}
+      open
+    />,
+  );
+
+  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+
+  // The dialog must dismiss itself on completion — the toast (with its link) is what remains.
+  await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1), {
+    timeout: 6000,
+  });
+}, 10000);
+
+it('omits the link when the job returns no redirect url', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  jobsMock.onGet('/jobs/9').reply(200, { status: 'completed' });
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+
+  await waitFor(() => expect(toast.success).toHaveBeenCalled(), {
+    timeout: 6000,
+  });
+
+  const message = (toast.success as unknown as jest.Mock).mock.calls[0][0];
+  const toasted = render(<div>{message}</div>);
+
+  expect(await toasted.findByText(/Assessment duplicated\./)).toBeVisible();
+  expect(
+    toasted.queryByRole('link', { name: 'View assessment' }),
+  ).not.toBeInTheDocument();
+}, 10000);
+
+// Guards the reworded failure copy — the old string was a malformed gerund
+// ("Duplicating assessment failed.").
+it('reports a failed duplication in plain language', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  jobsMock.onGet('/jobs/9').reply(200, { status: 'errored' });
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={jest.fn()}
+      open
+    />,
+  );
+
+  fireEvent.click(await page.findByRole('button', { name: /Duplicate/ }));
+
+  await waitFor(() => expect(toast.error).toHaveBeenCalled(), {
+    timeout: 6000,
+  });
+
+  expect(toast.error).toHaveBeenCalledWith(
+    'Could not duplicate the assessment.',
+  );
+  expect(toast.success).not.toHaveBeenCalled();
+}, 10000);
+
+it('locks the dialog while the job runs, then unlocks it without closing if the job fails', async () => {
+  mock.onPost(url).reply(200, { status: 'submitted', jobUrl: '/jobs/9' });
+  jobsMock.onGet('/jobs/9').reply(200, { status: 'errored' });
+  const onClose = jest.fn();
+
+  const page = render(
+    <DuplicateConfirmation
+      destinationCourse={course}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
+      listings={listings}
+      onClose={onClose}
+      open
+    />,
+  );
+
+  const duplicate = await page.findByRole('button', { name: /Duplicate/ });
+  fireEvent.click(duplicate);
+
+  // `Prompt` applies `disabled` to the cancel button as well as the primary one, so an in-flight
+  // job can be neither double-submitted nor abandoned halfway.
+  expect(duplicate).toBeDisabled();
+  expect(page.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+  fireEvent.click(duplicate);
+
+  await waitFor(() => expect(toast.error).toHaveBeenCalled(), {
+    timeout: 6000,
+  });
+
+  expect(mock.history.post).toHaveLength(1);
+
+  // A failed job must leave the dialog open and usable, so the user can retry.
+  await waitFor(() => expect(duplicate).toBeEnabled());
+  expect(page.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  expect(onClose).not.toHaveBeenCalled();
+}, 10000);
 
 // A request that never reaches the queue leaves no job to poll, so nothing else can re-enable the
 // prompt: the confirm button has to come back by itself for the user to be able to retry.
@@ -101,10 +499,9 @@ it('re-enables the prompt when the request itself fails', async () => {
   mock.onPost(url).reply(500);
   const page = render(
     <DuplicateConfirmation
-      destinationCategory={{ id: 5, title: 'Missions' }}
       destinationCourse={course}
-      destinationTab={{ id: 42, title: 'Assignments' }}
-      destinationTabId={42}
+      destinationTabs={destinationTabs}
+      initialDestinationTabId={42}
       listings={listings}
       onClose={jest.fn()}
       open

--- a/client/app/bundles/course/marketplace/pages/ListingPreview/__test__/index.test.tsx
+++ b/client/app/bundles/course/marketplace/pages/ListingPreview/__test__/index.test.tsx
@@ -46,6 +46,7 @@ it('renders the read-only assessment config', async () => {
   mock.onGet(url).reply(200, {
     id: 70,
     title: LISTING_TITLE,
+    destinationTabs: [],
     description: '<p>Awesome description 5</p>',
     gradingMode: 'manual',
     baseExp: 1000,
@@ -105,6 +106,7 @@ it('hides the EXP rows when the endpoint omits them', async () => {
   mock.onGet(url).reply(200, {
     id: 70,
     title: LISTING_TITLE,
+    destinationTabs: [],
     description: '',
     gradingMode: 'manual',
     showMcqMrqSolution: false,
@@ -127,6 +129,7 @@ it('carries from_tab into the per-question detail links', async () => {
   mock.onGet(url).reply(200, {
     id: 70,
     title: LISTING_TITLE,
+    destinationTabs: [],
     description: '<p>desc</p>',
     gradingMode: 'manual',
     showMcqMrqSolution: false,
@@ -161,6 +164,7 @@ it('navigates back to the marketplace carrying from_tab', async () => {
   mock.onGet(url).reply(200, {
     id: 70,
     title: LISTING_TITLE,
+    destinationTabs: [],
     description: '<p>desc</p>',
     gradingMode: 'manual',
     showMcqMrqSolution: false,
@@ -184,6 +188,7 @@ it('renders a back button to the marketplace index', async () => {
   mock.onGet(url).reply(200, {
     id: 70,
     title: LISTING_TITLE,
+    destinationTabs: [],
     description: '<p>desc</p>',
     gradingMode: 'manual',
     showMcqMrqSolution: false,

--- a/client/app/bundles/course/marketplace/pages/ListingPreview/__test__/index.test.tsx
+++ b/client/app/bundles/course/marketplace/pages/ListingPreview/__test__/index.test.tsx
@@ -204,3 +204,28 @@ it('renders a back button to the marketplace index', async () => {
   // Page renders the back affordance as an IconButton with this testid when `backTo` is set.
   expect(screen.getByTestId('ArrowBackIconButton')).toBeInTheDocument();
 });
+
+it('marks the page title as a preview', async () => {
+  const url = `/courses/${global.courseId}/marketplace/listings/7`;
+  mock.onGet(url).reply(200, {
+    id: 70,
+    title: LISTING_TITLE,
+    destinationTabs: [],
+    description: '<p>desc</p>',
+    gradingMode: 'manual',
+    baseExp: 0,
+    bonusExp: 0,
+    showMcqMrqSolution: false,
+    showRubricToStudents: false,
+    gradedTestCases: '',
+    typeCounts: {},
+    questions: [],
+  });
+
+  render(<ListingPreview />, { at: [url] });
+
+  await waitFor(() => expect(screen.getByText(LISTING_TITLE)).toBeVisible());
+  // A "Preview" chip sits beside the title so the read-only listing detail page is never mistaken
+  // for the real assessment it mirrors.
+  expect(screen.getByText('Preview')).toBeVisible();
+});

--- a/client/app/bundles/course/marketplace/pages/ListingPreview/index.tsx
+++ b/client/app/bundles/course/marketplace/pages/ListingPreview/index.tsx
@@ -78,10 +78,9 @@ const ListingPreview = (): JSX.Element => {
           </Subsection>
 
           <DuplicateConfirmation
-            destinationCategory={null}
             destinationCourse={{ title: courseTitle, url: courseUrl }}
-            destinationTab={null}
-            destinationTabId={fromTab}
+            destinationTabs={listing.destinationTabs}
+            initialDestinationTabId={fromTab}
             listings={[{ id: listing.id, title: listing.title }]}
             onClose={(): void => setDuplicating(false)}
             open={duplicating}

--- a/client/app/bundles/course/marketplace/pages/ListingPreview/index.tsx
+++ b/client/app/bundles/course/marketplace/pages/ListingPreview/index.tsx
@@ -49,7 +49,16 @@ const ListingPreview = (): JSX.Element => {
           }
           backTo={withFromTab(`${courseUrl}/marketplace`, fromTab)}
           className="space-y-5"
-          title={listing.title}
+          title={
+            <span className="flex items-center gap-2">
+              {listing.title}
+              <Chip
+                label={t(translations.previewBadge)}
+                size="small"
+                variant="outlined"
+              />
+            </span>
+          }
         >
           {listing.description && (
             <DescriptionCard description={listing.description} />

--- a/client/app/bundles/course/marketplace/pages/MarketplaceIndex/index.tsx
+++ b/client/app/bundles/course/marketplace/pages/MarketplaceIndex/index.tsx
@@ -10,7 +10,7 @@ import DuplicateConfirmation from '../../components/DuplicateConfirmation';
 import { readFromTab } from '../../fromTab';
 import { fetchListings } from '../../operations';
 import translations from '../../translations';
-import { DestinationTab, MarketplaceListing } from '../../types';
+import { MarketplaceListing } from '../../types';
 
 import MarketplaceTable from './MarketplaceTable';
 
@@ -20,43 +20,25 @@ const MarketplaceIndex = (): JSX.Element => {
   const fromTab = readFromTab(useLocation().search);
   const [pending, setPending] = useState<MarketplaceListing[]>([]);
 
-  const resolveDestination = (
-    tabs: DestinationTab[],
-  ): {
-    category: { id: number; title: string } | null;
-    tab: { id: number; title: string } | null;
-  } => {
-    const match = tabs.find((tab) => tab.id === fromTab);
-    if (!match) return { category: null, tab: null };
-    return {
-      category: { id: match.categoryId, title: match.categoryTitle },
-      tab: { id: match.id, title: match.title },
-    };
-  };
-
   return (
     <Preload render={<div />} while={fetchListings}>
-      {({ listings, destinationTabs }): JSX.Element => {
-        const destination = resolveDestination(destinationTabs);
-        return (
-          <Page title={t(translations.pageTitle)}>
-            <MarketplaceTable
-              fromTab={fromTab}
-              listings={listings}
-              onDuplicate={setPending}
-            />
-            <DuplicateConfirmation
-              destinationCategory={destination.category}
-              destinationCourse={{ title: courseTitle, url: courseUrl }}
-              destinationTab={destination.tab}
-              destinationTabId={fromTab}
-              listings={pending}
-              onClose={(): void => setPending([])}
-              open={pending.length > 0}
-            />
-          </Page>
-        );
-      }}
+      {({ listings, destinationTabs }): JSX.Element => (
+        <Page title={t(translations.pageTitle)}>
+          <MarketplaceTable
+            fromTab={fromTab}
+            listings={listings}
+            onDuplicate={setPending}
+          />
+          <DuplicateConfirmation
+            destinationCourse={{ title: courseTitle, url: courseUrl }}
+            destinationTabs={destinationTabs}
+            initialDestinationTabId={fromTab}
+            listings={pending}
+            onClose={(): void => setPending([])}
+            open={pending.length > 0}
+          />
+        </Page>
+      )}
     </Preload>
   );
 };

--- a/client/app/bundles/course/marketplace/translations.ts
+++ b/client/app/bundles/course/marketplace/translations.ts
@@ -73,6 +73,10 @@ export default defineMessages({
     id: 'course.marketplace.previewAction',
     defaultMessage: 'Preview',
   },
+  previewBadge: {
+    id: 'course.marketplace.previewBadge',
+    defaultMessage: 'Preview',
+  },
   duplicateAssessment: {
     id: 'course.marketplace.duplicateAssessment',
     defaultMessage: 'Duplicate Assessment',

--- a/client/app/bundles/course/marketplace/translations.ts
+++ b/client/app/bundles/course/marketplace/translations.ts
@@ -104,23 +104,40 @@ export default defineMessages({
     id: 'course.marketplace.destinationCourse',
     defaultMessage: 'Destination Course',
   },
-  assessmentsHeading: {
-    id: 'course.marketplace.assessmentsHeading',
-    defaultMessage: 'Assessments',
+  pickDestinationTab: {
+    id: 'course.marketplace.pickDestinationTab',
+    defaultMessage: 'Pick destination tab',
+  },
+  duplicating: {
+    id: 'course.marketplace.duplicating',
+    defaultMessage: 'Duplicating',
+  },
+  // Reuses the duplication bundle's existing id verbatim so formatjs extract dedupes rather than
+  // minting a marketplace-only duplicate; marketplace renders the ⊘ unpublished tooltip itself now.
+  itemUnpublished: {
+    id: 'course.duplication.Duplication.DuplicateItemsConfirmation.itemUnpublished',
+    defaultMessage:
+      'Items are duplicated as unpublished when duplicating to an existing course.',
   },
   duplicateConfirm: {
     id: 'course.marketplace.duplicateConfirm',
     defaultMessage: 'Duplicate',
   },
-  duplicateStarted: {
-    id: 'course.marketplace.duplicateStarted',
+  // Fired from pollJob's completion callback, so this reports what already happened. The old copy
+  // said "started", which was both malformed ("Duplicating assessment started.") and untrue.
+  duplicateCompleted: {
+    id: 'course.marketplace.duplicateCompleted',
     defaultMessage:
-      '{n, plural, one {Duplicating assessment} other {Duplicating assessments}} started.',
+      '{n, plural, one {Assessment duplicated} other {Assessments duplicated}}.',
   },
   duplicateFailed: {
     id: 'course.marketplace.duplicateFailed',
     defaultMessage:
-      '{n, plural, one {Duplicating assessment} other {Duplicating assessments}} failed.',
+      '{n, plural, one {Could not duplicate the assessment} other {Could not duplicate the assessments}}.',
+  },
+  viewDuplicatedAssessment: {
+    id: 'course.marketplace.viewDuplicatedAssessment',
+    defaultMessage: 'View assessment',
   },
   selectToDuplicate: {
     id: 'course.marketplace.selectToDuplicate',

--- a/client/app/bundles/course/marketplace/types.ts
+++ b/client/app/bundles/course/marketplace/types.ts
@@ -43,6 +43,9 @@ export interface ListingPreviewData {
   id: number;
   title: string;
   description: string;
+  // The previewer's own category/tab structure, so the duplicate dialog can offer the destination
+  // tab picker from the listing detail page (the listing itself lives in another course).
+  destinationTabs: DestinationTab[];
   gradingMode: 'autograded' | 'manual';
   // Absent, not null, when the assessment awards none: show.json.jbuilder emits these keys only
   // when the value is > 0, so the details table skips the row instead of printing a bare "0".

--- a/client/app/lib/hooks/toast/toast.tsx
+++ b/client/app/lib/hooks/toast/toast.tsx
@@ -16,7 +16,9 @@ import {
 import { Typography } from '@mui/material';
 import { produce } from 'immer';
 
-type Toaster = (message: string, options?: ToastOptions) => Id;
+// `formattedMessage` already renders a ReactNode (and `PromisedToastMessages` already types its
+// messages that way), so this only widens the type — nothing changes at runtime.
+type Toaster = (message: ReactNode, options?: ToastOptions) => Id;
 
 interface PromisedToastMessages {
   pending?: ReactNode;

--- a/client/app/routers/course/marketplace.tsx
+++ b/client/app/routers/course/marketplace.tsx
@@ -1,4 +1,4 @@
-import { RouteObject } from 'react-router-dom';
+import { Navigate, RouteObject } from 'react-router-dom';
 import { WithRequired } from 'types';
 
 import { Translated } from 'lib/hooks/useTranslation';
@@ -15,6 +15,12 @@ const marketplaceRouter: Translated<RouteObject> = () => ({
         Component: (await import('course/marketplace/pages/MarketplaceIndex'))
           .default,
       }),
+    },
+    {
+      // `listings` on its own (no id) is not a real page — send it back to the
+      // marketplace index so it lands in the same place as `marketplace/`.
+      path: 'listings',
+      element: <Navigate replace to=".." />,
     },
     {
       path: 'listings/:listingId',

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -6152,17 +6152,23 @@
   "course.marketplace.destinationCourse": {
     "defaultMessage": "Destination Course"
   },
-  "course.marketplace.assessmentsHeading": {
-    "defaultMessage": "Assessments"
+  "course.marketplace.pickDestinationTab": {
+    "defaultMessage": "Pick destination tab"
+  },
+  "course.marketplace.duplicating": {
+    "defaultMessage": "Duplicating"
   },
   "course.marketplace.duplicateConfirm": {
     "defaultMessage": "Duplicate"
   },
-  "course.marketplace.duplicateStarted": {
-    "defaultMessage": "{n, plural, one {Duplicating assessment} other {Duplicating assessments}} started."
+  "course.marketplace.duplicateCompleted": {
+    "defaultMessage": "{n, plural, one {Assessment duplicated} other {Assessments duplicated}}."
   },
   "course.marketplace.duplicateFailed": {
-    "defaultMessage": "{n, plural, one {Duplicating assessment} other {Duplicating assessments}} failed."
+    "defaultMessage": "{n, plural, one {Could not duplicate the assessment} other {Could not duplicate the assessments}}."
+  },
+  "course.marketplace.viewDuplicatedAssessment": {
+    "defaultMessage": "View assessment"
   },
   "course.marketplace.selectToDuplicate": {
     "defaultMessage": "Select to duplicate"

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -6125,6 +6125,9 @@
   "course.marketplace.previewAction": {
     "defaultMessage": "Preview"
   },
+  "course.marketplace.previewBadge": {
+    "defaultMessage": "Preview"
+  },
   "course.marketplace.duplicateAssessment": {
     "defaultMessage": "Duplicate Assessment"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -6089,6 +6089,9 @@
   "course.marketplace.previewAction": {
     "defaultMessage": "미리보기"
   },
+  "course.marketplace.previewBadge": {
+    "defaultMessage": "미리보기"
+  },
   "course.marketplace.duplicateAssessment": {
     "defaultMessage": "평가 복제"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -6116,17 +6116,23 @@
   "course.marketplace.destinationCourse": {
     "defaultMessage": "대상 강좌"
   },
-  "course.marketplace.assessmentsHeading": {
-    "defaultMessage": "평가"
+  "course.marketplace.pickDestinationTab": {
+    "defaultMessage": "대상 탭 선택"
+  },
+  "course.marketplace.duplicating": {
+    "defaultMessage": "복제 중"
   },
   "course.marketplace.duplicateConfirm": {
     "defaultMessage": "복제"
   },
-  "course.marketplace.duplicateStarted": {
-    "defaultMessage": "{n, plural, one {평가 복제가} other {평가 복제가}} 시작되었습니다."
+  "course.marketplace.duplicateCompleted": {
+    "defaultMessage": "{n, plural, one {평가가 복제되었습니다} other {평가가 복제되었습니다}}."
   },
   "course.marketplace.duplicateFailed": {
-    "defaultMessage": "{n, plural, one {평가 복제에} other {평가 복제에}} 실패했습니다."
+    "defaultMessage": "{n, plural, one {평가를 복제할 수 없습니다} other {평가를 복제할 수 없습니다}}."
+  },
+  "course.marketplace.viewDuplicatedAssessment": {
+    "defaultMessage": "평가 보기"
   },
   "course.marketplace.selectToDuplicate": {
     "defaultMessage": "복제하려면 선택"

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -6110,17 +6110,23 @@
   "course.marketplace.destinationCourse": {
     "defaultMessage": "目标课程"
   },
-  "course.marketplace.assessmentsHeading": {
-    "defaultMessage": "评估"
+  "course.marketplace.pickDestinationTab": {
+    "defaultMessage": "选择目标标签页"
+  },
+  "course.marketplace.duplicating": {
+    "defaultMessage": "正在复制"
   },
   "course.marketplace.duplicateConfirm": {
     "defaultMessage": "复制"
   },
-  "course.marketplace.duplicateStarted": {
-    "defaultMessage": "{n, plural, one {评估复制} other {评估复制}}已开始。"
+  "course.marketplace.duplicateCompleted": {
+    "defaultMessage": "{n, plural, one {评估已复制} other {评估已复制}}。"
   },
   "course.marketplace.duplicateFailed": {
-    "defaultMessage": "{n, plural, one {评估复制} other {评估复制}}失败。"
+    "defaultMessage": "{n, plural, one {无法复制评估} other {无法复制评估}}。"
+  },
+  "course.marketplace.viewDuplicatedAssessment": {
+    "defaultMessage": "查看评估"
   },
   "course.marketplace.selectToDuplicate": {
     "defaultMessage": "选择评估复制"

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -6083,6 +6083,9 @@
   "course.marketplace.previewAction": {
     "defaultMessage": "预览"
   },
+  "course.marketplace.previewBadge": {
+    "defaultMessage": "预览"
+  },
   "course.marketplace.duplicateAssessment": {
     "defaultMessage": "复制评估"
   },

--- a/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
+++ b/spec/controllers/course/assessment/marketplace/listings_controller_spec.rb
@@ -146,6 +146,20 @@ RSpec.describe Course::Assessment::Marketplace::ListingsController, type: :contr
         expect(question['options']).to be_present
       end
 
+      it 'includes the current course destination tabs so the duplicate dialog can offer a picker' do
+        get :show, params: { course_id: course, id: listing.id, format: :json }
+        tabs = response.parsed_body['destinationTabs']
+        expect(tabs).to be_present
+        default_tab = course.assessment_categories.first.tabs.first
+        row = tabs.find { |tab| tab['id'] == default_tab.id }
+        expect(row).to include(
+          'id' => default_tab.id,
+          'title' => default_tab.title,
+          'categoryId' => default_tab.category.id,
+          'categoryTitle' => default_tab.category.title
+        )
+      end
+
       context 'when the listing is unpublished' do
         let!(:listing) { create(:course_assessment_marketplace_listing, published: false) }
         it 'is forbidden' do


### PR DESCRIPTION
## Summary

This rounds out the preview/duplicate flow from the parent PR. The duplicate confirmation dialog now lets the user actively pick the destination category/tab via a new `DestinationTabPicker`, instead of just displaying whichever tab they happened to arrive from. Completion feedback is upgraded to report once the duplication job actually finishes, with a link to where the assessment landed, instead of a fire-and-forget "started" toast. The listing preview page is badged so it's never mistaken for the real assessment it mirrors, and a bare `/marketplace/listings` now redirects to the marketplace index instead of 404ing.

## Design decisions

- `DuplicateConfirmation` now takes the full `destinationTabs` list and an `initialDestinationTabId`, letting the user change the destination tab instead of being locked into the one they arrived from; the initial selection still defaults to the `from_tab` tab when it names a real tab, falling back to the course's first tab otherwise.
- The completion toast now fires from `pollJob`'s completion callback and links to the duplicated assessment (`redirectUrl`), since the previous "Duplicating assessment started." toast fired on job submission and gave no way to find the result afterward.
- The selected tab is only re-seeded when the dialog reopens (`[open]` as the sole effect dependency), not on every parent re-render, so an in-progress tab choice isn't reset out from under the user while the dialog stays open.

## Regression prevention

Tests cover: `DestinationTabPicker`'s category grouping (including tabs arriving non-contiguously) and its selection wiring; the tab-selection reset-on-reopen vs. preserve-while-open behaviour; the completion and failure toast copy and the redirect link; the dialog locking/unlocking around an in-flight job so it can't be double-submitted or abandoned mid-job; the `destinationTabs` now returned from the listing show endpoint; the `/marketplace/listings` redirect; and the listing preview page's "Preview" badge.

Manual testing covered picking a different destination tab before confirming, the completion toast and its link after a duplication job finishes, a failed duplication leaving the dialog open for retry, and the bare `/marketplace/listings` redirect.
