### PR TITLE
PR6a - fix(spec): make factory sequences unique per process

### DIFF
--- a/spec/factories/instances.rb
+++ b/spec/factories/instances.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 FactoryBot.define do
-  base_time = Time.zone.now.to_i
+  # Unique per process — see the note in user_emails.rb; host and name are both unique-constrained.
+  run_id = "#{Time.zone.now.to_i}-#{Process.pid}"
   sequence :host do |n|
-    "local-#{base_time}-#{n}.lvh.me"
+    "local-#{run_id}-#{n}.lvh.me"
   end
 
   factory :instance do
-    sequence(:name) { |n| "Instance-#{base_time}-#{n}" }
+    sequence(:name) { |n| "Instance-#{run_id}-#{n}" }
     host
 
     trait :with_learning_map_component_enabled do

--- a/spec/factories/user_emails.rb
+++ b/spec/factories/user_emails.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 FactoryBot.define do
-  base_time = Time.zone.now.to_i
+  # Unique per process. Specs commit (use_transactional_fixtures is false), so a bare timestamp
+  # collides whenever two rspec processes start within the same second, and the second process then
+  # fails User::Email's uniqueness validation. Two processes sharing a database are on the same host,
+  # so their pids cannot collide; the timestamp keeps a recycled pid out of the same second and makes
+  # leaked rows traceable.
+  run_id = "#{Time.zone.now.to_i}-#{Process.pid}"
   sequence :email do |n|
-    "user_#{n}@domain-#{base_time}-name.com"
+    "user_#{n}@domain-#{run_id}-name.com"
   end
 
   factory :user_email, class: User::Email.name do

--- a/spec/support/userstamp.rb
+++ b/spec/support/userstamp.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
-ActsAsTenant.with_tenant(Instance.default) do
-  # Create a global stamper for this spec run
-  User.stamper = User.human_users.first
+RSpec.configure do |config|
+  # Create a global stamper for this spec run.
+  #
+  # The stamper becomes the creator (and therefore the auto-built owner course_user) of courses
+  # created in specs, and mail-sending specs deliver to that owner — so the stamper MUST own a
+  # valid email. This suite commits without cleanup (use_transactional_fixtures is false, no
+  # DatabaseCleaner), so if any spec removes the seeded admin's email it stays removed; the next
+  # process's db:seed then recreates the admin as a *new* user, leaving the lowest-id human
+  # (User.human_users.first) permanently without an email.
+  #
+  # Resolve the stamper by the seeded admin email (matching db/seeds and seed.rake) so it always
+  # owns one, and do it in before(:suite) — this runs AFTER rails_helper's top-level db:seed, so
+  # the admin email is guaranteed present even after such a recreation. (Setting it at file-load
+  # time ran before db:seed and re-froze the stale, emailless user.) Fall back to the lowest-id
+  # human only if that email is somehow absent.
+  config.before(:suite) do
+    ActsAsTenant.with_tenant(Instance.default) do
+      User.stamper = User::Email.find_by_email('test@example.org')&.user || User.human_users.first
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Spec factories built a bare per-second timestamp into their sequences. Specs run with `use_transactional_fixtures` disabled, so two rspec processes that start within the same second generate identical values and trip unique constraints. Appending the pid makes the sequences unique regardless of when a process starts: two processes that share a database run on the same host, so their pids cannot collide while both are alive, and the timestamp keeps a recycled pid out of the same second while still making leaked rows traceable to a run.

This also moves the global userstamp setup into a `before(:suite)` hook and resolves the stamper by the seeded admin email instead of the lowest-id human. The stamper becomes the creator (and owner course_user) of courses built in specs, and mail-sending specs deliver to that owner, so it must own a valid email. Because the suite commits without cleanup, a spec that removes the seeded admin's email leaves it removed; the next process's `db:seed` then recreates the admin as a new user and the lowest-id human is permanently emailless. Setting the stamper at file-load time ran before `db:seed` and re-froze that stale user.

## Regression prevention

Covers two sequences that carried a bare timestamp: instance hosts and user email. The values only ever need to be unique, never stable or predictable, so no spec depends on their format. Exercised by every parallel rspec run.
