### PR TITLE
test(sidekiq): create test sidekiq processor for job-related specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,13 +165,18 @@ group :production do
   gem 'fog-aws', '>= 3.19'
   gem 'flamegraph'
   gem 'stackprof'
-  gem 'sidekiq', '~> 7.3.10'
   gem 'sidekiq-cron'
   gem 'rollbar', '>= 1.5.3'
 
   # better log format
   gem 'lograge'
   gem 'lograge-sql'
+end
+
+# Sidekiq also loaded in :test so job specs can exercise the real Sidekiq client/server path
+# (serialization + middleware) instead of only the in-process :background_thread adapter.
+group :production, :test do
+  gem 'sidekiq', '~> 7.3.10'
 end
 
 # Multitenancy

--- a/spec/jobs/course/announcement/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/announcement/opening_reminder_job_spec.rb
@@ -36,5 +36,21 @@ RSpec.describe Course::Announcement::OpeningReminderJob do
         it { expect { subject }.to have_enqueued_job(Course::Announcement::OpeningReminderJob) }
       end
     end
+
+    # The examples above only assert the job is ENQUEUED. Running it (its `perform`) is what exercises
+    # opening_reminder_job.rb + ReminderService; left to async specs that coverage is race-prone, so
+    # run it deterministically here.
+    context 'when the enqueued reminder job runs', :sidekiq_same_thread do
+      let(:old_start_at) { time_now - 2.days }
+      let(:new_start_at) { time_now + 3.days }
+
+      it 'notifies the user of the announcement' do
+        recipient = create(:course_user, course: announcement.course).user
+        expect_any_instance_of(Course::AnnouncementNotifier).to receive(:new_announcement).once
+        perform_sidekiq_jobs do
+          described_class.perform_later(recipient, announcement, announcement.opening_reminder_token)
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
     end
 
     context 'when the assessment is non-autograded' do
-      it 'evaluates answers and does not update the exp' do
+      it 'evaluates answers and does not update the exp', :sidekiq_same_thread do
         initial_points = submission.points_awarded
 
-        subject.perform_now(answer)
-        expect(answer).to be_graded
-        expect(submission.points_awarded).to eq(initial_points)
+        perform_sidekiq_jobs { subject.perform_later(answer) }
+        expect(answer.reload).to be_graded
+        expect(submission.reload.points_awarded).to eq(initial_points)
       end
     end
 
@@ -54,14 +54,14 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
 
       let(:assessment_traits) { [:autograded] }
 
-      it 'evaluates answers and updates the exp' do
+      it 'evaluates answers and updates the exp', :sidekiq_same_thread do
         initial_points = submission.points_awarded
 
-        subject.perform_now(answer)
-        expect(answer).to be_graded
+        perform_sidekiq_jobs { subject.perform_later(answer) }
+        expect(answer.reload).to be_graded
         expect(answer.grade).to eq(question.maximum_grade)
         correct_exp = assessment.base_exp + assessment.time_bonus_exp
-        expect(submission.points_awarded).to eq(correct_exp)
+        expect(submission.reload.points_awarded).to eq(correct_exp)
         expect(submission.points_awarded).not_to eq(initial_points)
       end
     end

--- a/spec/jobs/course/assessment/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/closing_reminder_job_spec.rb
@@ -44,5 +44,16 @@ RSpec.describe Course::Assessment::ClosingReminderJob do
         end
       end
     end
+
+    # The examples above only assert the job is ENQUEUED. Running it (its `perform`) is left to async
+    # specs, where that coverage is race-prone; drive it deterministically here. The service has its
+    # own spec, so we just assert the job runs it after a real Redis round-trip.
+    context 'when the enqueued reminder job runs', :sidekiq_same_thread do
+      it 'invokes the closing reminder service' do
+        expect(Course::Assessment::ReminderService).to receive(:closing_reminder).
+          with(assessment, assessment.closing_reminder_token).once
+        perform_sidekiq_jobs { described_class.perform_later(assessment, assessment.closing_reminder_token) }
+      end
+    end
   end
 end

--- a/spec/jobs/course/lesson_plan/coursewide_personalized_timeline_update_job_spec.rb
+++ b/spec/jobs/course/lesson_plan/coursewide_personalized_timeline_update_job_spec.rb
@@ -37,14 +37,13 @@ RSpec.describe Course::LessonPlan::CoursewidePersonalizedTimelineUpdateJob do
         personal_time
       end
 
-      it 'updates the end_at of personal times' do
+      it 'updates the end_at of personal times', :sidekiq_same_thread do
         submission
         personal_time = shifted_personal_time
         # 1 minute is for the lag between the assignment to this comparison
         expect(personal_time.end_at).to be_within(1.minute).of 5.days.from_now
 
-        update_job = subject.perform_later(assessment.lesson_plan_item)
-        update_job.perform_now
+        perform_sidekiq_jobs { subject.perform_later(assessment.lesson_plan_item) }
         expect(personal_time.reload.end_at).to be_within(1.second).of assessment.end_at
       end
     end
@@ -66,14 +65,13 @@ RSpec.describe Course::LessonPlan::CoursewidePersonalizedTimelineUpdateJob do
         personal_time
       end
 
-      it 'updates the start_at of personal times' do
+      it 'updates the start_at of personal times', :sidekiq_same_thread do
         submission
         personal_time = shifted_personal_time
         # 1 minute is for the lag between the assignment to this comparison
         expect(personal_time.start_at).to be_within(1.minute).of 3.days.from_now
 
-        update_job = subject.perform_later(assessment.lesson_plan_item)
-        update_job.perform_now
+        perform_sidekiq_jobs { subject.perform_later(assessment.lesson_plan_item) }
         expect(personal_time.reload.start_at).to be_within(1.second).of assessment.start_at
       end
     end

--- a/spec/jobs/course/survey/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/survey/closing_reminder_job_spec.rb
@@ -22,5 +22,16 @@ RSpec.describe Course::Survey::ClosingReminderJob do
         end
       end
     end
+
+    # The examples above only assert the job is ENQUEUED. Running it (its `perform`) is left to async
+    # specs, where that coverage is race-prone; drive it deterministically here. The service has its
+    # own spec, so we just assert the job runs it after a real Redis round-trip.
+    context 'when the enqueued reminder job runs', :sidekiq_same_thread do
+      it 'invokes the closing reminder service' do
+        expect(Course::Survey::ReminderService).to receive(:closing_reminder).
+          with(survey, survey.closing_reminder_token).once
+        perform_sidekiq_jobs { described_class.perform_later(survey, survey.closing_reminder_token) }
+      end
+    end
   end
 end

--- a/spec/jobs/course/user_deletion_job_spec.rb
+++ b/spec/jobs/course/user_deletion_job_spec.rb
@@ -20,16 +20,17 @@ RSpec.describe Course::UserDeletionJob do
         to have_enqueued_job(subject).exactly(:once)
     end
 
-    it 'delete one user upon successful course user deletion' do
-      expect { subject.perform_now(course, student, user) }.
-        to change { course.course_users.count }.by(-1)
+    it 'delete one user upon successful course user deletion', :sidekiq_same_thread do
+      expect do
+        perform_sidekiq_jobs { subject.perform_later(course, student, user) }
+      end.to change { course.course_users.count }.by(-1)
     end
 
-    it 'sends failure email upon failing course user deletion' do
-      allow(student).to receive(:destroy).and_return(false)
+    it 'sends failure email upon failing course user deletion', :sidekiq_same_thread do
+      # The job operates on a deserialised course_user, so stub any instance (not just `student`).
+      allow_any_instance_of(CourseUser).to receive(:destroy).and_return(false)
 
-      deletion_job = subject.perform_later(course, student, user)
-      deletion_job.perform_now
+      perform_sidekiq_jobs { subject.perform_later(course, student, user) }
 
       emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
       email_subjects = ActionMailer::Base.deliveries.map(&:subject)

--- a/spec/jobs/course/video/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/video/closing_reminder_job_spec.rb
@@ -21,5 +21,16 @@ RSpec.describe Course::Video::ClosingReminderJob do
         end
       end
     end
+
+    # The examples above only assert the job is ENQUEUED. Running it (its `perform`) is left to async
+    # specs, where that coverage is race-prone; drive it deterministically here. The service has its
+    # own spec, so we just assert the job runs it (without a tenant) after a real Redis round-trip.
+    context 'when the enqueued reminder job runs', :sidekiq_same_thread do
+      it 'invokes the closing reminder service' do
+        expect(Course::Video::ReminderService).to receive(:closing_reminder).
+          with(video, video.closing_reminder_token).once
+        perform_sidekiq_jobs { described_class.perform_later(video, video.closing_reminder_token) }
+      end
+    end
   end
 end

--- a/spec/jobs/video_statistic_update_job_spec.rb
+++ b/spec/jobs/video_statistic_update_job_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe VideoStatisticUpdateJob do
     let(:course) { create(:course) }
     let!(:video) { create(:video, course: course) }
 
-    describe '#perform' do
-      subject { VideoStatisticUpdateJob.perform_now }
+    describe '#perform', :sidekiq_same_thread do
+      subject { perform_sidekiq_jobs { VideoStatisticUpdateJob.perform_later } }
 
       context 'video statistics' do
         it 'marks uncached video statistics as cached' do

--- a/spec/libraries/trackable_job_spec.rb
+++ b/spec/libraries/trackable_job_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe TrackableJob do
     end
   end
 
-  describe '#wait' do
+  describe '#wait', :sidekiq_separate_thread do
     it 'waits for the job to finish' do
       expect(subject.job).to be_submitted
       subject.wait

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+# Two RSpec tags run a spec's jobs through a REAL, Redis-backed Sidekiq processor (perform_later ->
+# Redis -> Sidekiq fetch -> server middleware -> job) instead of the custom `:background_thread`
+# ActiveJob adapter. They differ ONLY in which thread the processor runs on:
+#
+# `:sidekiq_same_thread` — processor runs in the TEST thread (synchronous).
+#   - RSpec message expectations / mocks work (same thread).
+#   - Cannot drive TrackableJob's `#wait` (PostgreSQL LISTEN/NOTIFY): the thread that would emit the
+#     NOTIFY is the one blocked waiting for it, so it deadlocks. Run the job, then assert.
+#   - Run only the job(s) you enqueue with `perform_sidekiq_jobs { … }` (see Isolation below).
+#   - The default for essentially all job specs.
+#
+#       it 'grades the answer', :sidekiq_same_thread do
+#         perform_sidekiq_jobs { AutoGradingJob.perform_later(answer) }
+#         expect(answer.reload).to be_graded
+#       end
+#
+# `:sidekiq_separate_thread` — processor runs in a separate WORKER thread (concurrent).
+#   - Handles TrackableJob's `#wait` (the job runs concurrently and emits the NOTIFY).
+#   - RSpec mocks DO NOT cross the thread boundary — assert on DB state, not on mocks.
+#   - Enqueue with `perform_later`; synchronise via the app's own `#wait`.
+#
+#       it 'waits for the job', :sidekiq_separate_thread do
+#         job = SomeTrackableJob.perform_later
+#         job.wait
+#         expect(job.reload).to be_completed
+#       end
+#
+# Both keep execution in-process (SimpleCov records job coverage) and make a real round-trip through
+# Redis (non-serialisable args + real client/server middleware are exercised).
+#
+# Isolation (`perform_sidekiq_jobs`): processes ONLY the jobs the block enqueues (identified by JID
+# via a client middleware) plus any they enqueue, leaving every other queued job untouched — so a
+# spec is never polluted by, and never clobbers, setup jobs or a concurrent test's jobs. No global
+# `clear!` is used for isolation. See sidekiq_test_migration_plan.md.
+require 'sidekiq'
+require 'sidekiq/api'
+require 'sidekiq/processor'
+require 'sidekiq/testing'
+
+module SidekiqTestSupport
+  # All queues the app's jobs use (queue_as), plus the delayed_* variants produced dynamically.
+  QUEUES = %w[
+    highest default delayed_medium_high delayed_high delayed_medium_low delayed_low
+    duplication lowest
+  ].freeze
+
+  # Sidekiq::Processor REQUIRES a "death handler" block — its run loop calls `@callback.call(self)`
+  # / `@callback.call(self, exception)` when it exits. We drive the lifecycle ourselves, so it's a
+  # no-op, but it must be present otherwise NoMethodError is raised.
+  NOOP_DEATH_HANDLER = ->(*) {}
+
+  # Client middleware: while a tracking array is installed on the current thread, record the JID of
+  # each job pushed to Redis. This is how a spec learns exactly which jobs it enqueued.
+  class JidTracker
+    def call(_job_class, job, _queue, _redis_pool = nil)
+      Thread.current[:sidekiq_tracked_jids]&.push(job['jid'])
+      yield
+    end
+  end
+
+  module_function
+
+  def configure!
+    @configure ||= begin
+      # Configure the default config directly — NOT via `Sidekiq.configure_server`, whose block only
+      # runs inside an actual Sidekiq server process (`Sidekiq.server?`), which a spec is not.
+      config = Sidekiq.default_configuration
+      # Quiet Sidekiq's per-job start/done logging (job_logger uses config.logger).
+      config.logger.level = ::Logger::FATAL
+      # Record the JID of each job a spec enqueues, so we can run only those (see #perform_tracked).
+      config.client_middleware { |chain| chain.add(JidTracker) }
+      # The processor fetches only from its capsule's queues — set them explicitly (the memoised
+      # default capsule doesn't pick up config.queues after creation).
+      config.default_capsule do |cap|
+        cap.queues = QUEUES
+        cap.concurrency = 1
+      end
+      true
+    end
+  end
+
+  def processor
+    @processor ||= Sidekiq::Processor.new(Sidekiq.default_configuration.default_capsule, &NOOP_DEATH_HANDLER)
+  end
+
+  # --- async (separate-thread) processor, for TrackableJob's LISTEN/NOTIFY ---
+  # Runs a real Sidekiq processor in its OWN thread (in-process, so SimpleCov still records job
+  # coverage). The job runs concurrently with the test thread, which TrackableJob's `#wait` needs.
+  def start_worker!
+    @worker = Sidekiq::Processor.new(Sidekiq.default_configuration.default_capsule, &NOOP_DEATH_HANDLER)
+    @worker.start
+  end
+
+  def stop_worker!
+    @worker&.terminate(true)
+    @worker = nil
+  end
+
+  # Runs the block (which enqueues the spec's job[s]), then processes to completion ONLY those jobs
+  # and any they enqueue — identified by JID — leaving every other queued job untouched.
+  def perform_tracked(timeout: 15)
+    Thread.current[:sidekiq_tracked_jids] = []
+    yield
+    process_tracked(timeout: timeout)
+  ensure
+    Thread.current[:sidekiq_tracked_jids] = nil
+  end
+
+  def process_tracked(timeout:)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      record = next_tracked_record
+      break if record.nil? # no tracked job left in the immediate queues
+
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        raise "Sidekiq: timed out running tracked jobs #{Thread.current[:sidekiq_tracked_jids].inspect}"
+      end
+
+      Thread.current[:sidekiq_tracked_jids].delete(record.jid)
+      record.delete
+      run_record(record) # may enqueue descendants, which JidTracker adds to the tracked set
+    end
+  end
+
+  # The first queued job whose JID the current spec enqueued.
+  def next_tracked_record
+    jids = Thread.current[:sidekiq_tracked_jids]
+    return nil if jids.empty?
+
+    QUEUES.each do |name|
+      record = Sidekiq::Queue.new(name).find { |job| jids.include?(job.jid) }
+      return record if record
+    end
+    nil
+  end
+
+  # Run one specific queued job through the real Sidekiq server middleware + Rails reloader.
+  def run_record(record)
+    uow = Sidekiq::BasicFetch::UnitOfWork.new(
+      "queue:#{record.queue}", record.value, Sidekiq.default_configuration.default_capsule
+    )
+    processor.send(:process, uow)
+  end
+
+  # Clear ONLY Sidekiq's own keys (queues + retry/scheduled/dead sets). Used for coarse cleanup at
+  # example boundaries (never mid-example); avoids `flushdb` so unrelated keys sharing the Redis DB
+  # (e.g. the app's `REDIS` global) are untouched. Parallel/shared-Redis runs still need a Redis DB
+  # per worker.
+  def clear!
+    QUEUES.each { |name| Sidekiq::Queue.new(name).clear }
+    Sidekiq::RetrySet.new.clear
+    Sidekiq::ScheduledSet.new.clear
+    Sidekiq::DeadSet.new.clear
+  end
+end
+
+module SidekiqSpecHelpers
+  # Runs to completion ONLY the job(s) enqueued within the block (plus any they enqueue), through the
+  # real Sidekiq path, in the test thread. Faithful to testing the spec's own job in isolation.
+  #
+  #   perform_sidekiq_jobs { described_class.perform_later(record) }
+  #   expect(record.reload).to be_processed
+  def perform_sidekiq_jobs(&block)
+    SidekiqTestSupport.perform_tracked(&block)
+  end
+end
+
+RSpec.configure do |config|
+  config.include SidekiqSpecHelpers
+
+  # Synchronous, in-thread — for plain jobs. Isolate with `perform_sidekiq_jobs { … }`.
+  config.around(:each, :sidekiq_same_thread) do |example|
+    previous_adapter = ActiveJob::Base.queue_adapter
+    SidekiqTestSupport.configure!
+    Sidekiq::Testing.disable! # real Redis-backed mode
+    SidekiqTestSupport.clear!
+    ActiveJob::Base.queue_adapter = :sidekiq
+    example.run
+  ensure
+    ActiveJob::Base.queue_adapter = previous_adapter
+    SidekiqTestSupport.clear!
+  end
+
+  # Async, separate-thread processor — for TrackableJob / LISTEN-NOTIFY (the job runs concurrently
+  # while the test `#wait`s). Enqueue with `perform_later`; synchronise via the app's `#wait`.
+  config.around(:each, :sidekiq_separate_thread) do |example|
+    previous_adapter = ActiveJob::Base.queue_adapter
+    SidekiqTestSupport.configure!
+    Sidekiq::Testing.disable!
+    SidekiqTestSupport.clear!
+    ActiveJob::Base.queue_adapter = :sidekiq
+    SidekiqTestSupport.start_worker!
+    example.run
+  ensure
+    SidekiqTestSupport.stop_worker!
+    ActiveJob::Base.queue_adapter = previous_adapter
+    SidekiqTestSupport.clear!
+  end
+end


### PR DESCRIPTION
## Why

Production runs jobs on **Sidekiq** (`config.active_job.queue_adapter = :sidekiq`), but the test
suite runs them through a custom in-process **`:background_thread`** ActiveJob adapter. So the real
Sidekiq path — argument serialization (the JSON round-trip through Redis), client/server middleware,
and the Rails reloader — is **never exercised in CI**. Sidekiq-specific incompatibilities have
reached production undetected as a result.

This PR adds a test harness that runs selected job specs through an **actual Redis-backed Sidekiq
processor**, and migrates a pilot set of specs onto it — without regressing coverage (it improves
it). It is the first, self-contained slice of a progressive, multi-PR migration; the custom adapter
stays the default for every spec not explicitly tagged.

## What's in this PR

**`Gemfile`** — `sidekiq` is now also in the `:test` group (was `:production` only) so the test
bundle can load it. `sidekiq-cron` stays production-only.

**`spec/support/sidekiq.rb`** — the harness. Two RSpec metadata tags, differing only in which thread
the processor runs on:

- **`:sidekiq_same_thread`** — processor runs in the **test thread** (synchronous). RSpec mocks work;
  drive it with `perform_sidekiq_jobs { … }`, which runs **only the job(s) the block enqueues** (plus
  any they enqueue) and leaves every other queued job untouched. The default for job specs.
- **`:sidekiq_separate_thread`** — processor runs in a **worker thread** (concurrent). Needed for
  `TrackableJob#wait` (PostgreSQL `LISTEN`/`NOTIFY`), where a same-thread run would deadlock. Assert
  on DB state, not mocks (*rspec-mocks don't cross the thread boundary*).

**Migrated pilot specs**
- → `:sidekiq_same_thread`: `video_statistic_update_job`, `coursewide_personalized_timeline_update_job`,
  `user_deletion_job`, `assessment/answer/auto_grading_job`.
- → `:sidekiq_separate_thread`: `trackable_job` `#wait`.

**Reminder job specs — added deterministic execution coverage**
`announcement/opening`, `assessment/closing`, `survey/closing`, `video/closing` reminder job specs
were **enqueue-only** (`have_enqueued_job`), so each job's `perform` body was covered only by
race-prone async specs. Each now also has a `:sidekiq_same_thread` example that actually runs the job
(real Redis round-trip), covering the `perform` body deterministically. The enqueue-only assertions
stay (they test the enqueue contract).

## Design notes for reviewers

- **In-process ⇒ coverage is preserved.** The processor runs in the same Ruby process, so SimpleCov
  records job-body coverage exactly as `:background_thread` does — including from the worker thread
  (Ruby's `Coverage` is process-global).
- **Surgical isolation, no queue clearing.** A Sidekiq **client middleware** records the JID of every
  job enqueued inside a `perform_sidekiq_jobs` block; the harness then runs exactly those. It never
  calls `clear!`/`flushdb` mid-example, so it can't race with or clobber a concurrent test's jobs on
  a shared Redis. (Namespaced cleanup — Sidekiq's own queue + retry/scheduled/dead sets, never
  `flushdb` — runs only at example boundaries.)
- **Config goes on `Sidekiq.default_configuration`, not `configure_server`** — the latter's block only
  runs inside a real Sidekiq **server** process (`Sidekiq.server?`), which a spec is not.

## Verification

- All migrated specs green; RuboCop clean.
- Reminder `perform` bodies now fully covered, every run: announcement/opening **6/6**,
  assessment/closing **6/6**, survey/closing **5/5**, video/closing **5/5**; announcement
  `reminder_service` **6/6** (the announcement job runs the real service).
- Coverage preserved for the other migrated jobs (`COLLECT_COVERAGE=true` lcov spot-checks).

## Sidekiq 7 vs 8

The harness touches a few Sidekiq **internals** (`Processor#process`, `BasicFetch::UnitOfWork`) that
sit outside Sidekiq's public-API compatibility promise. We are on **Sidekiq 7**, which Rails 8
supports, so this is fine for the Rails 8 objective. A future Sidekiq 8 upgrade may require adjusting
those touchpoints in `spec/support/sidekiq.rb` — **application code is unaffected**.

## Out of scope / future plans

- **Progressive rollout.** ~45 remaining job-spawning spec files migrate PR-by-PR, simplest first.
  See `sidekiq_test_migration_plan.md` for the full design + per-example migration recipe.
- **`programming_auto_grading_service` and peers** — covered by heavy async **feature** specs;
  migratable but deferred to a later PR.
- **`reduce_priority_auto_grading_job_spec`** — stays on `perform_now`. Its "wrong answer" cases
  assert on in-memory `answer` state that diverges from the DB once the job runs on a *deserialised*
  copy; this is a test-fragility issue, not something the harness can fix.
- **Scheduled/retry execution** — the harness runs immediate queues; scheduled/retry jobs are cleared
  at boundaries, not executed.
- **`have_enqueued_job` examples stay on the default adapter** — it's an ActiveJob `:test`-adapter
  matcher (the real `:sidekiq` adapter doesn't populate `enqueued_jobs`), and queue routing
  (`on_queue`) is resolved by ActiveJob *before* the adapter, so migrating it would add nothing.

## How to use the harness

```ruby
it 'grades the answer', :sidekiq_same_thread do
  perform_sidekiq_jobs { AutoGradingJob.perform_later(answer) }
  expect(answer.reload).to be_graded         # reload — the job mutated a deserialised copy
end

it 'waits for the job', :sidekiq_separate_thread do
  job = SomeTrackableJob.perform_later
  job.wait
  expect(job.reload).to be_completed
end
```
