### PR TITLE
chore(deps): partial dependency upgrade for rails 8.x compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,10 @@ gem 'yajl-ruby', '~> 1.4'
 # Page profiler
 gem 'rack-mini-profiler'
 
-gem 'redis-rails'
+# Redis client — used directly (the REDIS global for assessment tokens, the ActionCable redis
+# adapter, rack-mini-profiler storage, and the RedisCacheStore / :cache_store session store).
+# Previously pulled in transitively via redis-rails; now a direct dependency.
+gem 'redis'
 
 group :development do
   # Spring speeds up development by keeping your application running in the background.
@@ -97,7 +100,6 @@ end
 group :test do
   gem 'email_spec'
   gem 'rspec-html-matchers'
-  gem 'should_not'
   gem 'shoulda-matchers'
 
   # Capybara for feature testing
@@ -144,13 +146,6 @@ group :ci do
   gem 'rspec-retry'
   gem 'rspec_junit_formatter'
   gem 'rubocop-rails'
-end
-
-# This is used only when producing Production assets. Deals with things like minifying JavaScript
-# source files/image assets.
-group :assets do
-  # Compress image assets
-  gem 'image_optim_rails'
 end
 
 group :development, :production, :test do
@@ -219,7 +214,6 @@ gem 'rwordnet', git: 'https://github.com/Coursemology/rwordnet'
 gem 'loofah', '>= 2.2.1'
 gem 'rails-html-sanitizer', '>= 1.0.4'
 
-gem 'mimemagic', '0.4.3'
 gem 'ffi', '>= 1.14.2'
 
 # Retreival Augmented Generation (RAG) Support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,6 @@ GEM
     event_stream_parser (1.0.0)
     excon (1.4.2)
       logger
-    exifr (1.4.0)
     factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
@@ -286,7 +285,6 @@ GEM
       reline
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)
-    fspath (3.1.2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -317,21 +315,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
       terminal-table (>= 1.5.1)
-    image_optim (0.31.3)
-      exifr (~> 1.2, >= 1.2.2)
-      fspath (~> 3.0)
-      image_size (>= 1.5, < 4)
-      in_threads (~> 1.3)
-      progress (~> 3.0, >= 3.0.1)
-    image_optim_rails (0.5.0)
-      image_optim (~> 0.24)
-      railties
-      sprockets
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
-    image_size (3.4.0)
-    in_threads (1.6.0)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -396,9 +382,6 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0414)
-    mimemagic (0.4.3)
-      nokogiri (~> 1)
-      rake
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
@@ -444,7 +427,6 @@ GEM
     pragmatic_segmenter (0.3.24)
     prettyprint (0.2.0)
     prism (1.9.0)
-    progress (3.6.0)
     psych (5.3.1)
       date
       stringio
@@ -516,26 +498,10 @@ GEM
     recaptcha (5.21.2)
     record_tag_helper (1.0.1)
       actionview (>= 5)
-    redis (5.2.0)
+    redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-actionpack (5.4.0)
-      actionpack (>= 5, < 8)
-      redis-rack (>= 2.1.0, < 4)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.3.0)
-      activesupport (>= 3, < 8)
-      redis-store (>= 1.3, < 2)
     redis-client (0.28.0)
       connection_pool
-    redis-rack (3.0.0)
-      rack-session (>= 0.2.0)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.10.0)
-      redis (>= 4, < 6)
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -622,7 +588,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    should_not (1.1.0)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
     sidekiq (7.3.10)
@@ -651,9 +616,6 @@ GEM
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
     spring (4.6.0)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
     ssrf_filter (1.5.0)
     stackprof (0.2.28)
     stringio (3.2.0)
@@ -739,7 +701,6 @@ DEPENDENCIES
   htmlentities
   http_accept_language
   i18n-tasks
-  image_optim_rails
   jbuilder
   jwt (~> 2.10.3)
   keycloak
@@ -749,7 +710,6 @@ DEPENDENCIES
   lograge-sql
   lol_dba
   loofah (>= 2.2.1)
-  mimemagic (= 0.4.3)
   mini_magick
   neighbor
   nokogiri (>= 1.19.4)
@@ -766,7 +726,7 @@ DEPENDENCIES
   rails-html-sanitizer (>= 1.0.4)
   recaptcha
   record_tag_helper
-  redis-rails
+  redis
   rexml
   rinku
   rollbar (>= 1.5.3)
@@ -783,7 +743,6 @@ DEPENDENCIES
   rwordnet!
   sanitize (>= 4.6.3)
   settings_on_rails!
-  should_not
   shoulda-matchers
   sidekiq (~> 7.3.10)
   sidekiq-cron

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,8 +71,18 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # Redis cache store. This MUST be set here, not in an initializer: Rails.cache is built during
+  # the :initialize_cache bootstrap step (before config/initializers run), so a store configured
+  # in an initializer is silently ignored and Rails.cache falls back to the default FileStore.
+  # Backs both Rails.cache and the :cache_store session store (see config/initializers/cache_store.rb).
+  config.cache_store = :redis_cache_store, {
+    host: ENV['REDIS_HOST'],
+    port: 6379,
+    db: 0,
+    password: Rails.application.credentials.dig(:redis, :password),
+    namespace: 'cache',
+    expires_in: 90.minutes
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,21 +1,15 @@
 # frozen_string_literal: true
 Rails.application.configure do
-  config.cache_store = :redis_cache_store, {
-    host: ENV['REDIS_HOST'],
-    port: 6379,
-    db: 0,
-    password: Rails.application.credentials.dig(:redis, :password),
-    namespace: 'cache',
-    expires_in: 90.minutes
-  }
-
-  config.session_store :redis_store,
-                       servers: {
-                         host: ENV['REDIS_HOST'],
-                         port: 6379,
-                         db: 0,
-                         password: Rails.application.credentials.dig(:redis, :password),
-                         namespace: 'session'
-                       },
+  # Store sessions in Rails.cache (Redis in production — configured in
+  # config/environments/production.rb), using Rails' built-in ActionDispatch::Session::CacheStore.
+  # This replaces the redis-actionpack `:redis_store` store so the redis-rails gem family can be
+  # dropped while keeping sessions server-side on Redis.
+  #
+  # NOTE: this is the *production* session store. config/initializers/session_store.rb overrides it
+  # with :cookie_store in development/test, and is removed from the deployment image
+  # (so :cache_store is the effective store in production).
+  config.session_store :cache_store,
+                       key: '_coursemology2_session',
+                       same_site: :lax,
                        expire_after: 240.minutes
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,6 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'action_mailer'
 require 'email_spec'
 require 'email_spec/rspec'
-require 'should_not/rspec'
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 


### PR DESCRIPTION
# PR: Rails 8.x migration prep — low-risk cleanup batch

A batch of low-risk, independently-deployable changes on the path to **Rails 8.x**. Kept
deliberately low-risk so it can ship in a low-risk-only deployment window. More items will be
added to this PR (and this description) as we go.

---

## Item 1 — Remove the `redis-rails` gem family (cache + sessions → built-in Rails on Redis)

`redis-rails` (and its transitive `redis-actionpack` / `redis-activesupport` / `redis-rack` /
`redis-store`) is not Rails-8-ready and was providing a Redis **session** store. We move
sessions and cache onto Rails' **built-in** Redis support and drop the whole family.

### Changes
| File | Change |
| --- | --- |
| `Gemfile` | Remove `gem 'redis-rails'`. Add `gem 'redis'` as a **direct** dependency (it was previously pulled in transitively via `redis-store`; the app uses it directly — the `REDIS` global, ActionCable's redis adapter, rack-mini-profiler). |
| `config/environments/production.rb` | Add the `config.cache_store = :redis_cache_store, {...}` block **here** (moved out of the initializer — see "cache ordering bug"). |
| `config/initializers/cache_store.rb` | Session store `:redis_store` (redis-actionpack) → built-in **`:cache_store`** (`ActionDispatch::Session::CacheStore`, writes through `Rails.cache`). Removed the now-relocated cache-store line. |
| `config/initializers/session_store.rb` | **Unchanged** — still `:cookie_store` for dev/test; removed from the deploy image, so `:cache_store` is the effective prod store. |

### Net effect (production)
- **Cache**: per-container `FileStore` → shared `RedisCacheStore`. Only consumer is JWKS.
- **Sessions**: redis-actionpack `:redis_store` → built-in `:cache_store` on the **same Redis**. Still server-side, still ≤ 4 h TTL.
    - Rails 7.2 sets `samesite=lax` by default on session cookies; this configuration is now made explicit.
- **redis-rails family removed.** Redis is still used everywhere it was (Sidekiq, ActionCable, `REDIS` global, rack-mini-profiler) via the `redis` / `redis-client` gems.

### Why this is low-risk — the investigation

Verified on the **production console**:

- **`Rails.cache` was `FileStore`, not Redis.** (`/app/coursemology2/tmp/cache/`.) The
  `:redis_cache_store` line in the initializer never took effect (see below). Its **only**
  consumer is JWKS (Keycloak signing keys) — a single global key, re-fetched on miss and
  self-invalidating on key rotation. Moving it to a shared Redis cache is harmless (at worst a
  few extra JWKS fetches on a cold cache — one global key, negligible).
- **Sessions held no auth.** Inspecting the live `session:*` values, each was literally
  `{ "_csrf_token" => "…" }` — no `warden.user.user.key`, no user id. **Authentication is not
  in the Rails session**: it rides the encrypted `access_token` JWT cookie
  (`ApplicationAuthenticationConcern`: `Authorization: Bearer …` or `cookies.encrypted[:access_token]`,
  validated against Keycloak). The session store carries only the CSRF token (plus, situationally,
  assessment "unblocked browser" proctoring flags).
- **Session data is short-lived.** Every `session:*` key has a TTL ≤ 4 h (`expire_after`);
  none without expiry. So a backend swap does **not** log anyone out — worst case is a one-off
  CSRF refresh on an in-flight state-changing request, and stale keys self-expire within 4 h.

### The cache ordering bug (why the cache config moved to `production.rb`)
`Rails.cache` is built during the bootstrap `:initialize_cache` step, which runs **before**
`config/initializers/*`. A `config.cache_store = …` set in an initializer is therefore silently
ignored and `Rails.cache` falls back to the default `[:file_store, "tmp/cache/"]`. Environment
files (`config/environments/*.rb`) load **before** `:initialize_cache`, so the config must live
there to take effect. This is also why prod cache was FileStore despite the config saying Redis.
_Verified locally:_ a `cache_store` set in `development.rb` reaches `Rails.cache` (becomes
`MemoryStore`); the same set in the initializer did not.

### Deploy-time verification (run on prod console after deploy)
```ruby
Rails.cache.class                                          # => ActiveSupport::Cache::RedisCacheStore
Rails.application.config.session_store                     # => ActionDispatch::Session::CacheStore
# sessions now live under the cache namespace with a _session_id: prefix:
REDIS.scan_each(match: 'cache:*',   count: 1000).first(5)  # includes cache:_session_id:… (+ cache:auth/jwks)
# old redis-actionpack session keys drain away within 4h:
REDIS.scan_each(match: 'session:*', count: 1000).first(5)  # shrinking → []
```

### Local verification done
- Boots without redis-rails; `Redis` constant available (redis 5.4.1, now a direct dep).
- Dev unchanged: `:cookie_store` sessions, `NullStore` cache.
- `ActionDispatch::Session::CacheStore` resolves; env-file `cache_store` confirmed to reach
  `Rails.cache` (validates the `production.rb` placement).
- redis-rails / redis-actionpack / redis-activesupport / redis-rack / redis-store absent from `Gemfile.lock`.

### Intentionally out of scope
- **`session_store.rb` ↔ Dockerfile reconciliation.** The deploy image `rm`s
  `config/initializers/session_store.rb`, so dev/test use `:cookie_store` while prod uses the
  store from `cache_store.rb`. Left as-is for now; may be reconciled by maintainers separately.

### Appendix — production-state evidence (console transcripts)

_Session IDs and CSRF token values are masked; everything else is verbatim. Every key shown
carries a ≤ 4 h TTL and was captured in a low-activity window, so all have long since expired._

**Cache is `FileStore` (not Redis); sessions are `RedisStore`; the `cache:*` namespace is empty:**
```
Loading production environment (Rails 7.2.3.1)
application(prod)> Rails.cache.instance_variable_get(:@cache_path)
=> "/app/coursemology2/tmp/cache/"
application(prod)> Rails.cache.options
=> {:compress=>true, :compress_threshold=>1024}
application(prod)> Rails.cache.class
=> ActiveSupport::Cache::FileStore
application(prod)> Rails.application.config.session_store
=> ActionDispatch::Session::RedisStore
application(prod)> Rails.application.config.session_options
=> {:servers=>{:host=>"172.**.**.**", :port=>6379, :db=>0, :password=>"********", :namespace=>"session"},
    :expire_after=>240 minutes}
application(prod)> REDIS.scan_each(match: 'session:*', count: 1000).first(5)
=> ["session:2::1351c3ec…", "session:2::39a6805b…", "session:2::0bd8d67f…",
    "session:2::821f4556…", "session:2::ac745635…"]
application(prod)> REDIS.scan_each(match: 'cache:*', count: 1000).first(5)
=> []
```

**The deploy image removes `session_store.rb`, so the effective prod session store is the
`:redis_store` declared in `cache_store.rb`:**
```
# Dockerfile:
# Remove session store config as sessions are stored in Redis, configured in cache_store.rb
rm /app/coursemology2/config/initializers/session_store.rb

app@…:~/coursemology2$ sha256sum config/initializers/cache_store.rb
e065345b4fa26c3cdfc450c99e89feea9c6dc66c555239cf76c16f0d6cd9a103  config/initializers/cache_store.rb
app@…:~/coursemology2$ sha256sum config/initializers/session_store.rb
sha256sum: config/initializers/session_store.rb: No such file or directory
```

**Session TTLs — all ≤ 14400 s (4 h); 12 live keys in a low-activity window (~= a deploy window):**
```
application(prod)> ttls = REDIS.pipelined { |p| keys.each { |k| p.ttl(k) } }
=> [1532, 8865, 1204, 973, 2073, 2812, 1582, 13604, 200, 14335, 1919, 6230]
```

**Session contents — only a CSRF token, no auth (raw Marshal; token masked):**
```
application(prod)> keys.map { |k| REDIS.get(k)&.force_encoding(Encoding::BINARY).inspect }
# 12 keys, all the same shape (one entry was nil = key expired between SCAN and GET):
"\x04\b{\x06I\"\x10_csrf_token\x06:\x06EFI\"0<44-char token — masked>\x06;\x00F"
```
Hand-decoded: `{ "_csrf_token" => "<token>" }` — no `warden.user.user.key`, no user id, confirming
auth is not in the session (it's the `access_token` JWT cookie).

---

## Item 2 — Remove two dead gems: `mimemagic` and `should_not`

Two gems that are no longer used at all. Each removal is zero-behavior-change and deployable on
Rails 7.2 now.

### Changes
- `Gemfile`: remove `gem 'mimemagic', '0.4.3'` and `gem 'should_not'`.
- `spec/spec_helper.rb`: remove `require 'should_not/rspec'`.

### `mimemagic` — introduced as a yank-workaround, superseded by marcel
- **Introduced:** [`54dc675` "update outdate gem"](https://github.com/Coursemology/coursemology2/commit/54dc6751a7d0f6df89d73d117c74920d392bfbc4)
  (2021-05-08) pinned `gem 'mimemagic', '>= 0.3.7'` (later `= 0.4.3`) — the classic fix for the
  **March-2021 mimemagic RubyGems yank**, needed because **CarrierWave 2.x** depended on mimemagic
  for MIME detection.
- **Never used directly:** `MimeMagic` appears in **zero** commits across all history — it was
  always a transitive requirement, never called from app code.
- **Now superseded:** CarrierWave **3.1.3** uses **marcel**, not mimemagic. The explicit pin is
  vestigial. There is no app usage-site to diff — the change is purely at the dependency level:

  ```diff
  # Gemfile
  - gem 'mimemagic', '0.4.3'          # pinned 2021 to survive the yank (CarrierWave 2.x transitive dep)

  # Gemfile.lock — CarrierWave's MIME backend, then vs now:
  - carrierwave (2.2.x)  ->  mimemagic
  + carrierwave (3.1.3)  ->  marcel (~> 1.0.0)
  ```

### `should_not` — a should-syntax guard, now redundant with RSpec's `:expect` config
- **Introduced:** [`8833b03` "Use the should_not gem to make sure we don't put 'should' in specs"](https://github.com/Coursemology/coursemology2/commit/8833b038f3ecf89f3c140a61f3947910eaf4a05d)
  (2014-12-11). Its only job is to make `obj.should` / `obj.should_not` raise, forcing `expect`
  syntax — in the RSpec-2 era where `.should` was the default. It has no matcher call sites; the
  only reference was `require 'should_not/rspec'`.
- **Now redundant:** [`8a8b72b` "Use the new expectations syntax only"](https://github.com/Coursemology/coursemology2/commit/8a8b72b66feae4ed005235e7f5cd569bd03c06c5)
  set `expectations.syntax = :expect` in `spec_helper.rb`, which RSpec 3 uses to restrict to
  expect-only syntax natively — doing the gem's entire job. Zero `.should` / `.should_not` matcher
  usages exist in the suite.

  ```diff
  # spec/spec_helper.rb — the enforcement mechanism, then vs now:
  - require 'should_not/rspec'        # then: the gem blocks .should / .should_not
    config.expect_with :rspec do |expectations|
      expectations.syntax = :expect   # now: RSpec restricts to expect-only natively
    end
  ```

### Verification done
- `bundle install` clean; `mimemagic` and `should_not` absent from `Gemfile.lock`.
- App boots; CarrierWave MIME handling resolves via marcel.
- Green: `spec/uploaders`, `spec/models/attachment*`, `has_one_many_attachments`,
  `attachment_references_controller`, `spec/models/course/forum/topic_spec` (88 examples, 0 failures)
  — covering the upload/MIME surface (mimemagic) and confirming the suite loads and runs the
  `:expect`-only syntax without `should_not`.

---

## Item 3 — Remove `image_optim_rails` (dead asset-pipeline gem; app is a React SPA)

`image_optim_rails` is a Sprockets processor that compresses **image assets during
`assets:precompile`**. The app no longer renders HTML or serves images through the Rails asset
pipeline — the frontend is a React SPA whose assets are built by the client (webpack) toolchain —
so this gem has nothing to do.

### Changes
- `Gemfile`: remove `gem 'image_optim_rails'` and the now-empty `group :assets` block (it was the
  only gem in that group). Drops `image_optim_rails` **and** `image_optim` from the lockfile.

### Why it's dead
- **Introduced:** [`9d94645` "Add \`image_optim\` to the list of gems"](https://github.com/Coursemology/coursemology2/commit/9d946457d366e84c1978f13046a69533c264987a)
  (2016-02-26) — the server-rendered-HTML era, when Rails served image assets via Sprockets.
- **Now:** `app/assets/` contains only an **empty** `config/manifest.js` — **no images** anywhere in
  the Rails pipeline for it to optimize. No `ImageOptim` references in code, no `.image_optim.yml`,
  no initializer. Nothing else in the bundle depends on `image_optim_rails` / `image_optim`.

  ```diff
  # then: Rails served images through Sprockets; image_optim compressed them at precompile.
  # now:  React SPA — frontend assets are built client-side (webpack); app/assets is empty:
  #   app/assets/config/manifest.js   (empty)
  #   app/assets/**/*.{png,jpg,gif,svg}  → none
  ```

### Verification done
- `bundle install` clean; `image_optim_rails` + `image_optim` absent from `Gemfile.lock`.
- App boots. `image_optim_rails` only runs during image asset compilation, and there are no images
  to compile (empty manifest), so there is no runtime or precompile behavior to change.

---

## Additional low-risk items
_(added as we continue)_

## Not in this PR (follow-ups)
- Session-store / Dockerfile reconciliation (dev `:cookie_store` vs prod `:cache_store`) — deferred.
- **`after_commit_action`** — flagged as redundant with Rails-native `enqueue_after_transaction_commit`
  / `ActiveRecord.after_all_transactions_commit`, but it has **19 call sites**, so it's a refactor,
  not a deletion. Belongs in its own change, not this low-risk batch.
