### PR TITLE
feat(text-responses): add optional target sheet configuration for spreadsheet formulas

### DIFF
--- a/app/controllers/course/assessment/question/text_responses_controller.rb
+++ b/app/controllers/course/assessment/question/text_responses_controller.rb
@@ -94,7 +94,7 @@ class Course::Assessment::Question::TextResponsesController < Course::Assessment
             :id, :file, :_destroy, :is_randomization_enabled, :num_random_tests,
             :is_random_seed_fixed, :test_random_seed,
             :is_timestamp_fixed, :test_timestamp,
-            :variables
+            :target_sheet_name, :variables
           ]
         ]]
       )

--- a/app/models/course/assessment/question/text_response_solution_spreadsheet.rb
+++ b/app/models/course/assessment/question/text_response_solution_spreadsheet.rb
@@ -10,7 +10,7 @@ class Course::Assessment::Question::TextResponseSolutionSpreadsheet < Applicatio
   def assign_params(params)
     assign_attributes(
       params.slice(:is_randomization_enabled, :num_random_tests, :is_random_seed_fixed,
-                   :test_random_seed, :is_timestamp_fixed, :test_timestamp)
+                   :test_random_seed, :is_timestamp_fixed, :test_timestamp, :target_sheet_name)
     )
     self.variables = JSON.parse(params[:variables]) if params[:variables]
     self.file = params[:file] if params[:file]
@@ -19,7 +19,8 @@ class Course::Assessment::Question::TextResponseSolutionSpreadsheet < Applicatio
   def initialize_duplicate(duplicator, other)
     assign_attributes(other.attributes.slice('is_randomization_enabled', 'is_random_seed_fixed',
                                              'test_random_seed', 'is_timestamp_fixed',
-                                             'test_timestamp', 'num_random_tests', 'variables'))
+                                             'test_timestamp', 'num_random_tests', 'variables',
+                                             'target_sheet_name'))
     self.attachment = duplicator.duplicate(other.attachment)
   end
 

--- a/app/services/course/assessment/answer/text_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_auto_grading_service.rb
@@ -139,7 +139,8 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
           spreadsheet:
             {
               id: solution.test_spreadsheet.id,
-              filename: solution.test_spreadsheet.container_filename
+              filename: solution.test_spreadsheet.container_filename,
+              target_sheet_name: solution.test_spreadsheet.target_sheet_name
             }
         }
       end

--- a/app/views/course/assessment/question/text_responses/_solution_details.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_solution_details.json.jbuilder
@@ -18,6 +18,7 @@ json.solutions question.solutions do |sol|
       json.isTimestampFixed sol.test_spreadsheet.is_timestamp_fixed
       json.testTimestamp sol.test_spreadsheet.test_timestamp
       json.numRandomTests sol.test_spreadsheet.num_random_tests
+      json.targetSheetName sol.test_spreadsheet.target_sheet_name
       json.variables sol.test_spreadsheet.variables
     end
   end

--- a/client/app/bundles/course/assessment/question/text-responses/components/Solution.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/Solution.tsx
@@ -58,6 +58,7 @@ const Solution: FC<SolutionProps> = ({
           solution.spreadsheet?.testTimestamp ?? Date.now(),
         ),
         numRandomTests: solution.spreadsheet?.numRandomTests ?? 2,
+        targetSheetName: solution.spreadsheet?.targetSheetName ?? null,
         file: solution.spreadsheet?.file ?? { file: null, name: '', url: '' },
         variables: solution.spreadsheet?.variables,
       });

--- a/client/app/bundles/course/assessment/question/text-responses/components/SpreadsheetManagerPrompt.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/SpreadsheetManagerPrompt.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { IconButton } from '@mui/material';
+import { IconButton, Typography } from '@mui/material';
 import {
   CellRandomConfig,
   TextResponseEditableFormData,
@@ -9,6 +9,9 @@ import {
 import Prompt from 'lib/components/core/dialogs/Prompt';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormDateTimePickerField from 'lib/components/form/fields/DateTimePickerField';
+import FormSelectField from 'lib/components/form/fields/SelectField';
+import { GridData } from 'lib/components/form/fields/SingleFileInput/types';
+import { parseSpreadsheet } from 'lib/components/form/fields/SingleFileInput/utils';
 import FormTextField from 'lib/components/form/fields/TextField';
 import RandomizeIcon from 'lib/components/icons/RandomizeIcon';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -36,6 +39,29 @@ const SpreadsheetManagerPrompt: FC<Props> = ({
   const { control, watch, setValue } =
     useFormContext<TextResponseEditableFormData>();
   const spreadsheet = watch(`solutions.${index}.spreadsheet`);
+
+  // Parse the (hydrated) spreadsheet file once here and share the result with
+  // both the target-sheet dropdown and the randomization manager, so the file is
+  // not parsed multiple times across the Advanced Options prompt.
+  const [gridData, setGridData] = useState<GridData | null>(null);
+  useEffect(() => {
+    if (!file) {
+      setGridData(null);
+      return undefined;
+    }
+    let cancelled = false;
+    parseSpreadsheet(file)
+      .then((data) => {
+        if (!cancelled) setGridData(data);
+      })
+      .catch(() => {
+        if (!cancelled) setGridData(null);
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [file]);
+  const sheetNames = gridData?.sheetNames ?? [];
 
   // Incremented each time the dialog opens so SpreadsheetRandomizationManager
   // remounts and re-initialises from the latest saved variables.
@@ -132,10 +158,50 @@ const SpreadsheetManagerPrompt: FC<Props> = ({
             />
           )}
         />
+        <div className="flex flex-col">
+          <Typography variant="body1">{t(translations.targetSheet)}</Typography>
+          <Typography className="text-neutral-500" variant="body2">
+            {t(translations.targetSheetDescription)}
+          </Typography>
+          <Controller
+            control={control}
+            name={`solutions.${index}.spreadsheet.targetSheetName`}
+            render={({ field, fieldState }): JSX.Element => {
+              const defaultSheet = sheetNames[0];
+              // A null/empty value means "use the first sheet", so show the first
+              // sheet as selected — that is what autograding actually resolves to.
+              const current = field.value || defaultSheet || '';
+              // Ensure a previously-saved sheet still displays even if it is not
+              // among the parsed names (e.g. file not yet loaded, or renamed).
+              const options = (
+                current && !sheetNames.includes(current)
+                  ? [current, ...sheetNames]
+                  : sheetNames
+              ).map((name) => ({ value: name, label: name }));
+              return (
+                <FormSelectField
+                  disabled={sheetNames.length <= 1}
+                  field={{
+                    ...field,
+                    value: current,
+                    onChange: (e) =>
+                      field.onChange(
+                        e.target.value === defaultSheet ? null : e.target.value,
+                      ),
+                  }}
+                  fieldState={fieldState}
+                  options={options}
+                  variant="outlined"
+                />
+              );
+            }}
+          />
+        </div>
 
         <SpreadsheetRandomizationManager
           key={dialogKey}
           file={file ?? undefined}
+          gridData={gridData}
           initialVariables={spreadsheet?.variables}
           onVariablesChange={(vars) => {
             pendingVariablesRef.current = vars;

--- a/client/app/bundles/course/assessment/question/text-responses/components/SpreadsheetRandomizationManager.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/SpreadsheetRandomizationManager.tsx
@@ -22,10 +22,7 @@ import {
   SheetGrid,
   SpreadsheetCellValue,
 } from 'lib/components/form/fields/SingleFileInput/types';
-import {
-  getCellKey,
-  parseSpreadsheet,
-} from 'lib/components/form/fields/SingleFileInput/utils';
+import { getCellKey } from 'lib/components/form/fields/SingleFileInput/utils';
 import AZIcon from 'lib/components/icons/AZIcon';
 import OneNineIcon from 'lib/components/icons/OneNineIcon';
 import RandomizeIcon from 'lib/components/icons/RandomizeIcon';
@@ -46,6 +43,7 @@ import StringRandomizationManager from './StringRandomizationManager';
 
 interface Props {
   file?: File;
+  gridData?: GridData | null;
   initialVariables?: CellRandomConfig[];
   onVariablesChange?: (variables: CellRandomConfig[]) => void;
 }
@@ -244,6 +242,7 @@ const CellOverrideContent: FC<{
 
 const SpreadsheetRandomizationManager: FC<Props> = ({
   file,
+  gridData,
   initialVariables,
   onVariablesChange,
 }) => {
@@ -253,41 +252,35 @@ const SpreadsheetRandomizationManager: FC<Props> = ({
   const [cellConfigs, setCellConfigs] = useState<
     CellRandomConfigState | undefined
   >(() => fromVariables(initialVariables));
-  const [gridData, setGridData] = useState<GridData | null>(null);
   const popoverActionsRef = useRef<PopoverActions>(null);
   const spreadsheetRef = useRef<HTMLDivElement>(null);
-  const fileRef = useRef<File | undefined>(undefined);
+  // Whether default configs have already been applied for a grid in this mount,
+  // used to detect a file/grid *replacement* (which always forces an override).
+  const appliedRef = useRef(false);
 
   const updateCellConfigs = (newState: CellRandomConfigState): void => {
     setCellConfigs(newState);
     onVariablesChange?.(toVariables(newState));
   };
 
-  const initSpreadsheetDefaultConfigFromFile = async (
-    override: boolean,
-  ): Promise<void> => {
-    if (!file) return;
-    const data = await parseSpreadsheet(file);
-    setGridData(data);
-    if (override) {
-      updateCellConfigs(
-        initSpreadsheetDefaultConfig(data.sheetNames, data.sheets),
-      );
-    }
+  const applyDefaultConfig = (): void => {
+    if (!gridData) return;
+    updateCellConfigs(
+      initSpreadsheetDefaultConfig(gridData.sheetNames, gridData.sheets),
+    );
   };
 
-  // If there is a previous file, we always override because old config structure is no longer valid.
-  // If there are initial variables, it implies this is the first render editing a spreadsheet formula, so don't override.
-  // If there are no initial variables, this triggers when a file is uploaded for the first time creating new spreadsheet formula solution.
+  // The spreadsheet is parsed once by the parent and passed in as `gridData`.
+  // If a previous grid was already applied in this mount, the grid was replaced,
+  // so we always override because the old config structure is no longer valid.
+  // If there are initial variables, this is the first render editing a spreadsheet
+  // formula, so don't override. If there are no initial variables, this is a file
+  // uploaded for the first time creating a new spreadsheet formula solution.
   useEffect(() => {
-    initSpreadsheetDefaultConfigFromFile(
-      Boolean(fileRef.current) || !initialVariables,
-    );
-    fileRef.current = file;
-    return (): void => {
-      fileRef.current = undefined;
-    };
-  }, [file]);
+    if (!gridData) return;
+    if (appliedRef.current || !initialVariables) applyDefaultConfig();
+    appliedRef.current = true;
+  }, [gridData]);
 
   const isEditableElement = (el: Element | null): boolean => {
     if (!el) return false;
@@ -381,7 +374,7 @@ const SpreadsheetRandomizationManager: FC<Props> = ({
     }
   };
 
-  if (!file) return null;
+  if (!file || !gridData) return null;
 
   return (
     <>
@@ -405,7 +398,7 @@ const SpreadsheetRandomizationManager: FC<Props> = ({
         </Button>
         <Button
           className="w-fit"
-          onClick={() => initSpreadsheetDefaultConfigFromFile(true)}
+          onClick={() => applyDefaultConfig()}
           size="small"
           variant="outlined"
         >
@@ -423,6 +416,7 @@ const SpreadsheetRandomizationManager: FC<Props> = ({
               ? 'bg-blue-100'
               : '';
           }}
+          grid={gridData}
           onCellClick={(e, rowIdx, colIdx, sheetName, cellValue) => {
             setPopover({
               anchorEl: e.currentTarget,

--- a/client/app/bundles/course/assessment/question/text-responses/operations.ts
+++ b/client/app/bundles/course/assessment/question/text-responses/operations.ts
@@ -80,6 +80,7 @@ const adaptSpreadsheetPostData = (
     is_timestamp_fixed: spreadsheet.isTimestampFixed,
     test_timestamp: spreadsheet.testTimestamp?.toISOString() ?? null,
     num_random_tests: spreadsheet.numRandomTests,
+    target_sheet_name: spreadsheet.targetSheetName ?? null,
     variables: JSON.stringify(
       (spreadsheet.variables ?? []).map((v) => {
         if (v.mode !== 'date') return v;

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -1164,6 +1164,15 @@ const translations = defineMessages({
     id: 'course.assessment.question.textResponses.numberOfRandomTests',
     defaultMessage: 'Number of random tests',
   },
+  targetSheet: {
+    id: 'course.assessment.question.textResponses.SpreadsheetManager.targetSheet',
+    defaultMessage: 'Target sheet',
+  },
+  targetSheetDescription: {
+    id: 'course.assessment.question.textResponses.SpreadsheetManager.targetSheetDescription',
+    defaultMessage:
+      'The sheet that unqualified cell references (e.g. A1) resolve to when evaluating the formula. Defaults to the first sheet.',
+  },
   fixedRandomSeed: {
     id: 'course.assessment.question.textResponses.SpreadsheetManager.fixedRandomSeed',
     defaultMessage: 'Fixed random seed',

--- a/client/app/lib/components/form/fields/SingleFileInput/SpreadsheetPreview.tsx
+++ b/client/app/lib/components/form/fields/SingleFileInput/SpreadsheetPreview.tsx
@@ -9,6 +9,9 @@ import { getCellKey, parseSpreadsheet } from './utils';
 
 interface SpreadsheetPreviewProps {
   file: File | null;
+  // Optionally supply already-parsed grid data to avoid re-parsing the file.
+  // When omitted, the component parses `file` itself.
+  grid?: GridData | null;
   activeCellKey?: string | null;
   getCellClassName?: (
     cellValue: SpreadsheetCellValue,
@@ -29,6 +32,7 @@ interface SpreadsheetPreviewProps {
 
 const SpreadsheetPreview: FC<SpreadsheetPreviewProps> = ({
   file,
+  grid: providedGrid,
   activeCellKey,
   onCellClick,
   renderCell,
@@ -36,7 +40,7 @@ const SpreadsheetPreview: FC<SpreadsheetPreviewProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const [grid, setGrid] = useState<GridData | null>(null);
+  const [parsedGrid, setParsedGrid] = useState<GridData | null>(null);
   const [activeSheetIdx, setActiveSheetIdx] = useState(0);
   const [activeCell, setActiveCell] = useState<{
     rowIdx: number;
@@ -44,17 +48,22 @@ const SpreadsheetPreview: FC<SpreadsheetPreviewProps> = ({
   } | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
     setActiveSheetIdx(0);
-    if (file) {
-      parseSpreadsheet(file).then((parsed) => {
-        if (!cancelled) setGrid(parsed);
-      });
-    }
+  }, [file, providedGrid]);
+
+  useEffect(() => {
+    // Skip parsing when the caller already supplies parsed grid data.
+    if (providedGrid !== undefined || !file) return undefined;
+    let cancelled = false;
+    parseSpreadsheet(file).then((parsed) => {
+      if (!cancelled) setParsedGrid(parsed);
+    });
     return (): void => {
       cancelled = true;
     };
-  }, [file]);
+  }, [file, providedGrid !== undefined]);
+
+  const grid = providedGrid ?? parsedGrid;
 
   if (!grid) {
     return <div className="block">{t(translations.dropzone)}</div>;

--- a/client/app/types/course/assessment/question/text-responses.ts
+++ b/client/app/types/course/assessment/question/text-responses.ts
@@ -67,6 +67,7 @@ export interface SolutionData {
     isTimestampFixed: boolean;
     testTimestamp: Date | null;
     numRandomTests: number;
+    targetSheetName?: string | null;
     file?: {
       name: string;
       url: string;
@@ -129,6 +130,7 @@ export interface TextResponseSpreadsheetPostData {
   is_timestamp_fixed?: boolean;
   test_timestamp?: string | null;
   num_random_tests?: number;
+  target_sheet_name?: string | null;
   variables?: string;
   _destroy?: boolean;
 }

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -2330,6 +2330,12 @@
   "course.assessment.question.textResponses.numberOfRandomTests": {
     "defaultMessage": "Number of random tests"
   },
+  "course.assessment.question.textResponses.SpreadsheetManager.targetSheet": {
+    "defaultMessage": "Target sheet"
+  },
+  "course.assessment.question.textResponses.SpreadsheetManager.targetSheetDescription": {
+    "defaultMessage": "The sheet that unqualified cell references (e.g. A1) resolve to when evaluating the formula. Defaults to the first sheet."
+  },
   "course.assessment.question.textResponses.SpreadsheetManager.fixedRandomSeed": {
     "defaultMessage": "Fixed random seed"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -2357,6 +2357,12 @@
   "course.assessment.question.textResponses.numberOfRandomTests": {
     "defaultMessage": "무작위 테스트 횟수"
   },
+  "course.assessment.question.textResponses.SpreadsheetManager.targetSheet": {
+    "defaultMessage": "대상 시트"
+  },
+  "course.assessment.question.textResponses.SpreadsheetManager.targetSheetDescription": {
+    "defaultMessage": "수식을 평가할 때 시트가 지정되지 않은 셀 참조(예: A1)가 가리키는 시트입니다. 기본값은 첫 번째 시트입니다."
+  },
   "course.assessment.question.textResponses.SpreadsheetManager.fixedRandomSeed": {
     "defaultMessage": "고정 무작위 시드"
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -2312,6 +2312,12 @@
   "course.assessment.question.textResponses.numberOfRandomTests": {
     "defaultMessage": "随机测试次数"
   },
+  "course.assessment.question.textResponses.SpreadsheetManager.targetSheet": {
+    "defaultMessage": "目标工作表"
+  },
+  "course.assessment.question.textResponses.SpreadsheetManager.targetSheetDescription": {
+    "defaultMessage": "求值公式时，未指定工作表的单元格引用（例如 A1）所指向的工作表。默认为第一个工作表。"
+  },
   "course.assessment.question.textResponses.SpreadsheetManager.fixedRandomSeed": {
     "defaultMessage": "固定随机种子"
   },

--- a/db/migrate/20260701000000_add_target_sheet_name_to_text_response_solution_spreadsheets.rb
+++ b/db/migrate/20260701000000_add_target_sheet_name_to_text_response_solution_spreadsheets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddTargetSheetNameToTextResponseSolutionSpreadsheets < ActiveRecord::Migration[7.2]
+  def change
+    add_column :course_assessment_question_text_response_solution_spreadsheets,
+               :target_sheet_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_25_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_01_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -467,6 +467,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_25_000000) do
     t.datetime "test_timestamp"
     t.integer "num_random_tests", default: 2, null: false
     t.jsonb "variables", default: [], null: false
+    t.string "target_sheet_name"
     t.index ["solution_id"], name: "idx_on_solution_id_1073150e65"
   end
 

--- a/lib/evaluator_scripts/python/autograde_spreadsheet.py
+++ b/lib/evaluator_scripts/python/autograde_spreadsheet.py
@@ -32,18 +32,27 @@ def generate_character_map(charset):
 
 
 class FormulaEvaluator:
-  def __init__(self, formula_str, filename, variables, randomize_inputs):
+  def __init__(self, formula_str, filename, variables, randomize_inputs, target_sheetname=None):
     self.xl_model = formulas.ExcelModel().loads(local_file_path(filename))
     self.bookname, bookdata = next(iter(self.xl_model.books.items()))
     internal_book = next((v for k, v in bookdata.items() if str(k) == 'Book'), None)
     self.sheetnames = internal_book.sheetnames
     self.book_epoch = internal_book.epoch
-    self.default_sheetname = self.sheetnames[0]
+    # Unqualified references (and variable cells) resolve against the configured
+    # target sheet, falling back to the first sheet when unset or unrecognized.
+    self.default_sheetname = self.resolve_sheetname(target_sheetname)
     self.variables = variables
     self.randomize_inputs = randomize_inputs
 
     rewrite_str = self.rewrite_formula(formula_str)
     self.xl_model.from_dict({ "SHEET1!A1": rewrite_str })
+
+  def resolve_sheetname(self, target_sheetname):
+    if target_sheetname:
+      match = next((s for s in self.sheetnames if s.upper() == target_sheetname.upper()), None)
+      if match:
+        return match
+    return self.sheetnames[0]
 
   def split_sheetname_from_ref(self, ref):
     if '!' in ref:
@@ -158,7 +167,8 @@ def is_output_correct(output, expected):
     return np.all(np.vectorize(compare_output_elements)(comparable_answer, comparable_solution)).item()
   return compare_output_elements(comparable_answer, comparable_solution)
 
-def evaluate_spreadsheet(identifier, answer, solution, filename, variables, random_seed, randomize_inputs):
+def evaluate_spreadsheet(identifier, answer, solution, filename, variables, random_seed, randomize_inputs,
+                         target_sheetname=None):
   result = {
     'identifier': identifier,
     'correct': False
@@ -166,7 +176,7 @@ def evaluate_spreadsheet(identifier, answer, solution, filename, variables, rand
 
   try:
     np.random.seed(random_seed)
-    output_raw = FormulaEvaluator(answer, filename, variables, randomize_inputs).evaluate()
+    output_raw = FormulaEvaluator(answer, filename, variables, randomize_inputs, target_sheetname).evaluate()
     result['output'] = serialize_output(output_raw)
   except Exception as e:
     print(f"Error occurred while evaluating answer formula: {e}", file=sys.stderr, flush=True)
@@ -174,7 +184,7 @@ def evaluate_spreadsheet(identifier, answer, solution, filename, variables, rand
 
   try:
     np.random.seed(random_seed)
-    expected_raw = FormulaEvaluator(solution, filename, variables, randomize_inputs).evaluate()
+    expected_raw = FormulaEvaluator(solution, filename, variables, randomize_inputs, target_sheetname).evaluate()
     result['expected'] = serialize_output(expected_raw)
   except Exception as e:
     print(f"Error occurred while evaluating solution formula: {e}", file=sys.stderr, flush=True)
@@ -195,6 +205,8 @@ def evaluate_solution(answer, solution):
 
   random_seeds = np.random.randint(0, 2**31-1, size=num_random_tests + 1)
 
+  target_sheetname = solution['spreadsheet'].get('target_sheet_name')
+
   with time_machine.travel(datetime.fromisoformat(timestamp)):
     return {
       'solution_id': solution['id'],
@@ -202,12 +214,12 @@ def evaluate_solution(answer, solution):
         evaluate_spreadsheet(
           'test_original_spreadsheet',
           answer, solution['solution'], solution['spreadsheet']['filename'], solution['variables'],
-          random_seeds[0], False
+          random_seeds[0], False, target_sheetname
         ),
         *[evaluate_spreadsheet(
           f"test_random_{i+1}",
           answer, solution['solution'], solution['spreadsheet']['filename'], solution['variables'],
-          random_seeds[i+1], True
+          random_seeds[i+1], True, target_sheetname
         ) for i in range(num_random_tests)]
       ]
     }

--- a/lib/evaluator_scripts/python/tests/test_autograde_spreadsheet.py
+++ b/lib/evaluator_scripts/python/tests/test_autograde_spreadsheet.py
@@ -53,6 +53,23 @@ class TestEvaluateFormula(unittest.TestCase):
     np.random.seed(42)
     self.assertFormula('=RAND() * RAND()', 0.5114958297721829)
 
+  def test_target_sheetname(self):
+    # An unqualified reference resolves against the configured target sheet,
+    # matching the value of the explicitly-qualified reference.
+    for target, expected in [('new sheet', 2), ('newer sheet', 3)]:
+      with self.subTest(target):
+        result = FormulaEvaluator('=A1', SPREADSHEET_PATH, None, False, target).evaluate()
+        self.assertTrue(is_output_correct(result, expected), f'Expected {expected!r}, got {result.value!r}')
+
+  def test_target_sheetname_case_insensitive(self):
+    result = FormulaEvaluator('=A1', SPREADSHEET_PATH, None, False, 'NEW SHEET').evaluate()
+    self.assertTrue(is_output_correct(result, 2), f'Expected 2, got {result.value!r}')
+
+  def test_target_sheetname_unknown_falls_back_to_first_sheet(self):
+    fallback = FormulaEvaluator('=A1', SPREADSHEET_PATH, None, False, 'does not exist').evaluate()
+    default = FormulaEvaluator('=A1', SPREADSHEET_PATH, None, False).evaluate()
+    self.assertTrue(is_output_correct(fallback, default), f'Expected {default.value!r}, got {fallback.value!r}')
+
   def test_spreadsheet_evaluation_error(self):
     result = evaluate_spreadsheet(
       'test_spreadsheet_evaluation_error',

--- a/spec/models/course/assessment/question/text_response_solution_spreadsheet_spec.rb
+++ b/spec/models/course/assessment/question/text_response_solution_spreadsheet_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextResponseSolutionSpreadsheet, type: :model do
+  it 'belongs to solution' do
+    expect(subject).to belong_to(:solution).
+      class_name(Course::Assessment::Question::TextResponseSolution.name)
+  end
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#assign_params' do
+      subject { described_class.new }
+
+      it 'assigns the target sheet name' do
+        subject.assign_params(target_sheet_name: 'Sheet2')
+
+        expect(subject.target_sheet_name).to eq('Sheet2')
+      end
+
+      it 'leaves the target sheet name nil when not provided' do
+        subject.assign_params(num_random_tests: 3)
+
+        expect(subject.target_sheet_name).to be_nil
+      end
+    end
+
+    describe '#initialize_duplicate' do
+      let(:duplicator) { double.tap { |d| allow(d).to receive(:duplicate).and_return(nil) } }
+      let(:other) { described_class.new(target_sheet_name: 'Data', num_random_tests: 5) }
+
+      it 'copies the target sheet name to the duplicate' do
+        subject.initialize_duplicate(duplicator, other)
+
+        expect(subject.target_sheet_name).to eq('Data')
+        expect(subject.num_random_tests).to eq(5)
+      end
+    end
+  end
+end

--- a/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
@@ -135,5 +135,29 @@ RSpec.describe Course::Assessment::Answer::TextResponseAutoGradingService do
         end
       end
     end
+
+    describe '#save_container_test_metadata' do
+      let(:target_sheet_name) { 'Sheet2' }
+      let(:test_spreadsheet) do
+        Course::Assessment::Question::TextResponseSolutionSpreadsheet.new(target_sheet_name: target_sheet_name)
+      end
+      let(:spreadsheet_solution) do
+        build(:course_assessment_question_text_response_solution,
+              solution_type: :spreadsheet_formula, solution: '=A1').tap do |solution|
+          solution.test_spreadsheet = test_spreadsheet
+        end
+      end
+
+      it 'includes the target sheet name in the container test metadata' do
+        captured = nil
+        container = instance_double(CoursemologyDockerContainer)
+        allow(container).to receive(:store_file) { |_path, data| captured = data }
+
+        subject.send(:save_container_test_metadata, container, '=A1', [spreadsheet_solution])
+
+        metadata = JSON.parse(captured)
+        expect(metadata['solutions'].first['spreadsheet']['target_sheet_name']).to eq(target_sheet_name)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds an optional **target sheet** setting to spreadsheet-formula (Excel) autograding.
When configured, a student/solution formula is evaluated as if it lived on that sheet, so
unqualified cell references (e.g. `=A1+A2`) resolve against the chosen sheet instead of
always the first one.

Previously we assumed a formula's result was independent of its location, so no sheet could
be configured. That holds for most formulas, but not when the same cell address exists on
multiple sheets — this closes that gap.

## Changes

### Autograder (`lib/evaluator_scripts/python/autograde_spreadsheet.py`)
- `FormulaEvaluator` accepts a `target_sheetname`. It resolves case-insensitively against the
  workbook's actual sheet names and falls back to the first sheet when unset or unrecognized.
- The resolved sheet becomes `self.default_sheetname`, which the existing `book_ref` fallback
  chain already applies to **both** unqualified formula references and variable-cell overrides —
  so the formula's reads and its randomized inputs stay on the same sheet automatically.
- The formula cell itself is still injected into the isolated scratch cell `SHEET1!A1`
  (encoded as `[filename.xlsx]SHEET1!A1`), so it never collides with real sheets — only the
  reference-resolution default changes.

### Backend (Rails)
- Migration adds a nullable `target_sheet_name` column to
  `course_assessment_question_text_response_solution_spreadsheets` (`NULL` = first sheet, so no
  backfill needed).
- `TextResponseSolutionSpreadsheet#assign_params` and `#initialize_duplicate` handle the new field
  (assignment + duplication).
- Permitted params, the solution-details jbuilder (`targetSheetName`), and the container
  `tests.json` metadata (`target_sheet_name`) are threaded through.

### Frontend
- New **Target sheet** dropdown in the spreadsheet solution's *Advanced Options*, placed under
  the "Fixed date and time" section, directly above the randomization manager. Built with
  `FormSelectField` for consistency.
- A `null` value renders as the first sheet selected (what autograding actually uses), and
  selecting the first sheet stores `null` — keeping the column nullable with no out-of-range
  Select value. A previously-saved sheet still displays even if it is not among the parsed names.
- The dropdown is disabled when there is no spreadsheet or the workbook has only one sheet.
- **Single-parse refactor:** the spreadsheet file is now parsed once in `SpreadsheetManagerPrompt`
  and the parsed `gridData` is shared with the dropdown, `SpreadsheetRandomizationManager` (via a
  new `gridData` prop, replacing its own internal parse), and `SpreadsheetPreview` (via a new
  optional `grid` prop that falls back to self-parsing for its standalone file-input usage).

### i18n
- Added `targetSheet` / `targetSheetDescription` message descriptors and locale entries for
  `en`, `zh`, and `ko`.
  
<img width="1023" height="551" alt="Screenshot 2026-07-19 at 02 03 56" src="https://github.com/user-attachments/assets/2b84da78-9894-4293-872a-ba2eb64c72c3" />


