### PR TITLE
PR6d - feat(marketplace): access audit list and per-user block controls

### DIFF
--- a/client/app/api/system/Admin.ts
+++ b/client/app/api/system/Admin.ts
@@ -5,7 +5,10 @@ import {
 } from 'types/course/announcements';
 import { CourseListData } from 'types/system/courses';
 import { InstanceListData, InstancePermissions } from 'types/system/instances';
-import { AllowlistRulePreviewData } from 'types/system/marketplaceAccess';
+import {
+  AllowlistRulePreviewData,
+  MarketplaceAccessData,
+} from 'types/system/marketplaceAccess';
 import {
   AllowlistRuleData,
   AllowlistRuleFormData,
@@ -246,6 +249,36 @@ export default class AdminAPI extends BaseSystemAPI {
   deleteMarketplaceAllowlistRule(id: number): Promise<AxiosResponse> {
     return this.client.delete(
       `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules/${id}`,
+    );
+  }
+
+  /**
+   * Fetches the marketplace access audit list (everyone with effective access, blocked flagged).
+   */
+  indexMarketplaceAccess(): Promise<AxiosResponse<MarketplaceAccessData>> {
+    return this.client.get(`${AdminAPI.#urlPrefix}/marketplace_access`);
+  }
+
+  /**
+   * Blocks (disables) a user's marketplace access. Returns the created block's id.
+   */
+  blockMarketplaceUser(
+    userId: number,
+  ): Promise<AxiosResponse<{ id: number; userId: number }>> {
+    return this.client.post(
+      `${AdminAPI.#urlPrefix}/marketplace_access_blocks`,
+      {
+        user_id: userId,
+      },
+    );
+  }
+
+  /**
+   * Removes a block, re-enabling the user's marketplace access.
+   */
+  unblockMarketplaceUser(blockId: number): Promise<AxiosResponse> {
+    return this.client.delete(
+      `${AdminAPI.#urlPrefix}/marketplace_access_blocks/${blockId}`,
     );
   }
 }

--- a/client/app/bundles/system/admin/admin/components/MarketplaceAccessFilter.tsx
+++ b/client/app/bundles/system/admin/admin/components/MarketplaceAccessFilter.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { FilterList } from '@mui/icons-material';
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Divider,
+  FormControlLabel,
+  IconButton,
+  Menu,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+export interface RuleOption {
+  id: number;
+  label: string;
+}
+
+interface Props {
+  showActive: boolean;
+  showBlocked: boolean;
+  onToggleActive: () => void;
+  onToggleBlocked: () => void;
+  /** Empty when the marketplace is open to everyone — the rule group is then meaningless. */
+  ruleOptions: RuleOption[];
+  /**
+   * Ids the admin has UNchecked. Tracking exclusions rather than inclusions means a newly added
+   * rule is filtered in by default, with no state to resynchronise when `ruleOptions` changes.
+   */
+  uncheckedRuleIds: Set<number>;
+  onToggleRule: (id: number) => void;
+  onClear: () => void;
+}
+
+const translations = defineMessages({
+  trigger: {
+    id: 'system.admin.admin.MarketplaceAccessFilter.trigger',
+    defaultMessage: 'Filter',
+  },
+  status: {
+    id: 'system.admin.admin.MarketplaceAccessFilter.status',
+    defaultMessage: 'Status',
+  },
+  active: {
+    id: 'system.admin.admin.MarketplaceAccessFilter.active',
+    defaultMessage: 'Active',
+  },
+  blocked: {
+    id: 'system.admin.admin.MarketplaceAccessFilter.blocked',
+    defaultMessage: 'Blocked',
+  },
+  allowedByRule: {
+    id: 'system.admin.admin.MarketplaceAccessFilter.allowedByRule',
+    defaultMessage: 'Allowed by rule',
+  },
+  clearAll: {
+    id: 'system.admin.admin.MarketplaceAccessFilter.clearAll',
+    defaultMessage: 'Clear all',
+  },
+});
+
+const MarketplaceAccessFilter = ({
+  showActive,
+  showBlocked,
+  onToggleActive,
+  onToggleBlocked,
+  ruleOptions,
+  uncheckedRuleIds,
+  onToggleRule,
+  onClear,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  const activeCount =
+    (showActive ? 0 : 1) + (showBlocked ? 0 : 1) + uncheckedRuleIds.size;
+
+  const label = t(translations.trigger);
+
+  return (
+    <>
+      <Tooltip title={label}>
+        <Badge badgeContent={activeCount} className="shrink-0" color="primary">
+          <IconButton
+            aria-label={label}
+            color="primary"
+            onClick={(event): void => setAnchor(event.currentTarget)}
+          >
+            <FilterList />
+          </IconButton>
+        </Badge>
+      </Tooltip>
+
+      <Menu
+        anchorEl={anchor}
+        onClose={(): void => setAnchor(null)}
+        open={Boolean(anchor)}
+      >
+        <div className="flex min-w-[16rem] flex-col px-4 py-2">
+          <Typography color="text.secondary" variant="caption">
+            {t(translations.status)}
+          </Typography>
+
+          <FormControlLabel
+            control={
+              <Checkbox checked={showActive} onChange={onToggleActive} />
+            }
+            label={t(translations.active)}
+          />
+
+          <FormControlLabel
+            control={
+              <Checkbox checked={showBlocked} onChange={onToggleBlocked} />
+            }
+            label={t(translations.blocked)}
+          />
+
+          {ruleOptions.length > 0 && (
+            <>
+              <Divider className="my-2" />
+
+              <Typography color="text.secondary" variant="caption">
+                {t(translations.allowedByRule)}
+              </Typography>
+
+              {ruleOptions.map((option) => (
+                <FormControlLabel
+                  key={option.id}
+                  control={
+                    <Checkbox
+                      checked={!uncheckedRuleIds.has(option.id)}
+                      onChange={(): void => onToggleRule(option.id)}
+                    />
+                  }
+                  label={option.label}
+                />
+              ))}
+            </>
+          )}
+
+          <Button className="mt-2 self-end" onClick={onClear} size="small">
+            {t(translations.clearAll)}
+          </Button>
+        </div>
+      </Menu>
+    </>
+  );
+};
+
+export default MarketplaceAccessFilter;

--- a/client/app/bundles/system/admin/admin/components/MarketplaceAccessSection.tsx
+++ b/client/app/bundles/system/admin/admin/components/MarketplaceAccessSection.tsx
@@ -1,0 +1,642 @@
+import { useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Button, Chip, Typography } from '@mui/material';
+import {
+  AllowedByRule,
+  MarketplaceAccessUser,
+} from 'types/system/marketplaceAccess';
+import { AllowlistRuleData } from 'types/system/marketplaceAllowlist';
+
+import SystemAPI from 'api/system';
+import Link from 'lib/components/core/Link';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Table, { ColumnTemplate } from 'lib/components/table';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import MarketplaceAccessFilter, { RuleOption } from './MarketplaceAccessFilter';
+
+/**
+ * Filter id for the synthetic "System admin" option. Negative so it can never collide with a real
+ * allow-list rule id, which is what the other options carry.
+ */
+const SYSTEM_ADMIN_OPTION_ID = -1;
+
+interface Props {
+  /** Owned by the page, not this section: the toggle and this list must never disagree. */
+  openToEveryone: boolean;
+  /** Bumped by the page on every rule mutation; a change refetches the list. */
+  ruleVersion: number;
+  /** The page's current scoped rules, used to label the filter's rule checkboxes. */
+  rules: AllowlistRuleData[];
+  /**
+   * Published after each fetch: rule id => number of listed users that rule grants access to. The
+   * rules table above the section consumes it to flag rules that match nobody. A rule granting zero
+   * people contributes no key, so a zero-match rule is simply absent from the map.
+   */
+  onMatchCounts?: (counts: Map<number, number>) => void;
+}
+
+const translations = defineMessages({
+  heading: {
+    id: 'system.admin.admin.MarketplaceAccessSection.heading',
+    defaultMessage: 'People matched by these rules',
+  },
+  summary: {
+    id: 'system.admin.admin.MarketplaceAccessSection.summary',
+    defaultMessage: 'Total with access: {count} · {mode}',
+  },
+  summaryWithBlocked: {
+    id: 'system.admin.admin.MarketplaceAccessSection.summaryWithBlocked',
+    defaultMessage:
+      'Total with access: {count} · Total blocked: {blocked} · {mode}',
+  },
+  filteredCounts: {
+    id: 'system.admin.admin.MarketplaceAccessSection.filteredCounts',
+    defaultMessage: 'Filtered: {count} with access · {blocked} blocked',
+  },
+  modeOpen: {
+    id: 'system.admin.admin.MarketplaceAccessSection.modeOpen',
+    defaultMessage: 'Open to everyone',
+  },
+  modeScoped: {
+    id: 'system.admin.admin.MarketplaceAccessSection.modeScoped',
+    defaultMessage: 'Scoped to the rules above',
+  },
+  fetchFailure: {
+    id: 'system.admin.admin.MarketplaceAccessSection.fetchFailure',
+    defaultMessage: 'Failed to load the marketplace access list.',
+  },
+  colName: {
+    id: 'system.admin.admin.MarketplaceAccessSection.colName',
+    defaultMessage: 'Name',
+  },
+  colEmail: {
+    id: 'system.admin.admin.MarketplaceAccessSection.colEmail',
+    defaultMessage: 'Email',
+  },
+  colEligibleVia: {
+    id: 'system.admin.admin.MarketplaceAccessSection.colEligibleVia',
+    defaultMessage: 'Eligible via',
+  },
+  colAllowedBy: {
+    id: 'system.admin.admin.MarketplaceAccessSection.colAllowedBy',
+    defaultMessage: 'Allowed by',
+  },
+  colStatus: {
+    id: 'system.admin.admin.MarketplaceAccessSection.colStatus',
+    defaultMessage: 'Status',
+  },
+  colActions: {
+    id: 'system.admin.admin.MarketplaceAccessSection.colActions',
+    defaultMessage: 'Actions',
+  },
+  managesCourses: {
+    id: 'system.admin.admin.MarketplaceAccessSection.managesCourses',
+    defaultMessage: 'Manages {count, plural, one {# course} other {# courses}}',
+  },
+  instanceInstructor: {
+    id: 'system.admin.admin.MarketplaceAccessSection.instanceInstructor',
+    defaultMessage: 'Instance instructor',
+  },
+  instanceAdministrator: {
+    id: 'system.admin.admin.MarketplaceAccessSection.instanceAdministrator',
+    defaultMessage: 'Instance administrator',
+  },
+  allowedEveryone: {
+    id: 'system.admin.admin.MarketplaceAccessSection.allowedEveryone',
+    defaultMessage: 'Everyone',
+  },
+  allowedNothing: {
+    id: 'system.admin.admin.MarketplaceAccessSection.allowedNothing',
+    defaultMessage: 'No matching rule',
+  },
+  systemAdmin: {
+    id: 'system.admin.admin.MarketplaceAccessSection.systemAdmin',
+    defaultMessage: 'System admin',
+  },
+  typeUser: {
+    id: 'system.admin.admin.MarketplaceAccessSection.typeUser',
+    defaultMessage: 'User',
+  },
+  typeInstance: {
+    id: 'system.admin.admin.MarketplaceAccessSection.typeInstance',
+    defaultMessage: 'Instance',
+  },
+  typeEmailDomain: {
+    id: 'system.admin.admin.MarketplaceAccessSection.typeEmailDomain',
+    defaultMessage: 'Email domain',
+  },
+  statusActive: {
+    id: 'system.admin.admin.MarketplaceAccessSection.statusActive',
+    defaultMessage: 'Active',
+  },
+  statusBlocked: {
+    id: 'system.admin.admin.MarketplaceAccessSection.statusBlocked',
+    defaultMessage: 'Blocked',
+  },
+  disable: {
+    id: 'system.admin.admin.MarketplaceAccessSection.disable',
+    defaultMessage: 'Block',
+  },
+  reEnable: {
+    id: 'system.admin.admin.MarketplaceAccessSection.reEnable',
+    defaultMessage: 'Unblock',
+  },
+  disableSuccess: {
+    id: 'system.admin.admin.MarketplaceAccessSection.disableSuccess',
+    defaultMessage: 'Access blocked for this user.',
+  },
+  disableFailure: {
+    id: 'system.admin.admin.MarketplaceAccessSection.disableFailure',
+    defaultMessage: 'Failed to block access.',
+  },
+  reEnableSuccess: {
+    id: 'system.admin.admin.MarketplaceAccessSection.reEnableSuccess',
+    defaultMessage: 'Access unblocked for this user.',
+  },
+  reEnableFailure: {
+    id: 'system.admin.admin.MarketplaceAccessSection.reEnableFailure',
+    defaultMessage: 'Failed to unblock access.',
+  },
+  searchPlaceholder: {
+    id: 'system.admin.admin.MarketplaceAccessSection.searchPlaceholder',
+    defaultMessage: 'Search by name or email',
+  },
+  dormantHeading: {
+    id: 'system.admin.admin.MarketplaceAccessSection.dormantHeading',
+    defaultMessage: 'Dormant blocks ({count})',
+  },
+  dormantExplanation: {
+    id: 'system.admin.admin.MarketplaceAccessSection.dormantExplanation',
+    defaultMessage:
+      'These people are blocked but no rule currently grants them access. The block denies ' +
+      'nothing today — but it would take effect again if a rule starts matching them, so clear ' +
+      'it if it is no longer wanted.',
+  },
+  clearBlock: {
+    id: 'system.admin.admin.MarketplaceAccessSection.clearBlock',
+    defaultMessage: 'Clear block',
+  },
+});
+
+const MarketplaceAccessSection = ({
+  openToEveryone,
+  ruleVersion,
+  rules,
+  onMatchCounts,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [users, setUsers] = useState<MarketplaceAccessUser[]>([]);
+  const [showActive, setShowActive] = useState(true);
+  const [showBlocked, setShowBlocked] = useState(true);
+  const [uncheckedRuleIds, setUncheckedRuleIds] = useState<Set<number>>(
+    new Set(),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsRefreshing(true);
+
+    SystemAPI.admin
+      .indexMarketplaceAccess()
+      .then((response) => {
+        if (cancelled) return;
+        setUsers(response.data.users);
+        // Publish per-rule grant counts for the rules table above. Built from rows, so a rule that
+        // grants access to nobody contributes no key at all — its absence is the zero-match signal.
+        const counts = new Map<number, number>();
+        response.data.users.forEach((user) => {
+          user.allowedByRules.forEach((rule) => {
+            counts.set(rule.id, (counts.get(rule.id) ?? 0) + 1);
+          });
+        });
+        onMatchCounts?.(counts);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        toast.error(t(translations.fetchFailure));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+        setIsRefreshing(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ruleVersion]);
+
+  const handleDisable = async (user: MarketplaceAccessUser): Promise<void> => {
+    try {
+      const response = await SystemAPI.admin.blockMarketplaceUser(user.id);
+      setUsers((current) =>
+        current.map((u) =>
+          u.id === user.id
+            ? { ...u, blocked: true, blockId: response.data.id }
+            : u,
+        ),
+      );
+      toast.success(t(translations.disableSuccess));
+    } catch {
+      toast.error(t(translations.disableFailure));
+    }
+  };
+
+  /**
+   * Whether anything currently grants this person access, ignoring any block. Mirrors the server's
+   * own notion of "allowed": the role, the everyone-mode, or at least one matching rule. Note that
+   * everyone-mode deliberately sends no per-row rules, so an empty `allowedByRules` is NOT on its
+   * own a signal that someone has no access.
+   */
+  const isAllowed = (user: MarketplaceAccessUser): boolean =>
+    user.systemAdmin || openToEveryone || user.allowedByRules.length > 0;
+
+  /** Blocked, but nothing would grant them access anyway — the block denies nothing today. */
+  const isDormantBlock = (user: MarketplaceAccessUser): boolean =>
+    user.blocked && !isAllowed(user);
+
+  const handleReEnable = async (user: MarketplaceAccessUser): Promise<void> => {
+    if (user.blockId === null) return;
+    try {
+      await SystemAPI.admin.unblockMarketplaceUser(user.blockId);
+      setUsers((current) =>
+        // Someone listed ONLY because they were blocked has no reason to stay once the block goes —
+        // patching the row in place would leave them as "Active · No matching rule", counted as
+        // having access they do not have. Mirrors the server: listed iff allowed OR blocked.
+        current.flatMap((u) => {
+          if (u.id !== user.id) return [u];
+          return isAllowed(u) ? [{ ...u, blocked: false, blockId: null }] : [];
+        }),
+      );
+      toast.success(t(translations.reEnableSuccess));
+    } catch {
+      toast.error(t(translations.reEnableFailure));
+    }
+  };
+
+  const eligibleVia = (user: MarketplaceAccessUser): string => {
+    // A system admin's eligibility comes from the role, not from courses or instance membership —
+    // and they are listed even when they have neither, where the other branches say nothing.
+    if (user.systemAdmin) return t(translations.systemAdmin);
+
+    const parts: string[] = [];
+    if (user.courseCount > 0) {
+      parts.push(t(translations.managesCourses, { count: user.courseCount }));
+    }
+    if (user.instanceRole === 'instructor') {
+      parts.push(t(translations.instanceInstructor));
+    }
+    if (user.instanceRole === 'administrator') {
+      parts.push(t(translations.instanceAdministrator));
+    }
+    return parts.length > 0 ? parts.join('; ') : '—';
+  };
+
+  const typeLabels: Record<AllowedByRule['ruleType'], string> = {
+    user: t(translations.typeUser),
+    instance: t(translations.typeInstance),
+    email_domain: t(translations.typeEmailDomain),
+  };
+
+  const ruleLabel = (rule: AllowedByRule): string =>
+    `${typeLabels[rule.ruleType]} (${rule.labelValue ?? `#${rule.id}`})`;
+
+  // Every reason, not one winner: the admin reads this column to decide which rules are safe to
+  // delete, and a single reason answers that question wrongly.
+  const renderAllowedBy = (user: MarketplaceAccessUser): JSX.Element => {
+    // Ahead of both other branches: the role is why they have access, and it outlives any rule
+    // change — saying "Everyone" or naming a rule would misattribute it.
+    if (user.systemAdmin) return <span>{t(translations.systemAdmin)}</span>;
+    if (openToEveryone) return <span>{t(translations.allowedEveryone)}</span>;
+    if (user.allowedByRules.length === 0) {
+      return <span>{t(translations.allowedNothing)}</span>;
+    }
+
+    return (
+      <div className="flex flex-col">
+        {user.allowedByRules.map((rule) => (
+          <span key={rule.id}>{ruleLabel(rule)}</span>
+        ))}
+      </div>
+    );
+  };
+
+  const ruleOptionLabel = (rule: AllowlistRuleData): string => {
+    switch (rule.ruleType) {
+      case 'user':
+        return `${typeLabels.user} (${rule.userName ?? `#${rule.userId}`})`;
+      case 'instance':
+        return `${typeLabels.instance} (${
+          rule.instanceName ?? `#${rule.instanceId}`
+        })`;
+      default:
+        return `${typeLabels.email_domain} (${rule.emailDomain ?? ''})`;
+    }
+  };
+
+  // Open to everyone means every row is granted by the mode, not by a rule, so the group is hidden.
+  // System admin is a reason in its own right, so it gets an option whenever any listed user is
+  // one — including in everyone-mode, where their access still comes from the role, not the mode.
+  const ruleOptions: RuleOption[] = [
+    ...(users.some((user) => user.systemAdmin)
+      ? [{ id: SYSTEM_ADMIN_OPTION_ID, label: t(translations.systemAdmin) }]
+      : []),
+    ...(openToEveryone
+      ? []
+      : rules.map((rule) => ({ id: rule.id, label: ruleOptionLabel(rule) }))),
+  ];
+
+  const toggleRule = (id: number): void =>
+    setUncheckedRuleIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const clearFilters = (): void => {
+    setShowActive(true);
+    setShowBlocked(true);
+    setUncheckedRuleIds(new Set());
+  };
+
+  const matchesFilter = (user: MarketplaceAccessUser): boolean => {
+    if (user.blocked ? !showBlocked : !showActive) return false;
+    if (uncheckedRuleIds.size === 0) return true;
+
+    // Being a system admin is a reason alongside the rules, so an admin survives the filter while
+    // that option stays checked — without this they carry no reasons at all and would vanish the
+    // moment any rule box is unchecked.
+    const reasonIds = user.allowedByRules.map((rule) => rule.id);
+    if (user.systemAdmin) reasonIds.push(SYSTEM_ADMIN_OPTION_ID);
+    // Everyone-mode grants access outside the rules, so only the admin option can filter there.
+    if (openToEveryone && !user.systemAdmin) return true;
+
+    return reasonIds.some((id) => !uncheckedRuleIds.has(id));
+  };
+
+  const columns: ColumnTemplate<MarketplaceAccessUser>[] = [
+    {
+      of: 'name',
+      title: t(translations.colName),
+      searchable: true,
+      cell: (user) => (
+        <Link to={`/users/${user.id}`} underline="hover">
+          {user.name}
+        </Link>
+      ),
+    },
+    {
+      of: 'email',
+      title: t(translations.colEmail),
+      searchable: true,
+      cell: (user) => user.email,
+    },
+    {
+      id: 'eligibleVia',
+      title: t(translations.colEligibleVia),
+      cell: (user) => eligibleVia(user),
+    },
+    {
+      id: 'allowedBy',
+      title: t(translations.colAllowedBy),
+      cell: (user) => renderAllowedBy(user),
+    },
+    {
+      id: 'status',
+      title: t(translations.colStatus),
+      // This column's content changes with row STATE (Active↔Blocked), so its intrinsic width
+      // changes as people are blocked, shifting every column to its left. A width on the cell
+      // itself does NOT fix that: under table-layout:auto a cell width is only a suggestion, and
+      // the browser still distributes slack using each column's max-content width. Pinning the
+      // width on a wrapper INSIDE the cell makes that max-content constant, which is what actually
+      // holds the layout still. `whitespace-nowrap` keeps an overlong translation overflowing
+      // visibly rather than wrapping and silently reintroducing the shift.
+      className: 'whitespace-nowrap',
+      cell: (user) => (
+        <div className="w-28">
+          <Chip
+            color={user.blocked ? 'default' : 'success'}
+            label={
+              user.blocked
+                ? t(translations.statusBlocked)
+                : t(translations.statusActive)
+            }
+            size="small"
+            variant={user.blocked ? 'outlined' : 'filled'}
+          />
+        </div>
+      ),
+    },
+    {
+      id: 'action',
+      title: t(translations.colActions),
+      // Same reasoning as `status` above: Block↔Unblock. Sized to `Unblock`, the wider of the
+      // two, so flipping a row never moves its neighbours.
+      className: 'whitespace-nowrap',
+      cell: (user) =>
+        // No action for a system admin: `can :manage, :all` outranks the allow-list, so a block
+        // would not actually revoke anything — the row would read "Blocked" while they kept full
+        // access. Better to offer nothing than an action that silently does nothing.
+        user.systemAdmin ? null : (
+          <div className="w-24">
+            {/*
+            `min-w-0 px-0` on both: MUI gives a Button horizontal padding and a 64px min-width, so
+            the label sits inset from the cell edge (misaligned with the `Actions` header) by an
+            amount that DIFFERS per label — `Block` is narrower than the min-width and gets
+            centred in the leftover space, `Unblock` is not. Stripping both makes the button hug
+            its text, so header and both states start at the same x.
+          */}
+            {user.blocked ? (
+              <Button
+                className="min-w-0 px-0"
+                color="primary"
+                onClick={(): Promise<void> => handleReEnable(user)}
+                size="small"
+              >
+                {t(translations.reEnable)}
+              </Button>
+            ) : (
+              <Button
+                className="min-w-0 px-0"
+                color="error"
+                onClick={(): Promise<void> => handleDisable(user)}
+                size="small"
+              >
+                {t(translations.disable)}
+              </Button>
+            )}
+          </div>
+        ),
+    },
+  ];
+
+  // No status or reason columns: every row here is dormant-blocked and allowed by nothing, so
+  // those cells would repeat the section heading on every line.
+  const dormantColumns: ColumnTemplate<MarketplaceAccessUser>[] = [
+    {
+      of: 'name',
+      title: t(translations.colName),
+      cell: (user) => (
+        <Link to={`/users/${user.id}`} underline="hover">
+          {user.name}
+        </Link>
+      ),
+    },
+    {
+      of: 'email',
+      title: t(translations.colEmail),
+      cell: (user) => user.email,
+    },
+    {
+      id: 'action',
+      title: t(translations.colActions),
+      className: 'whitespace-nowrap',
+      cell: (user) => (
+        <div className="w-28">
+          <Button
+            className="min-w-0 px-0"
+            color="primary"
+            onClick={(): Promise<void> => handleReEnable(user)}
+            size="small"
+          >
+            {t(translations.clearBlock)}
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  if (isLoading) return <LoadingIndicator />;
+
+  // Derived from the rows, not the server summary: block/unblock patch rows locally without a
+  // refetch, so a summary-bound count would drift the moment an admin disables someone.
+  // Split first: a dormant block is not a person with access, so it is counted out of the headline
+  // totals and out of the main table, and gets its own section below.
+  const dormantUsers = users.filter(isDormantBlock);
+  const accessUsers = users.filter((user) => !isDormantBlock(user));
+  const totalWithAccess = accessUsers.filter((user) => !user.blocked).length;
+  const totalBlocked = accessUsers.filter((user) => user.blocked).length;
+  const filteredUsers = accessUsers.filter(matchesFilter);
+  // Only the filter menu is observable here — the search box lives inside Table and narrows the
+  // rows after this point, so a search alone does not surface the line.
+  const isFiltered = filteredUsers.length < accessUsers.length;
+  const mode = openToEveryone
+    ? t(translations.modeOpen)
+    : t(translations.modeScoped);
+
+  // Remount the main table when the filter state changes so pagination snaps back to the first
+  // page: an admin on page 2 who narrows the filter below one page of results would otherwise be
+  // stranded on an empty page. The shared Table keeps pagination internal with no external setter
+  // and does not auto-reset the page index on a data change, so a key change is the only in-section
+  // lever. Keyed on the filter state alone (not the fetched data), so a background refetch does not
+  // disturb the current page. The dormant table below is unfiltered and needs none of this.
+  const filterKey = `${showActive}:${showBlocked}:${[...uncheckedRuleIds]
+    .sort((a, b) => a - b)
+    .join(',')}`;
+
+  return (
+    <div className="mt-8">
+      <Typography variant="h6">{t(translations.heading)}</Typography>
+
+      <Typography color="text.secondary" variant="body2">
+        {totalBlocked > 0
+          ? t(translations.summaryWithBlocked, {
+              count: totalWithAccess,
+              blocked: totalBlocked,
+              mode,
+            })
+          : t(translations.summary, { count: totalWithAccess, mode })}
+      </Typography>
+
+      {/*
+        Only while the filter is narrowing: unfiltered, this line would repeat the totals verbatim.
+        The totals above stay put as the audit anchor — this answers the narrower question the
+        filter poses ("of the people this rule lets in, how many are blocked?"), which nothing else
+        on the page reports.
+      */}
+      {isFiltered && (
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.filteredCounts, {
+            count: filteredUsers.filter((user) => !user.blocked).length,
+            blocked: filteredUsers.filter((user) => user.blocked).length,
+          })}
+        </Typography>
+      )}
+
+      <div className={`mt-3 ${isRefreshing ? 'opacity-50' : ''}`}>
+        <Table
+          key={filterKey}
+          columns={columns}
+          data={filteredUsers}
+          getRowId={(user): string => user.id.toString()}
+          pagination={{
+            initialPageSize: 20,
+            rowsPerPage: [10, 20, 50, DEFAULT_TABLE_ROWS_PER_PAGE],
+            showAllRows: true,
+          }}
+          search={{
+            searchPlaceholder: t(translations.searchPlaceholder),
+            searchProps: {
+              shouldInclude: (user, filterValue?: string): boolean => {
+                if (!filterValue) return true;
+                const query = filterValue.toLowerCase().trim();
+                return (
+                  user.name.toLowerCase().includes(query) ||
+                  user.email.toLowerCase().includes(query)
+                );
+              },
+            },
+          }}
+          toolbar={{
+            show: true,
+            buttons: [
+              <MarketplaceAccessFilter
+                key="marketplace-access-filter"
+                onClear={clearFilters}
+                onToggleActive={(): void => setShowActive((on) => !on)}
+                onToggleBlocked={(): void => setShowBlocked((on) => !on)}
+                onToggleRule={toggleRule}
+                ruleOptions={ruleOptions}
+                showActive={showActive}
+                showBlocked={showBlocked}
+                uncheckedRuleIds={uncheckedRuleIds}
+              />,
+            ],
+          }}
+        />
+      </div>
+
+      {dormantUsers.length > 0 && (
+        <div className="mt-8">
+          <Typography variant="h6">
+            {t(translations.dormantHeading, { count: dormantUsers.length })}
+          </Typography>
+
+          <Typography className="mb-3" color="text.secondary" variant="body2">
+            {t(translations.dormantExplanation)}
+          </Typography>
+
+          <div className={isRefreshing ? 'opacity-50' : undefined}>
+            <Table
+              columns={dormantColumns}
+              data={dormantUsers}
+              getRowId={(user): string => user.id.toString()}
+              pagination={{
+                initialPageSize: 10,
+                rowsPerPage: [10, 20, 50, DEFAULT_TABLE_ROWS_PER_PAGE],
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MarketplaceAccessSection;

--- a/client/app/bundles/system/admin/admin/components/__test__/MarketplaceAccessSection.test.tsx
+++ b/client/app/bundles/system/admin/admin/components/__test__/MarketplaceAccessSection.test.tsx
@@ -1,0 +1,997 @@
+import userEvent from '@testing-library/user-event';
+import { createMockAdapter } from 'mocks/axiosMock';
+import { act, fireEvent, render, waitFor, within } from 'test-utils';
+import TestApp from 'utilities/TestApp';
+
+import SystemAPI from 'api/system';
+
+import MarketplaceAccessSection from '../MarketplaceAccessSection';
+
+const mock = createMockAdapter(SystemAPI.admin.client);
+beforeEach(() => mock.reset());
+
+const ACCESS_URL = '/admin/marketplace_access';
+const BLOCKS_URL = '/admin/marketplace_access_blocks';
+const NUS_LABEL = 'nus.edu.sg';
+const DORMANT_DAN = 'Dormant Dan';
+const ROOT_ADMIN = 'Root Admin';
+const EMAIL_NUS_LABEL = 'Email domain (nus.edu.sg)';
+const SYSTEM_ADMIN = 'System admin';
+const FETCH_FAILURE = 'Failed to load the marketplace access list.';
+
+const activeUser = {
+  id: 1,
+  name: 'Jane Tan',
+  email: 'jane@nus.edu.sg',
+  courseCount: 3,
+  instanceRole: null,
+  allowedByRules: [
+    { id: 10, ruleType: 'email_domain' as const, labelValue: NUS_LABEL },
+  ],
+  systemAdmin: false,
+  blocked: false,
+  blockId: null,
+};
+
+/** Blocked AND still allowed by a rule — a LIVE block, so they belong in the main table. */
+const blockedUser = {
+  id: 2,
+  name: 'Kumar Raj',
+  email: 'kumar@sch.edu.sg',
+  courseCount: 0,
+  instanceRole: 'instructor' as const,
+  allowedByRules: [
+    { id: 10, ruleType: 'email_domain' as const, labelValue: NUS_LABEL },
+  ],
+  systemAdmin: false,
+  blocked: true,
+  blockId: 55,
+};
+
+/**
+ * Blocked with nothing granting them access — their rule was deleted while the block stood. The
+ * block denies nothing today, so this one belongs in the dormant section, not the main table.
+ */
+const dormantUser = {
+  id: 4,
+  name: DORMANT_DAN,
+  email: 'dan@sch.edu.sg',
+  courseCount: 1,
+  instanceRole: null,
+  allowedByRules: [],
+  systemAdmin: false,
+  blocked: true,
+  blockId: 77,
+};
+
+const adminUser = {
+  id: 3,
+  name: ROOT_ADMIN,
+  email: 'root@coursemology.org',
+  courseCount: 0,
+  instanceRole: null,
+  allowedByRules: [],
+  systemAdmin: true,
+  blocked: false,
+  blockId: null,
+};
+
+const DOMAIN_RULE = {
+  id: 10,
+  ruleType: 'email_domain' as const,
+  userId: null,
+  userName: null,
+  userEmail: null,
+  instanceId: null,
+  instanceName: null,
+  emailDomain: NUS_LABEL,
+};
+
+const USER_RULE = {
+  id: 11,
+  ruleType: 'user' as const,
+  userId: 1,
+  userName: 'Jane Tan',
+  userEmail: 'jane@nus.edu.sg',
+  instanceId: null,
+  instanceName: null,
+  emailDomain: null,
+};
+
+const openFilter = async (page: ReturnType<typeof render>): Promise<void> => {
+  fireEvent.click(page.getByRole('button', { name: 'Filter' }));
+  await page.findByRole('menu');
+};
+
+const closeFilter = async (page: ReturnType<typeof render>): Promise<void> => {
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(page.queryByRole('menu')).not.toBeInTheDocument());
+};
+
+/** Open the filter, toggle one checkbox by its accessible name, then close it. */
+const toggleFilter = async (
+  page: ReturnType<typeof render>,
+  checkboxName: string,
+): Promise<void> => {
+  await openFilter(page);
+  fireEvent.click(page.getByRole('checkbox', { name: checkboxName }));
+  await closeFilter(page);
+};
+
+const renderSection = (props?: {
+  openToEveryone?: boolean;
+  ruleVersion?: number;
+  rules?: (typeof DOMAIN_RULE | typeof USER_RULE)[];
+}): ReturnType<typeof render> =>
+  render(
+    <MarketplaceAccessSection
+      openToEveryone={props?.openToEveryone ?? false}
+      rules={props?.rules ?? [DOMAIN_RULE]}
+      ruleVersion={props?.ruleVersion ?? 0}
+    />,
+  );
+
+const accessGetCount = (): number =>
+  mock.history.get.filter((request) => request.url === ACCESS_URL).length;
+
+it('renders the access list with annotations and a summary', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+
+  expect(await page.findByText('Jane Tan')).toBeVisible();
+  expect(page.getByText('jane@nus.edu.sg')).toBeVisible();
+  expect(page.getByText('Manages 3 courses')).toBeVisible();
+  expect(page.getByText('Instance instructor')).toBeVisible();
+  // Both fixtures are allowed by the same rule, so the label appears once per row.
+  expect(page.getAllByText(EMAIL_NUS_LABEL)).toHaveLength(2);
+  expect(page.getByText('Active')).toBeVisible();
+  expect(page.getByText('Blocked')).toBeVisible();
+});
+
+it('names the blocked total in the subtitle when anyone is blocked', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+
+  expect(
+    await page.findByText(
+      'Total with access: 1 · Total blocked: 1 · Scoped to the rules above',
+    ),
+  ).toBeVisible();
+});
+
+it('omits the blocked segment when nobody is blocked', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+
+  expect(
+    await page.findByText('Total with access: 1 · Scoped to the rules above'),
+  ).toBeVisible();
+});
+
+it('reads the mode from props rather than the fetched summary', async () => {
+  // The parent owns the toggle, so a stale server summary must not win.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection({ openToEveryone: true });
+
+  expect(
+    await page.findByText('Total with access: 1 · Open to everyone'),
+  ).toBeVisible();
+});
+
+it('shows Everyone as the reason when the marketplace is open to everyone', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: true },
+  });
+
+  const page = renderSection({ openToEveryone: true });
+
+  expect(await page.findByText('Everyone')).toBeVisible();
+  expect(page.queryByText(EMAIL_NUS_LABEL)).not.toBeInTheDocument();
+});
+
+it('lists every rule that grants a user access', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [
+      {
+        ...activeUser,
+        allowedByRules: [
+          { id: 10, ruleType: 'email_domain', labelValue: NUS_LABEL },
+          { id: 11, ruleType: 'user', labelValue: 'Jane Tan' },
+        ],
+      },
+    ],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+
+  expect(await page.findByText(EMAIL_NUS_LABEL)).toBeVisible();
+  expect(page.getByText('User (Jane Tan)')).toBeVisible();
+});
+
+it('moves a block with no matching rule into the dormant list', async () => {
+  // Their rule was deleted while the block stood. The block denies nothing today, so they are not
+  // "people with access" — but it must stay visible and clearable, because re-adding a matching
+  // rule would silently leave them blocked.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, dormantUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  expect(page.getByText('Dormant blocks (1)')).toBeVisible();
+  expect(page.getByText(DORMANT_DAN)).toBeVisible();
+  // Counted out of the headline totals, which describe people with access.
+  expect(
+    page.getByText('Total with access: 1 · Scoped to the rules above'),
+  ).toBeVisible();
+});
+
+it('keeps a block that a rule still backs in the main table', async () => {
+  // This block IS denying access right now, so it belongs with the people it applies to.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [blockedUser],
+    summary: { totalWithAccess: 0, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Kumar Raj');
+
+  expect(page.queryByText(/^Dormant blocks/)).not.toBeInTheDocument();
+  expect(
+    page.getByText(
+      'Total with access: 0 · Total blocked: 1 · Scoped to the rules above',
+    ),
+  ).toBeVisible();
+});
+
+it('shows no dormant section when there are no dormant blocks', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  expect(page.queryByText(/^Dormant blocks/)).not.toBeInTheDocument();
+});
+
+it('treats a block as dormant only outside everyone-mode', async () => {
+  // Everyone-mode grants access outside the rules, so an empty allowedByRules is not "no access" —
+  // the block is live and the row stays in the main table.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [dormantUser],
+    summary: { totalWithAccess: 0, totalBlocked: 1, openToEveryone: true },
+  });
+
+  const page = renderSection({ openToEveryone: true });
+  await page.findByText(DORMANT_DAN);
+
+  expect(page.queryByText(/^Dormant blocks/)).not.toBeInTheDocument();
+});
+
+it('clears a dormant block and drops the row', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, dormantUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+  mock.onDelete(`${BLOCKS_URL}/77`).reply(200);
+
+  const page = renderSection();
+  await page.findByText(DORMANT_DAN);
+
+  fireEvent.click(page.getByRole('button', { name: 'Clear block' }));
+
+  await waitFor(() => expect(mock.history.delete).toHaveLength(1));
+  expect(mock.history.delete[0].url).toBe(`${BLOCKS_URL}/77`);
+
+  // Nothing grants them access, so clearing the block removes their last reason to be listed.
+  await waitFor(() =>
+    expect(page.queryByText(DORMANT_DAN)).not.toBeInTheDocument(),
+  );
+  expect(page.queryByText(/^Dormant blocks/)).not.toBeInTheDocument();
+});
+
+it('pins the width of the two state-driven columns', async () => {
+  // Status and Actions are the only columns whose content changes with row STATE
+  // (Active↔Blocked, Block↔Unblock), so under table-layout:auto they resize as people are
+  // blocked and shift every column to their left. The width must sit on a wrapper INSIDE the cell,
+  // not on the cell: a table cell's width is only a suggestion under auto layout, so a cell-level
+  // class leaves the shift in place. jsdom does no layout, so this asserts the wrapper exists and
+  // is pinned in BOTH states; the visual claim is covered by manual verification.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  // Both status states, so a width applied to only one branch of the ternary would fail.
+  expect(page.getByText('Blocked').closest('div.w-28')).toBeInTheDocument();
+  expect(page.getByText('Active').closest('div.w-28')).toBeInTheDocument();
+
+  // Both action states, for the same reason.
+  const reEnable = page.getByRole('button', { name: 'Unblock' });
+  const disable = page.getByRole('button', { name: 'Block' });
+  expect(reEnable.closest('div.w-24')).toBeInTheDocument();
+  expect(disable.closest('div.w-24')).toBeInTheDocument();
+
+  // MUI's button padding and 64px min-width inset each label from the cell edge by a per-label
+  // amount, so the two states and the column header start at different x without these.
+  expect(reEnable).toHaveClass('min-w-0', 'px-0');
+  expect(disable).toHaveClass('min-w-0', 'px-0');
+});
+
+it('labels a system admin in both reason columns', async () => {
+  // The admin manages nothing and matches no rule, so without the systemAdmin branch these cells
+  // would read '—' and 'No matching rule' for someone who in fact bypasses every gate.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [adminUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText(ROOT_ADMIN);
+
+  expect(page.getAllByText(SYSTEM_ADMIN)).toHaveLength(2);
+  expect(page.queryByText('No matching rule')).not.toBeInTheDocument();
+});
+
+it('labels a system admin as such even when open to everyone', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [adminUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: true },
+  });
+
+  const page = renderSection({ openToEveryone: true });
+  await page.findByText(ROOT_ADMIN);
+
+  expect(page.getAllByText(SYSTEM_ADMIN)).toHaveLength(2);
+  expect(page.queryByText('Everyone')).not.toBeInTheDocument();
+});
+
+it('reports filtered counts only while the filter narrows the set', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  // Unfiltered: the line would only repeat the totals, so it is absent.
+  expect(page.queryByText(/^Filtered:/)).not.toBeInTheDocument();
+
+  await toggleFilter(page, 'Active');
+
+  expect(
+    await page.findByText('Filtered: 0 with access · 1 blocked'),
+  ).toBeVisible();
+  // The totals stay put as the audit anchor rather than being rewritten by the filter.
+  expect(
+    page.getByText(
+      'Total with access: 1 · Total blocked: 1 · Scoped to the rules above',
+    ),
+  ).toBeVisible();
+
+  await toggleFilter(page, 'Active');
+
+  await waitFor(() =>
+    expect(page.queryByText(/^Filtered:/)).not.toBeInTheDocument(),
+  );
+});
+
+it('offers no disable action for a system admin', async () => {
+  // Blocking an admin cannot revoke anything (`can :manage, :all` outranks the allow-list), so the
+  // action would be a lie — the row would say "Blocked" while they kept full access.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, adminUser],
+    summary: { totalWithAccess: 2, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText(ROOT_ADMIN);
+
+  // Exactly one Block button, and it belongs to the non-admin.
+  expect(page.getAllByRole('button', { name: 'Block' })).toHaveLength(1);
+  expect(
+    page.queryByRole('button', { name: 'Unblock' }),
+  ).not.toBeInTheDocument();
+});
+
+it('filters system admins in and out via their own option', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, adminUser],
+    summary: { totalWithAccess: 2, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText(ROOT_ADMIN);
+
+  await toggleFilter(page, SYSTEM_ADMIN);
+  await waitFor(() =>
+    expect(page.queryByText(ROOT_ADMIN)).not.toBeInTheDocument(),
+  );
+  expect(page.getByText('Jane Tan')).toBeVisible();
+
+  await toggleFilter(page, SYSTEM_ADMIN);
+  await waitFor(() => expect(page.getByText(ROOT_ADMIN)).toBeVisible());
+});
+
+it('keeps a system admin listed when a rule box is unchecked', async () => {
+  // An admin carries no rules, so treating rules as the only reasons would drop them from the
+  // table the moment any rule filter is touched.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, adminUser],
+    summary: { totalWithAccess: 2, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText(ROOT_ADMIN);
+
+  await toggleFilter(page, EMAIL_NUS_LABEL);
+
+  await waitFor(() =>
+    expect(page.queryByText('Jane Tan')).not.toBeInTheDocument(),
+  );
+  expect(page.getByText(ROOT_ADMIN)).toBeVisible();
+});
+
+it('offers no system-admin option when nobody listed is one', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+  await openFilter(page);
+
+  expect(
+    page.queryByRole('checkbox', { name: SYSTEM_ADMIN }),
+  ).not.toBeInTheDocument();
+});
+
+it('links each name to that user', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+
+  const link = await page.findByRole('link', { name: 'Jane Tan' });
+  expect(link).toHaveAttribute('href', '/users/1');
+});
+
+it('refetches the list when the rule version changes', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+  expect(accessGetCount()).toBe(1);
+
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp>
+      <MarketplaceAccessSection
+        openToEveryone={false}
+        rules={[DOMAIN_RULE]}
+        ruleVersion={1}
+      />
+    </TestApp>,
+  );
+
+  await waitFor(() => expect(accessGetCount()).toBe(2));
+  expect(await page.findByText('Kumar Raj')).toBeVisible();
+});
+
+it('does not refetch when unrelated props change', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+  expect(accessGetCount()).toBe(1);
+
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp>
+      <MarketplaceAccessSection
+        openToEveryone
+        rules={[DOMAIN_RULE]}
+        ruleVersion={0}
+      />
+    </TestApp>,
+  );
+
+  await waitFor(() =>
+    expect(
+      page.getByText('Total with access: 1 · Open to everyone'),
+    ).toBeVisible(),
+  );
+  expect(accessGetCount()).toBe(1);
+});
+
+it('toasts when the fetch fails', async () => {
+  mock.onGet(ACCESS_URL).reply(500);
+
+  const page = renderSection();
+
+  expect(await page.findByText(FETCH_FAILURE)).toBeVisible();
+});
+
+it('does not toast a failure from a fetch superseded by a rule-version change', async () => {
+  let failFirstFetch: (reason?: unknown) => void = () => {};
+  mock
+    .onGet(ACCESS_URL)
+    .replyOnce(
+      () =>
+        new Promise((_, reject) => {
+          failFirstFetch = reject;
+        }),
+    )
+    .onGet(ACCESS_URL)
+    .reply(200, {
+      users: [activeUser],
+      summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+    });
+
+  const page = renderSection();
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp>
+      <MarketplaceAccessSection
+        openToEveryone={false}
+        rules={[DOMAIN_RULE]}
+        ruleVersion={1}
+      />
+    </TestApp>,
+  );
+  await page.findByText('Jane Tan');
+
+  await act(async () => {
+    failFirstFetch(new Error('superseded'));
+  });
+
+  expect(page.queryByText(FETCH_FAILURE)).not.toBeInTheDocument();
+});
+
+it('disables an active user and flips the row to Blocked', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+  mock.onPost(BLOCKS_URL).reply(200, { id: 77, userId: 1 });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  fireEvent.click(page.getByRole('button', { name: 'Block' }));
+
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  expect(JSON.parse(mock.history.post[0].data)).toEqual({ user_id: 1 });
+
+  expect(await page.findByRole('button', { name: 'Unblock' })).toBeVisible();
+  expect(page.getByText('Blocked')).toBeVisible();
+});
+
+it('updates the subtitle counts after a local disable, without refetching', async () => {
+  // Block/unblock patch rows in place, so counts must come from the rows, not the server summary.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+  mock.onPost(BLOCKS_URL).reply(200, { id: 77, userId: 1 });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  fireEvent.click(page.getByRole('button', { name: 'Block' }));
+
+  expect(
+    await page.findByText(
+      'Total with access: 0 · Total blocked: 1 · Scoped to the rules above',
+    ),
+  ).toBeVisible();
+  expect(accessGetCount()).toBe(1);
+});
+
+it('re-enables a blocked user and flips the row to Active', async () => {
+  // A rule still allows them, so unblocking leaves them listed — the row flips rather than going.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [
+      {
+        ...blockedUser,
+        allowedByRules: [
+          {
+            id: 10,
+            ruleType: 'email_domain' as const,
+            labelValue: NUS_LABEL,
+          },
+        ],
+      },
+    ],
+    summary: { totalWithAccess: 0, totalBlocked: 1, openToEveryone: false },
+  });
+  mock.onDelete(`${BLOCKS_URL}/55`).reply(200);
+
+  const page = renderSection();
+  await page.findByText('Kumar Raj');
+
+  fireEvent.click(page.getByRole('button', { name: 'Unblock' }));
+
+  await waitFor(() => expect(mock.history.delete).toHaveLength(1));
+  expect(mock.history.delete[0].url).toBe(`${BLOCKS_URL}/55`);
+
+  expect(await page.findByRole('button', { name: 'Block' })).toBeVisible();
+  expect(page.getByText('Active')).toBeVisible();
+});
+
+it('keeps an unblocked user listed in everyone-mode, where rules are empty by design', async () => {
+  // Everyone-mode grants access outside the rules, so an empty allowedByRules is NOT a signal that
+  // they have no access — dropping on empty alone would wrongly remove them here.
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [dormantUser], // no rules at all, so only the everyone-mode branch can keep them
+    summary: { totalWithAccess: 0, totalBlocked: 1, openToEveryone: true },
+  });
+  mock.onDelete(`${BLOCKS_URL}/77`).reply(200);
+
+  const page = renderSection({ openToEveryone: true });
+  await page.findByText(DORMANT_DAN);
+
+  fireEvent.click(page.getByRole('button', { name: 'Unblock' }));
+
+  expect(await page.findByRole('button', { name: 'Block' })).toBeVisible();
+  expect(page.getByText(DORMANT_DAN)).toBeVisible();
+});
+
+it('searches by name and email', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  await userEvent.type(
+    page.getByPlaceholderText('Search by name or email'),
+    'kumar@',
+  );
+
+  await waitFor(() =>
+    expect(page.queryByText('Jane Tan')).not.toBeInTheDocument(),
+  );
+  expect(page.getByText('Kumar Raj')).toBeVisible();
+});
+
+it('shows both active and blocked users by default', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+
+  expect(await page.findByText('Jane Tan')).toBeVisible();
+  expect(page.getByText('Kumar Raj')).toBeVisible();
+});
+
+it('shows only blocked users when Active is unchecked', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  await toggleFilter(page, 'Active');
+
+  await waitFor(() =>
+    expect(page.queryByText('Jane Tan')).not.toBeInTheDocument(),
+  );
+  expect(page.getByText('Kumar Raj')).toBeVisible();
+});
+
+it('filters to the users a specific rule grants access to', async () => {
+  const otherUser = {
+    ...activeUser,
+    id: 3,
+    name: 'Wei Ling',
+    email: 'wei@moe.gov.sg',
+    allowedByRules: [
+      { id: 11, ruleType: 'user' as const, labelValue: 'Wei Ling' },
+    ],
+  };
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, otherUser],
+    summary: { totalWithAccess: 2, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection({ rules: [DOMAIN_RULE, USER_RULE] });
+  await page.findByText('Jane Tan');
+
+  // Uncheck the user rule; only the domain-granted user should remain.
+  await toggleFilter(page, 'User (Jane Tan)');
+
+  await waitFor(() =>
+    expect(page.queryByText('Wei Ling')).not.toBeInTheDocument(),
+  );
+  // Assert on the email, not the name: 'Jane Tan' is also the user rule's checkbox label, so a
+  // name query would match two elements whenever the filter menu is open.
+  expect(page.getByText('jane@nus.edu.sg')).toBeVisible();
+});
+
+it('hides the rule group when the marketplace is open to everyone', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: true },
+  });
+
+  const page = renderSection({ openToEveryone: true, rules: [DOMAIN_RULE] });
+  await page.findByText('Jane Tan');
+  await openFilter(page);
+
+  // Scoped to the menu: the table also has a Status column header.
+  expect(within(page.getByRole('menu')).getByText('Status')).toBeVisible();
+  expect(page.queryByText('Allowed by rule')).not.toBeInTheDocument();
+  expect(
+    page.queryByRole('checkbox', { name: EMAIL_NUS_LABEL }),
+  ).not.toBeInTheDocument();
+});
+
+it('badges the filter button while any box is unchecked', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+  await openFilter(page);
+
+  fireEvent.click(page.getByRole('checkbox', { name: 'Active' }));
+
+  // Scope to the badge: a bare '1' would also match pagination and count text.
+  expect(
+    await page.findByText('1', { selector: '.MuiBadge-badge' }),
+  ).toBeVisible();
+});
+
+it('composes the filter with the search field', async () => {
+  const otherBlocked = {
+    ...blockedUser,
+    id: 4,
+    name: 'Siti Nur',
+    email: 'siti@sch.edu.sg',
+    blockId: 56,
+  };
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser, otherBlocked],
+    summary: { totalWithAccess: 1, totalBlocked: 2, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  await toggleFilter(page, 'Active');
+  await waitFor(() =>
+    expect(page.queryByText('Jane Tan')).not.toBeInTheDocument(),
+  );
+
+  await userEvent.type(
+    page.getByPlaceholderText('Search by name or email'),
+    'siti',
+  );
+
+  await waitFor(() =>
+    expect(page.queryByText('Kumar Raj')).not.toBeInTheDocument(),
+  );
+  expect(page.getByText('Siti Nur')).toBeVisible();
+});
+
+it('restores everything when the filter is cleared', async () => {
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = renderSection();
+  await page.findByText('Jane Tan');
+
+  await toggleFilter(page, 'Active');
+  await waitFor(() =>
+    expect(page.queryByText('Jane Tan')).not.toBeInTheDocument(),
+  );
+
+  await openFilter(page);
+  fireEvent.click(page.getByRole('button', { name: 'Clear all' }));
+  await closeFilter(page);
+
+  expect(await page.findByText('Jane Tan')).toBeVisible();
+  expect(page.getByText('Kumar Raj')).toBeVisible();
+});
+
+it("publishes each rule's grant count after the access list loads", async () => {
+  const onMatchCounts = jest.fn();
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [
+      {
+        ...activeUser,
+        allowedByRules: [
+          { id: 10, ruleType: 'email_domain', labelValue: NUS_LABEL },
+          { id: 11, ruleType: 'user', labelValue: 'Jane Tan' },
+        ],
+      },
+      blockedUser, // allowedByRules: [rule 10]
+    ],
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  const page = render(
+    <MarketplaceAccessSection
+      onMatchCounts={onMatchCounts}
+      openToEveryone={false}
+      rules={[DOMAIN_RULE, USER_RULE]}
+      ruleVersion={0}
+    />,
+  );
+  await page.findByText('Jane Tan');
+
+  await waitFor(() => expect(onMatchCounts).toHaveBeenCalled());
+  const counts: Map<number, number> =
+    onMatchCounts.mock.calls[onMatchCounts.mock.calls.length - 1][0];
+  // Rule 10 grants both listed users; rule 11 grants only the first.
+  expect(counts.get(10)).toBe(2);
+  expect(counts.get(11)).toBe(1);
+});
+
+it('omits a rule that grants access to nobody from the published counts', async () => {
+  // A zero-match rule contributes no key — its absence is what the rules table reads as "nobody".
+  const onMatchCounts = jest.fn();
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser], // allowedByRules: [rule 10] only
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = render(
+    <MarketplaceAccessSection
+      onMatchCounts={onMatchCounts}
+      openToEveryone={false}
+      rules={[DOMAIN_RULE, USER_RULE]}
+      ruleVersion={0}
+    />,
+  );
+  await page.findByText('Jane Tan');
+
+  await waitFor(() => expect(onMatchCounts).toHaveBeenCalled());
+  const counts: Map<number, number> =
+    onMatchCounts.mock.calls[onMatchCounts.mock.calls.length - 1][0];
+  expect(counts.has(11)).toBe(false);
+  expect(counts.get(10)).toBe(1);
+});
+
+it('republishes counts when the rule version changes', async () => {
+  const onMatchCounts = jest.fn();
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser], // rule 10 grants 1
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = render(
+    <MarketplaceAccessSection
+      onMatchCounts={onMatchCounts}
+      openToEveryone={false}
+      rules={[DOMAIN_RULE]}
+      ruleVersion={0}
+    />,
+  );
+  await page.findByText('Jane Tan');
+  await waitFor(() => expect(onMatchCounts).toHaveBeenCalledTimes(1));
+
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [activeUser, blockedUser], // rule 10 now grants 2
+    summary: { totalWithAccess: 1, totalBlocked: 1, openToEveryone: false },
+  });
+
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp>
+      <MarketplaceAccessSection
+        onMatchCounts={onMatchCounts}
+        openToEveryone={false}
+        rules={[DOMAIN_RULE]}
+        ruleVersion={1}
+      />
+    </TestApp>,
+  );
+
+  await waitFor(() => expect(onMatchCounts).toHaveBeenCalledTimes(2));
+  const counts: Map<number, number> =
+    onMatchCounts.mock.calls[onMatchCounts.mock.calls.length - 1][0];
+  expect(counts.get(10)).toBe(2);
+});
+
+it('returns to the first page when the filter narrows the result set', async () => {
+  // 21 people are granted by the domain rule and 4 by the user rule, so the list spans two pages at
+  // the default page size of 20. An admin on page 2 who filters out the domain rule drops to a
+  // single page — the table must snap back to page 1 rather than strand them on an empty page 2.
+  const domainUsers = Array.from({ length: 21 }, (_, i) => ({
+    id: i + 1,
+    name: `Domain User ${i + 1}`,
+    email: `domain${i + 1}@nus.edu.sg`,
+    courseCount: 1,
+    instanceRole: null,
+    allowedByRules: [
+      { id: 10, ruleType: 'email_domain', labelValue: NUS_LABEL },
+    ],
+    systemAdmin: false,
+    blocked: false,
+    blockId: null,
+  }));
+  const userRuleUsers = Array.from({ length: 4 }, (_, i) => ({
+    id: 100 + i,
+    name: `Rule User ${i + 1}`,
+    email: `rule${i + 1}@moe.gov.sg`,
+    courseCount: 1,
+    instanceRole: null,
+    allowedByRules: [{ id: 11, ruleType: 'user', labelValue: 'Jane Tan' }],
+    systemAdmin: false,
+    blocked: false,
+    blockId: null,
+  }));
+  mock.onGet(ACCESS_URL).reply(200, {
+    users: [...domainUsers, ...userRuleUsers],
+    summary: { totalWithAccess: 25, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = renderSection({ rules: [DOMAIN_RULE, USER_RULE] });
+  await page.findByText('Domain User 1');
+
+  // Go to page 2 — the four user-rule people live here, past the first 20 domain users.
+  fireEvent.click(page.getByRole('button', { name: 'Go to next page' }));
+  await page.findByText('Rule User 1');
+  expect(page.queryByText('Domain User 1')).not.toBeInTheDocument();
+
+  // Filter out the domain rule: only the four user-rule people remain — a single page.
+  await toggleFilter(page, EMAIL_NUS_LABEL);
+
+  // Snapped back to page 1: the remaining people are visible, not stranded behind an empty page 2.
+  expect(await page.findByText('Rule User 1')).toBeVisible();
+  expect(page.getByText('Rule User 4')).toBeVisible();
+});

--- a/client/app/bundles/system/admin/admin/pages/MarketplaceAllowlistIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/MarketplaceAllowlistIndex.tsx
@@ -14,6 +14,7 @@ import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import toast from 'lib/hooks/toast';
 
 import MarketplaceAllowlistRuleForm from '../components/forms/MarketplaceAllowlistRuleForm';
+import MarketplaceAccessSection from '../components/MarketplaceAccessSection';
 import MarketplaceAllowlistModeBanner from '../components/MarketplaceAllowlistModeBanner';
 import MarketplaceAllowlistTable from '../components/tables/MarketplaceAllowlistTable';
 
@@ -72,6 +73,14 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [rules, setRules] = useState<AllowlistRuleData[]>([]);
   const [everyoneRuleId, setEveryoneRuleId] = useState<number | null>(null);
+  // Bumped on every rule mutation. Adding a domain rule changes who is in the access list in ways
+  // the client cannot compute locally, so the list must refetch rather than patch itself.
+  const [ruleVersion, setRuleVersion] = useState(0);
+  // Published by the access section after each fetch; passed to the rules table so it can flag rules
+  // that grant access to nobody. Null until the first fetch resolves (unknown ≠ zero).
+  const [matchCounts, setMatchCounts] = useState<Map<number, number> | null>(
+    null,
+  );
 
   useEffect(() => {
     SystemAPI.admin
@@ -85,12 +94,21 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
   }, []);
 
   const openToEveryone = everyoneRuleId !== null;
+  const invalidateAccessList = (): void => {
+    // Blank the counts until the refetch this triggers resolves: they are derived from the access
+    // list, so between a mutation and the fresh fetch they are stale. After a Restrict, the
+    // everyone-mode counts are an empty map that would mark every scoped rule as matching nobody.
+    // Null means "unknown, don't warn", same as before the first load.
+    setMatchCounts(null);
+    setRuleVersion((version) => version + 1);
+  };
 
   const handleCreate = async (data: AllowlistRuleFormData): Promise<void> => {
     try {
       const response =
         await SystemAPI.admin.createMarketplaceAllowlistRule(data);
       setRules((current) => [...current, response.data]);
+      invalidateAccessList();
       toast.success(intl.formatMessage(translations.createSuccess));
       setIsFormOpen(false);
     } catch (error) {
@@ -106,6 +124,7 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
     try {
       await SystemAPI.admin.deleteMarketplaceAllowlistRule(id);
       setRules((current) => current.filter((rule) => rule.id !== id));
+      invalidateAccessList();
       toast.success(intl.formatMessage(translations.deleteSuccess));
     } catch {
       toast.error(intl.formatMessage(translations.deleteFailure));
@@ -116,6 +135,7 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
     try {
       const response = await SystemAPI.admin.openMarketplaceToEveryone();
       setEveryoneRuleId(response.data.id);
+      invalidateAccessList();
       toast.success(intl.formatMessage(translations.openSuccess));
     } catch {
       toast.error(intl.formatMessage(translations.openFailure));
@@ -127,6 +147,7 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
     try {
       await SystemAPI.admin.deleteMarketplaceAllowlistRule(everyoneRuleId);
       setEveryoneRuleId(null);
+      invalidateAccessList();
       toast.success(intl.formatMessage(translations.restrictSuccess));
     } catch {
       toast.error(intl.formatMessage(translations.restrictFailure));
@@ -158,6 +179,7 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
           </AddButton>
         }
         disabled={openToEveryone}
+        matchCounts={openToEveryone ? null : matchCounts}
         onDelete={handleDelete}
         rules={rules}
       />
@@ -166,6 +188,13 @@ const MarketplaceAllowlistIndex: FC<Props> = ({ intl }) => {
         onClose={(): void => setIsFormOpen(false)}
         onSubmit={handleCreate}
         open={isFormOpen}
+      />
+
+      <MarketplaceAccessSection
+        onMatchCounts={setMatchCounts}
+        openToEveryone={openToEveryone}
+        rules={rules}
+        ruleVersion={ruleVersion}
       />
     </Page>
   );

--- a/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceAllowlistIndex.test.tsx
+++ b/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceAllowlistIndex.test.tsx
@@ -9,6 +9,10 @@ import MarketplaceAllowlistIndex from '../MarketplaceAllowlistIndex';
 const mock = createMockAdapter(SystemAPI.admin.client);
 beforeEach(() => {
   mock.reset();
+  mock.onGet('/admin/marketplace_access').reply(200, {
+    users: [],
+    summary: { totalWithAccess: 0, openToEveryone: false },
+  });
 });
 
 const INDEX_URL = '/admin/marketplace_allowlist_rules';
@@ -17,6 +21,8 @@ const NUS_DOMAIN = 'nus.edu.sg';
 const EMAIL_DOMAIN_SUBTITLE = 'Email domain (e.g. schools.gov.sg)';
 const OPEN_TO_EVERYONE = 'Open to everyone';
 const ADD_ACCESS_RULE = 'Add access rule';
+const ZERO_MATCH_WARNING =
+  'No eligible users currently match this rule, so it grants access to nobody.';
 const allowlistGetCount = (): number =>
   mock.history.get.filter((request) => request.url === INDEX_URL).length;
 const RULES = [
@@ -48,6 +54,10 @@ const ONE_MATCH_PREVIEW = {
     },
   ],
 };
+const accessGetCount = (): number =>
+  mock.history.get.filter(
+    (request) => request.url === '/admin/marketplace_access',
+  ).length;
 // Step 2's preview is a POST too, so `mock.history.post[0]` is the preview, not the create.
 const createPosts = (): typeof mock.history.post =>
   mock.history.post.filter((request) => request.url === INDEX_URL);
@@ -410,6 +420,81 @@ it('keeps the Open to everyone toggle label on a single line', async () => {
   expect(label).toHaveClass('whitespace-nowrap');
 });
 
+it('refreshes the access list after a rule is added', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: [] });
+  mock.onPost(PREVIEW_URL).reply(200, {
+    matchedCount: 1,
+    newCount: 1,
+    openToEveryone: false,
+    users: [],
+  });
+  mock.onPost(INDEX_URL).reply(200, {
+    id: 2,
+    ruleType: 'email_domain',
+    userId: null,
+    userName: null,
+    userEmail: null,
+    instanceId: null,
+    instanceName: null,
+    emailDomain: NUS_DOMAIN,
+  });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(allowlistGetCount()).toBe(1));
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+
+  fireEvent.click(page.getByText('Add access rule'));
+  await userEvent.type(page.getByLabelText(EMAIL_DOMAIN_SUBTITLE), NUS_DOMAIN);
+  fireEvent.click(page.getByRole('button', { name: 'Next' }));
+  await confirmAdd(page);
+
+  await waitFor(() => expect(accessGetCount()).toBe(2));
+});
+
+it('refreshes the access list after a rule is deleted', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES });
+  mock.onDelete(`${INDEX_URL}/1`).reply(200);
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(page.getByText(EMAIL_DOMAIN)).toBeVisible());
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+
+  fireEvent.click(page.getByTestId('DeleteIconButton'));
+  fireEvent.click(page.getByRole('button', { name: 'Delete' }));
+
+  await waitFor(() => expect(accessGetCount()).toBe(2));
+});
+
+it('refreshes the access list after the marketplace is opened to everyone', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: null });
+  mock.onPost(INDEX_URL).reply(200, { id: 99 });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+
+  fireEvent.click(page.getByRole('checkbox', { name: OPEN_TO_EVERYONE }));
+  const dialog = page.getByRole('dialog');
+  fireEvent.click(
+    within(dialog).getByRole('button', { name: OPEN_TO_EVERYONE }),
+  );
+
+  await waitFor(() => expect(accessGetCount()).toBe(2));
+});
+
+it('refreshes the access list after the marketplace is restricted again', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: 42 });
+  mock.onDelete(`${INDEX_URL}/42`).reply(200);
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+
+  fireEvent.click(page.getByRole('checkbox', { name: OPEN_TO_EVERYONE }));
+  const dialog = page.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Restrict' }));
+
+  await waitFor(() => expect(accessGetCount()).toBe(2));
+});
+
 it('surfaces the server message when a rule is rejected as a duplicate', async () => {
   mock.onGet(INDEX_URL).reply(200, { rules: [] });
   mock.onPost(PREVIEW_URL).reply(200, ONE_MATCH_PREVIEW);
@@ -429,4 +514,122 @@ it('surfaces the server message when a rule is rejected as a duplicate', async (
   expect(
     await page.findByText('Email domain already has the same rule.'),
   ).toBeVisible();
+});
+
+it('flags a rule that the loaded access list grants to nobody', async () => {
+  // beforeEach returns no access-list users, so the single email-domain rule matches nobody.
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByLabelText(ZERO_MATCH_WARNING)).toBeInTheDocument();
+});
+
+it('does not flag a rule that the access list grants to someone', async () => {
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES });
+  mock.onGet('/admin/marketplace_access').reply(200, {
+    users: [
+      {
+        id: 1,
+        name: 'Jane Tan',
+        email: 'jane@schools.gov.sg',
+        courseCount: 1,
+        instanceRole: null,
+        allowedByRules: [
+          { id: 1, ruleType: 'email_domain', labelValue: EMAIL_DOMAIN },
+        ],
+        systemAdmin: false,
+        blocked: false,
+        blockId: null,
+      },
+    ],
+    summary: { totalWithAccess: 1, totalBlocked: 0, openToEveryone: false },
+  });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  // Wait for the access list to render (counts are published only after it resolves).
+  await page.findByText('jane@schools.gov.sg');
+
+  expect(page.queryByLabelText(ZERO_MATCH_WARNING)).not.toBeInTheDocument();
+});
+
+it('suppresses zero-match warnings while the marketplace is open to everyone', async () => {
+  // Everyone-mode empties scoped_rules, so every rule would report zero — but the mode banner
+  // already says the rules are moot, so the page passes null and shows no icons at all.
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: 42 });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(page.getByText(EMAIL_DOMAIN)).toBeVisible());
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+
+  expect(page.queryByLabelText(ZERO_MATCH_WARNING)).not.toBeInTheDocument();
+});
+
+it('does not flash zero-match warnings while a refetch after restrict is in flight', async () => {
+  // Restrict flips openToEveryone off and triggers a refetch. Until it resolves, the previously
+  // published counts are stale: everyone-mode publishes an empty map, which would mark every scoped
+  // rule as matching nobody. invalidateAccessList must blank matchCounts to null so no false warning
+  // shows in that window.
+  mock.onGet(INDEX_URL).reply(200, { rules: RULES, everyoneRuleId: 42 });
+  mock.onDelete(`${INDEX_URL}/42`).reply(200);
+
+  let releaseSecond = (): void => {};
+  let accessCalls = 0;
+  mock.onGet('/admin/marketplace_access').reply(() => {
+    accessCalls += 1;
+    if (accessCalls === 1) {
+      // Everyone-mode: users carry no per-rule reasons, so the published map is empty.
+      return [
+        200,
+        { users: [], summary: { totalWithAccess: 0, openToEveryone: true } },
+      ];
+    }
+    // Second fetch (after restrict) stays pending until released.
+    return new Promise((resolve) => {
+      releaseSecond = (): void =>
+        resolve([
+          200,
+          {
+            users: [
+              {
+                id: 1,
+                name: 'Jane',
+                email: 'jane@schools.gov.sg',
+                courseCount: 1,
+                instanceRole: null,
+                allowedByRules: [
+                  { id: 1, ruleType: 'email_domain', labelValue: EMAIL_DOMAIN },
+                ],
+                systemAdmin: false,
+                blocked: false,
+                blockId: null,
+              },
+            ],
+            summary: {
+              totalWithAccess: 1,
+              totalBlocked: 0,
+              openToEveryone: false,
+            },
+          },
+        ]);
+    });
+  });
+
+  const page = render(<MarketplaceAllowlistIndex />, { at: [INDEX_URL] });
+  await waitFor(() => expect(accessGetCount()).toBe(1));
+  await page.findByText(EMAIL_DOMAIN);
+
+  // Restrict: toggle off, then confirm in the dialog.
+  fireEvent.click(page.getByRole('checkbox', { name: OPEN_TO_EVERYONE }));
+  const dialog = page.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Restrict' }));
+
+  // Refetch is now in flight (second GET pending). No stale zero-match warning may show.
+  await waitFor(() => expect(accessGetCount()).toBe(2));
+  expect(page.queryByLabelText(ZERO_MATCH_WARNING)).not.toBeInTheDocument();
+
+  // Let the refetch resolve; Jane matches rule 1, so still no warning.
+  releaseSecond();
+  await page.findByText('jane@schools.gov.sg');
+  expect(page.queryByLabelText(ZERO_MATCH_WARNING)).not.toBeInTheDocument();
 });

--- a/client/app/types/system/marketplaceAccess.ts
+++ b/client/app/types/system/marketplaceAccess.ts
@@ -1,3 +1,37 @@
+import { AllowlistRuleType } from 'types/system/marketplaceAllowlist';
+
+/**
+ * One rule granting a user access. A user may be granted by several rules at once — the audit list
+ * shows all of them, because the admin uses that column to decide which rules are safe to delete.
+ */
+export interface AllowedByRule {
+  id: number;
+  ruleType: AllowlistRuleType;
+  labelValue: string | null;
+}
+
+export interface MarketplaceAccessUser {
+  id: number;
+  name: string;
+  email: string;
+  courseCount: number;
+  instanceRole: 'instructor' | 'administrator' | null;
+  allowedByRules: AllowedByRule[];
+  /** System admins bypass every gate, so they are listed and labelled regardless of the rules. */
+  systemAdmin: boolean;
+  blocked: boolean;
+  blockId: number | null;
+}
+
+export interface MarketplaceAccessData {
+  users: MarketplaceAccessUser[];
+  summary: {
+    totalWithAccess: number;
+    totalBlocked: number;
+    openToEveryone: boolean;
+  };
+}
+
 export interface MarketplaceRulePreviewUser {
   id: number;
   name: string;

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -8924,6 +8924,126 @@
   "system.admin.admin.InstancesTable.updateSuccess": {
     "defaultMessage": "Renamed {field} from {prevValue} to {newValue}"
   },
+  "system.admin.admin.MarketplaceAccessFilter.trigger": {
+    "defaultMessage": "Filter"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.status": {
+    "defaultMessage": "Status"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.active": {
+    "defaultMessage": "Active"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.blocked": {
+    "defaultMessage": "Blocked"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.allowedByRule": {
+    "defaultMessage": "Allowed by rule"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.clearAll": {
+    "defaultMessage": "Clear all"
+  },
+  "system.admin.admin.MarketplaceAccessSection.heading": {
+    "defaultMessage": "People matched by these rules"
+  },
+  "system.admin.admin.MarketplaceAccessSection.summary": {
+    "defaultMessage": "Total with access: {count} · {mode}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.summaryWithBlocked": {
+    "defaultMessage": "Total with access: {count} · Total blocked: {blocked} · {mode}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.filteredCounts": {
+    "defaultMessage": "Filtered: {count} with access · {blocked} blocked"
+  },
+  "system.admin.admin.MarketplaceAccessSection.modeOpen": {
+    "defaultMessage": "Open to everyone"
+  },
+  "system.admin.admin.MarketplaceAccessSection.modeScoped": {
+    "defaultMessage": "Scoped to the rules above"
+  },
+  "system.admin.admin.MarketplaceAccessSection.fetchFailure": {
+    "defaultMessage": "Failed to load the marketplace access list."
+  },
+  "system.admin.admin.MarketplaceAccessSection.colName": {
+    "defaultMessage": "Name"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colEmail": {
+    "defaultMessage": "Email"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colEligibleVia": {
+    "defaultMessage": "Eligible via"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colAllowedBy": {
+    "defaultMessage": "Allowed by"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colStatus": {
+    "defaultMessage": "Status"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colActions": {
+    "defaultMessage": "Actions"
+  },
+  "system.admin.admin.MarketplaceAccessSection.managesCourses": {
+    "defaultMessage": "Manages {count, plural, one {# course} other {# courses}}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.instanceInstructor": {
+    "defaultMessage": "Instance instructor"
+  },
+  "system.admin.admin.MarketplaceAccessSection.instanceAdministrator": {
+    "defaultMessage": "Instance administrator"
+  },
+  "system.admin.admin.MarketplaceAccessSection.allowedEveryone": {
+    "defaultMessage": "Everyone"
+  },
+  "system.admin.admin.MarketplaceAccessSection.allowedNothing": {
+    "defaultMessage": "No matching rule"
+  },
+  "system.admin.admin.MarketplaceAccessSection.systemAdmin": {
+    "defaultMessage": "System admin"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeUser": {
+    "defaultMessage": "User"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeInstance": {
+    "defaultMessage": "Instance"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeEmailDomain": {
+    "defaultMessage": "Email domain"
+  },
+  "system.admin.admin.MarketplaceAccessSection.statusActive": {
+    "defaultMessage": "Active"
+  },
+  "system.admin.admin.MarketplaceAccessSection.statusBlocked": {
+    "defaultMessage": "Blocked"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disable": {
+    "defaultMessage": "Block"
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnable": {
+    "defaultMessage": "Unblock"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disableSuccess": {
+    "defaultMessage": "Access blocked for this user."
+  },
+  "system.admin.admin.MarketplaceAccessSection.disableFailure": {
+    "defaultMessage": "Failed to block access."
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnableSuccess": {
+    "defaultMessage": "Access unblocked for this user."
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnableFailure": {
+    "defaultMessage": "Failed to unblock access."
+  },
+  "system.admin.admin.MarketplaceAccessSection.searchPlaceholder": {
+    "defaultMessage": "Search by name or email"
+  },
+  "system.admin.admin.MarketplaceAccessSection.dormantHeading": {
+    "defaultMessage": "Dormant blocks ({count})"
+  },
+  "system.admin.admin.MarketplaceAccessSection.dormantExplanation": {
+    "defaultMessage": "These people are blocked but no rule currently grants them access. The block denies nothing today — but it would take effect again if a rule starts matching them, so clear it if it is no longer wanted."
+  },
+  "system.admin.admin.MarketplaceAccessSection.clearBlock": {
+    "defaultMessage": "Clear block"
+  },
   "system.admin.admin.MarketplaceAllowlistIndex.addRule": {
     "defaultMessage": "Add access rule"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -8900,6 +8900,126 @@
   "system.admin.admin.InstancesTable.updateSuccess": {
     "defaultMessage": "{field}이(가) {prevValue}에서 {newValue}로 변경되었습니다."
   },
+  "system.admin.admin.MarketplaceAccessFilter.trigger": {
+    "defaultMessage": "필터"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.status": {
+    "defaultMessage": "상태"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.active": {
+    "defaultMessage": "활성"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.blocked": {
+    "defaultMessage": "차단됨"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.allowedByRule": {
+    "defaultMessage": "허용 규칙"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.clearAll": {
+    "defaultMessage": "모두 지우기"
+  },
+  "system.admin.admin.MarketplaceAccessSection.heading": {
+    "defaultMessage": "접근 권한이 있는 사용자"
+  },
+  "system.admin.admin.MarketplaceAccessSection.summary": {
+    "defaultMessage": "총 접근 가능 인원: {count} · {mode}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.summaryWithBlocked": {
+    "defaultMessage": "총 접근 가능 인원: {count} · 총 차단 인원: {blocked} · {mode}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.filteredCounts": {
+    "defaultMessage": "필터링됨: 접근 가능 {count} · 차단 {blocked}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.modeOpen": {
+    "defaultMessage": "모두에게 공개"
+  },
+  "system.admin.admin.MarketplaceAccessSection.modeScoped": {
+    "defaultMessage": "위 규칙으로 제한됨"
+  },
+  "system.admin.admin.MarketplaceAccessSection.fetchFailure": {
+    "defaultMessage": "마켓플레이스 접근 목록을 불러오지 못했습니다."
+  },
+  "system.admin.admin.MarketplaceAccessSection.colName": {
+    "defaultMessage": "이름"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colEmail": {
+    "defaultMessage": "이메일"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colEligibleVia": {
+    "defaultMessage": "적격 사유"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colAllowedBy": {
+    "defaultMessage": "허용 근거"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colStatus": {
+    "defaultMessage": "상태"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colActions": {
+    "defaultMessage": "작업"
+  },
+  "system.admin.admin.MarketplaceAccessSection.managesCourses": {
+    "defaultMessage": "{count, plural, one {#개 과정 관리 중} other {#개 과정 관리 중}}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.instanceInstructor": {
+    "defaultMessage": "인스턴스 강사"
+  },
+  "system.admin.admin.MarketplaceAccessSection.instanceAdministrator": {
+    "defaultMessage": "인스턴스 관리자"
+  },
+  "system.admin.admin.MarketplaceAccessSection.allowedEveryone": {
+    "defaultMessage": "모든 사용자"
+  },
+  "system.admin.admin.MarketplaceAccessSection.allowedNothing": {
+    "defaultMessage": "일치하는 규칙 없음"
+  },
+  "system.admin.admin.MarketplaceAccessSection.systemAdmin": {
+    "defaultMessage": "시스템 관리자"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeUser": {
+    "defaultMessage": "사용자"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeInstance": {
+    "defaultMessage": "인스턴스"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeEmailDomain": {
+    "defaultMessage": "이메일 도메인"
+  },
+  "system.admin.admin.MarketplaceAccessSection.statusActive": {
+    "defaultMessage": "활성"
+  },
+  "system.admin.admin.MarketplaceAccessSection.statusBlocked": {
+    "defaultMessage": "차단됨"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disable": {
+    "defaultMessage": "차단"
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnable": {
+    "defaultMessage": "차단 해제"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disableSuccess": {
+    "defaultMessage": "이 사용자의 접근이 차단되었습니다."
+  },
+  "system.admin.admin.MarketplaceAccessSection.disableFailure": {
+    "defaultMessage": "접근 차단에 실패했습니다."
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnableSuccess": {
+    "defaultMessage": "이 사용자의 접근 차단이 해제되었습니다."
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnableFailure": {
+    "defaultMessage": "접근 차단 해제에 실패했습니다."
+  },
+  "system.admin.admin.MarketplaceAccessSection.searchPlaceholder": {
+    "defaultMessage": "이름 또는 이메일 검색"
+  },
+  "system.admin.admin.MarketplaceAccessSection.dormantHeading": {
+    "defaultMessage": "휴면 차단 ({count})"
+  },
+  "system.admin.admin.MarketplaceAccessSection.dormantExplanation": {
+    "defaultMessage": "이 사용자들은 차단되어 있지만, 현재 어떤 규칙도 이들에게 접근 권한을 부여하지 않습니다. 이 차단은 현재로서는 아무것도 막고 있지 않지만, 이후 어떤 규칙이 이들과 일치하게 되면 다시 효력을 발휘하므로, 더 이상 필요하지 않다면 차단을 해제하세요."
+  },
+  "system.admin.admin.MarketplaceAccessSection.clearBlock": {
+    "defaultMessage": "차단 제거"
+  },
   "system.admin.admin.MarketplaceAllowlistIndex.addRule": {
     "defaultMessage": "접근 규칙 추가"
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -8894,6 +8894,126 @@
   "system.admin.admin.InstancesTable.updateSuccess": {
     "defaultMessage": "已将 {field} 从 {prevValue} 重命名为 {newValue}"
   },
+  "system.admin.admin.MarketplaceAccessFilter.trigger": {
+    "defaultMessage": "筛选"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.status": {
+    "defaultMessage": "状态"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.active": {
+    "defaultMessage": "活跃"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.blocked": {
+    "defaultMessage": "已屏蔽"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.allowedByRule": {
+    "defaultMessage": "允许规则"
+  },
+  "system.admin.admin.MarketplaceAccessFilter.clearAll": {
+    "defaultMessage": "全部清除"
+  },
+  "system.admin.admin.MarketplaceAccessSection.heading": {
+    "defaultMessage": "拥有访问权限的用户"
+  },
+  "system.admin.admin.MarketplaceAccessSection.summary": {
+    "defaultMessage": "拥有访问权限总数：{count} · {mode}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.summaryWithBlocked": {
+    "defaultMessage": "拥有访问权限总数：{count} · 屏蔽总数：{blocked} · {mode}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.filteredCounts": {
+    "defaultMessage": "筛选结果：可访问 {count} · 已屏蔽 {blocked}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.modeOpen": {
+    "defaultMessage": "对所有人开放"
+  },
+  "system.admin.admin.MarketplaceAccessSection.modeScoped": {
+    "defaultMessage": "仅限于上方规则"
+  },
+  "system.admin.admin.MarketplaceAccessSection.fetchFailure": {
+    "defaultMessage": "无法加载市场访问权限列表。"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colName": {
+    "defaultMessage": "姓名"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colEmail": {
+    "defaultMessage": "电子邮件"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colEligibleVia": {
+    "defaultMessage": "资格来源"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colAllowedBy": {
+    "defaultMessage": "允许依据"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colStatus": {
+    "defaultMessage": "状态"
+  },
+  "system.admin.admin.MarketplaceAccessSection.colActions": {
+    "defaultMessage": "操作"
+  },
+  "system.admin.admin.MarketplaceAccessSection.managesCourses": {
+    "defaultMessage": "{count, plural, one {管理 # 门课程} other {管理 # 门课程}}"
+  },
+  "system.admin.admin.MarketplaceAccessSection.instanceInstructor": {
+    "defaultMessage": "实例教师"
+  },
+  "system.admin.admin.MarketplaceAccessSection.instanceAdministrator": {
+    "defaultMessage": "实例管理员"
+  },
+  "system.admin.admin.MarketplaceAccessSection.allowedEveryone": {
+    "defaultMessage": "每个人"
+  },
+  "system.admin.admin.MarketplaceAccessSection.allowedNothing": {
+    "defaultMessage": "没有匹配的规则"
+  },
+  "system.admin.admin.MarketplaceAccessSection.systemAdmin": {
+    "defaultMessage": "系统管理员"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeUser": {
+    "defaultMessage": "用户"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeInstance": {
+    "defaultMessage": "实例"
+  },
+  "system.admin.admin.MarketplaceAccessSection.typeEmailDomain": {
+    "defaultMessage": "电子邮件域名"
+  },
+  "system.admin.admin.MarketplaceAccessSection.statusActive": {
+    "defaultMessage": "活跃"
+  },
+  "system.admin.admin.MarketplaceAccessSection.statusBlocked": {
+    "defaultMessage": "已屏蔽"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disable": {
+    "defaultMessage": "屏蔽"
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnable": {
+    "defaultMessage": "取消屏蔽"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disableSuccess": {
+    "defaultMessage": "已屏蔽该用户的访问权限。"
+  },
+  "system.admin.admin.MarketplaceAccessSection.disableFailure": {
+    "defaultMessage": "屏蔽访问权限失败。"
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnableSuccess": {
+    "defaultMessage": "已取消屏蔽该用户的访问权限。"
+  },
+  "system.admin.admin.MarketplaceAccessSection.reEnableFailure": {
+    "defaultMessage": "取消屏蔽访问权限失败。"
+  },
+  "system.admin.admin.MarketplaceAccessSection.searchPlaceholder": {
+    "defaultMessage": "搜索姓名或电子邮件"
+  },
+  "system.admin.admin.MarketplaceAccessSection.dormantHeading": {
+    "defaultMessage": "休眠屏蔽（{count}）"
+  },
+  "system.admin.admin.MarketplaceAccessSection.dormantExplanation": {
+    "defaultMessage": "这些用户已被屏蔽，但目前没有任何规则授予他们访问权限。该屏蔽目前不会阻止任何事情——但如果日后有规则与他们匹配，它将再次生效，因此如果不再需要，请清除该屏蔽。"
+  },
+  "system.admin.admin.MarketplaceAccessSection.clearBlock": {
+    "defaultMessage": "清除屏蔽"
+  },
   "system.admin.admin.MarketplaceAllowlistIndex.addRule": {
     "defaultMessage": "添加访问规则"
   },

--- a/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
+++ b/spec/models/course/assessment/marketplace/allowlist_rule_spec.rb
@@ -4,9 +4,13 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Marketplace::AllowlistRule, type: :model do
   let!(:instance) { Instance.default }
 
+  HARDCODED_EMAIL_DOMAINS = ['schools.gov.sg', 'other.edu', 'school.edu', 'newdomain.example'].freeze
+
   before do
     Course::Assessment::Marketplace::AllowlistRule.delete_all
-    User::Email.delete_all
+    HARDCODED_EMAIL_DOMAINS.each do |domain|
+      User::Email.where('LOWER(email) LIKE ?', "%#{domain}").delete_all
+    end
   end
 
   with_tenant(:instance) do


### PR DESCRIPTION
## Summary

Adds the access audit section beneath the allow-list: a list of everyone who currently has marketplace access, why they are eligible, and which rule or rules grant it. The list is filterable by status and by granting rule, each row carries block and re-enable controls, and a separate section surfaces dormant blocks - blocks that no rule currently matches.

## Design decisions

- Blocking is exposed per person from the audit list rather than on its own screen - the decision to block is made while reading who has access, not in isolation.
- Dormant blocks are surfaced rather than hidden - such a block denies nothing today, but it takes effect again the moment a rule starts matching that person, so an admin has to be able to see and clear it.
- Rules that currently grant access to nobody are flagged in place rather than auto-removed - an admin may deliberately add a rule ahead of the people it will match.

## Regression prevention

Covers: audit list rendering with eligibility and granting-rule annotations, system administrators listed without any matching rule, rows present only because the person is blocked, the status and granting-rule filters plus clear-all, block and re-enable including failure toasts, the dormant blocks section, and the summary and filtered count lines.
