### PR TITLE
feat(marketplace): system-admin listing and version management

### DIFF
--- a/app/controllers/system/admin/marketplace_listings_controller.rb
+++ b/app/controllers/system/admin/marketplace_listings_controller.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+# System-admin view of every marketplace listing — what version is served, how many courses adopted
+# it, and whether its source still exists — plus the maintenance actions on a listing off the
+# marketplace: restore a source assessment (orphaned only), or delete it permanently.
+class System::Admin::MarketplaceListingsController < System::Admin::Controller
+  def index
+    @listings = Course::Assessment::Marketplace::Listing.for_admin_index
+    @adoption_counts = Course::Assessment::Marketplace::Adoption.
+                       where(listing_id: @listings.map(&:id)).group(:listing_id).
+                       distinct.count(:destination_course_id)
+    @authoring_urls = authoring_urls(@listings)
+  end
+
+  # The per-listing provenance + history page. Read-only: every mutation stays on the index.
+  def show
+    @listing = find_listing
+    @versions = @listing.versions.ordered.includes(:assessment, :published_by).to_a
+    @adoptions = ActsAsTenant.without_tenant do
+      @listing.adoptions.includes(destination_course: :instance).order(:created_at).to_a
+    end
+    @snapshot_urls = snapshot_urls(@versions)
+    @authoring_url = authoring_urls([@listing])[@listing.id]
+  end
+
+  # The manual repair for a listing that has no authoring copy: duplicates its latest snapshot into
+  # the marketplace's own container course and makes that the authoring copy, so "Publish new version"
+  # works again.
+  #
+  # A failsafe rather than the ordinary path: losing a source assessment re-points the listing inside
+  # the destroy transaction, so an orphan means that callback was bypassed. Asynchronous — assessment
+  # duplication is the same heavy path adopters go through — so the client polls the returned `jobUrl`.
+  def restore_authoring
+    listing = find_listing
+    error = restore_rejection(listing)
+    return render json: { errors: [error] }, status: :unprocessable_content if error
+
+    job = Course::Assessment::Marketplace::RestoreAuthoringJob.
+          perform_later(listing.id, current_user: current_user).job
+    render partial: 'jobs/submitted', locals: { job: job }
+  end
+
+  # Takes a listing off the marketplace, or puts it back. Reversible. Admin has to unlist a listing
+  # before `destroy` will accept said listing at all.
+  #
+  # Admin-side rather than the course-side unlist because that one hangs off the authoring assessment,
+  # which after a re-point lives in the container course on the preview instance — a course an admin
+  # cannot reach from their own host, and one an orphaned listing has no pointer to at all. Re-listing
+  # never cuts a version: it restores visibility over the version the listing already holds.
+  def update
+    listing = find_listing
+    error = list_rejection(listing, published_param)
+    return render json: { errors: [error] }, status: :unprocessable_content if error
+
+    listing.update!(published: published_param)
+    head :ok
+  end
+
+  # PERMANENT deletion, not unlisting. Restricted to listings that are off the marketplace.
+  def destroy
+    listing = find_listing
+    return render json: { errors: [purge_rejection(listing)] }, status: :unprocessable_content unless
+      listing.purgeable?
+
+    Course::Assessment::Marketplace::PurgeService.purge!(listing)
+    head :ok
+  end
+
+  # The single canonicalisation both the version rows and the adoption rows go through.
+  # @param [ActiveSupport::TimeWithZone, nil] published_at
+  # @return [String, nil]
+  def self.snapshot_key(published_at)
+    published_at&.utc&.iso8601(6)
+  end
+
+  private
+
+  # Listings span every instance while their snapshots live in the container's, so every lookup here
+  # is tenant-free — the same reason `.for_admin_index` is.
+  def find_listing
+    ActsAsTenant.without_tenant do
+      Course::Assessment::Marketplace::Listing.find(params[:id])
+    end
+  end
+
+  # `params[:published]` arrives as a JSON boolean from our own client and as a string from anything
+  # else, so it goes through the same cast the settings components use.
+  # @return [Boolean]
+  def published_param
+    ActiveRecord::Type::Boolean.new.cast(params[:published])
+  end
+
+  # Unlisting is always allowed — it is the reversible step, and it is what an admin reaches for when
+  # something is wrong with a listing.
+  #
+  # @return [String, nil] the reason the change is refused, or nil if it may proceed
+  def list_rejection(listing, published)
+    return nil unless published
+    return 'This listing has no published version to serve.' if listing.current_version_id.nil?
+
+    nil
+  end
+
+  # @return [String, nil] the reason the restore is refused, or nil if it may proceed
+  def restore_rejection(listing)
+    return 'Only an orphaned listing can have its source assessment rebuilt.' unless listing.orphaned?
+    return 'This listing has no published version to restore from.' if listing.current_version.nil?
+
+    nil
+  end
+
+  # @return [String] the reason the deletion is refused
+  def purge_rejection(_listing)
+    'A published listing cannot be permanently deleted. Unlist it first.'
+  end
+
+  # @return [Hash{String => String}] canonicalised publish date => absolute snapshot url
+  def snapshot_urls(versions)
+    return {} if versions.empty?
+
+    ActsAsTenant.without_tenant do
+      container = Course::Assessment::Marketplace::PreviewContainerService.container_course
+      host = container.instance.host
+
+      versions.each_with_object({}) do |version, urls|
+        next if version.assessment.nil?
+
+        urls[self.class.snapshot_key(version.published_at)] =
+          course_assessment_url(version.assessment.course_id, version.assessment, **host_options(host))
+      end
+    end
+  end
+
+  # An absolute URL carrying the source course's own host, not a path: `Course` is
+  # `acts_as_tenant :instance`, so a course id only resolves on its instance's host and a relative
+  # path 404s for every listing published from another instance.
+  #
+  # @return [Hash{Integer => String}] listing id => absolute authoring assessment url
+  def authoring_urls(listings)
+    ActsAsTenant.without_tenant do
+      listings.each_with_object({}) do |listing, urls|
+        assessment = listing.authoring_assessment
+        next if assessment.nil?
+
+        urls[listing.id] = course_assessment_url(assessment.course_id, assessment,
+                                                 **host_options(assessment.course.instance.host))
+      end
+    end
+  end
+
+  # @param [String] host an instance host, optionally carrying a port
+  # @return [Hash] the `host:`/`port:` options for a url on that instance
+  def host_options(host)
+    name, port = host.split(':', 2)
+    { host: name, port: port }
+  end
+end

--- a/app/jobs/course/assessment/marketplace/restore_authoring_job.rb
+++ b/app/jobs/course/assessment/marketplace/restore_authoring_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# The system admin's manual repair for an orphaned listing: rebuilds its authoring copy from the
+# latest snapshot, so the listing can cut versions again.
+#
+# This is the FAILSAFE, not the ordinary path. Losing a source assessment normally re-points the
+# listing inside the destroy transaction (`Course::Assessment#repoint_marketplace_listing_authoring`),
+# which is what keeps a listing from ever being observably orphaned. An orphan therefore means that
+# callback was bypassed (a raw delete leaving `fk_caml_authoring_assessment_id` to null the column)
+# and this is how an admin puts it right without a console.
+#
+# A job rather than an inline controller call for the reason adoption's `DuplicationJob` is one:
+# duplicating a large assessment can outlast a request. The re-point pays that cost inline only
+# because a clone that must precede a destroy cannot be deferred.
+#
+# The clone itself lives in `RestoreAuthoringService`, shared with the re-point, so a hand-repaired
+# listing is indistinguishable from an automatically re-pointed one.
+class Course::Assessment::Marketplace::RestoreAuthoringJob < ApplicationJob
+  include TrackableJob
+  include Rails.application.routes.url_helpers
+
+  queue_as :duplication
+
+  protected
+
+  def perform_tracked(listing_id, options = {})
+    current_user = options[:current_user]
+    ActsAsTenant.without_tenant do
+      listing = Course::Assessment::Marketplace::Listing.find(listing_id)
+      # Re-checked here rather than trusting the controller's guard: a republish restores an authoring
+      # copy on its own, and it can land between enqueue and perform. Completing rather than erroring
+      # is deliberate — the end state this job exists to reach is the one it found.
+      return unless listing.orphaned?
+      raise ArgumentError, 'listing has no version to restore from' if listing.current_version.nil?
+
+      copy = Course::Assessment::Marketplace::RestoreAuthoringService.
+             restore!(listing, current_user: current_user)
+      redirect_to course_assessment_url(copy.course, copy, host: copy.course.instance.host)
+    end
+  end
+end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -419,20 +419,14 @@ class Course::Assessment < ApplicationRecord
   # nothing to rebuild from and is left to orphan through `fk_caml_authoring_assessment_id`. The early
   # return also keeps an assessment that authors no listing from provisioning the preview instance and
   # container course inside an ordinary delete.
+  #
+  # The clone itself lives in `RestoreAuthoringService`, shared with the admin's repair action, so a
+  # listing rebuilt by hand is indistinguishable from one rebuilt here.
   def repoint_marketplace_listing_authoring
     listing = marketplace_listing
     return if listing.nil? || listing.current_version_id.nil?
 
-    ActsAsTenant.without_tenant do
-      container = Course::Assessment::Marketplace::PreviewContainerService.container_course
-      source = listing.current_version.assessment
-      User.with_stamper(User.system) do
-        copy = Course::Duplication::ObjectDuplicationService.duplicate_objects(
-          source.course, container, source, current_user: User.system
-        )
-        listing.update!(authoring_assessment: copy)
-      end
-    end
+    Course::Assessment::Marketplace::RestoreAuthoringService.restore!(listing)
   end
 
   # Parents the assessment under its duplicated parent tab, if it exists.

--- a/app/services/course/assessment/marketplace/restore_authoring_service.rb
+++ b/app/services/course/assessment/marketplace/restore_authoring_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# Gives a listing a fresh authoring copy by cloning its latest SNAPSHOT into the marketplace
+# container, and points `authoring_assessment` at the clone.
+#
+# The listing MUST have a `current_version`: there is nothing else to clone from.
+class Course::Assessment::Marketplace::RestoreAuthoringService
+  # @param [Course::Assessment::Marketplace::Listing] listing
+  # @param [User] current_user whoever the copy is stamped to — the system user for the automatic
+  #   re-point, the acting admin for the repair action
+  # @return [Course::Assessment] the new authoring copy
+  def self.restore!(listing, current_user: User.system)
+    new(listing, current_user).restore!
+  end
+
+  def initialize(listing, current_user)
+    @listing = listing
+    @current_user = current_user
+  end
+
+  # @return [Course::Assessment]
+  def restore!
+    ActsAsTenant.without_tenant do
+      container = Course::Assessment::Marketplace::PreviewContainerService.container_course
+      snapshot = @listing.current_version.assessment
+      User.with_stamper(@current_user) do
+        copy = Course::Duplication::ObjectDuplicationService.duplicate_objects(
+          snapshot.course, container, snapshot, current_user: @current_user
+        )
+        @listing.update!(authoring_assessment: copy)
+        copy
+      end
+    end
+  end
+end

--- a/app/views/system/admin/courses/_course_list_data.json.jbuilder
+++ b/app/views/system/admin/courses/_course_list_data.json.jbuilder
@@ -4,6 +4,7 @@ json.title course.title
 json.createdAt course.created_at
 json.activeUserCount course.active_user_count
 json.userCount course.user_count
+json.preview course.preview
 json.instance do
   json.id course.instance.id
   json.name course.instance.name

--- a/app/views/system/admin/marketplace_listings/index.json.jbuilder
+++ b/app/views/system/admin/marketplace_listings/index.json.jbuilder
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+json.listings @listings do |listing|
+  json.id listing.id
+  json.title listing.current_version&.assessment&.title
+  json.currentVersionPublishedAt listing.current_version&.published_at
+  json.lastPublishedAt listing.last_published_at
+  json.adoptions(@adoption_counts[listing.id] || 0)
+  json.sourceCourseId listing.source_course_id
+  json.sourceCourseName listing.source_course_name
+  json.sourceInstanceName listing.source_instance&.name
+  json.sourceInstanceHost listing.source_instance&.host
+  json.state listing.admin_state
+  # Orthogonal to `state`: WHERE the authoring copy lives, not whether the listing is on the
+  # marketplace.
+  json.marketplaceHosted listing.marketplace_hosted?
+  # Deletion facts, separate from `state`/visibility: a rebuilt listing can be published AND have a
+  # deleted origin at the same time.
+  json.sourceAssessmentDeleted listing.source_assessment_deleted?
+  json.sourceCourseDeleted listing.source_course_deleted?
+  json.authoringAssessmentUrl @authoring_urls[listing.id]
+end

--- a/app/views/system/admin/marketplace_listings/show.json.jbuilder
+++ b/app/views/system/admin/marketplace_listings/show.json.jbuilder
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+json.id @listing.id
+json.title @listing.current_version&.assessment&.title
+json.currentVersionPublishedAt @listing.current_version&.published_at
+json.state @listing.admin_state
+json.marketplaceHosted @listing.marketplace_hosted?
+json.sourceAssessmentDeleted @listing.source_assessment_deleted?
+json.sourceCourseDeleted @listing.source_course_deleted?
+json.authoringAssessmentUrl @authoring_url
+json.sourceCourseId @listing.source_course_id
+json.sourceCourseName @listing.source_course_name
+json.sourceInstanceName @listing.source_instance&.name
+json.sourceInstanceHost @listing.source_instance&.host
+
+json.versions @versions do |version|
+  json.publishedAt version.published_at
+  json.publisherName version.published_by&.name
+  json.isCurrent version.id == @listing.current_version_id
+  json.snapshotUrl @snapshot_urls[System::Admin::MarketplaceListingsController.snapshot_key(version.published_at)]
+end
+
+json.adoptions @adoptions do |adoption|
+  json.id adoption.id
+  json.destinationCourseId adoption.destination_course_id
+  json.destinationCourseName adoption.destination_course&.title
+  json.destinationCourseHost adoption.destination_course&.instance&.host
+  json.adoptedVersionAt adoption.adopted_version_at
+  json.adoptedAt adoption.created_at
+  snapshot_key = System::Admin::MarketplaceListingsController.snapshot_key(adoption.adopted_version_at)
+  json.snapshotUrl @snapshot_urls[snapshot_key]
+end

--- a/client/app/api/system/Admin.ts
+++ b/client/app/api/system/Admin.ts
@@ -13,6 +13,10 @@ import {
   AllowlistRuleData,
   AllowlistRuleFormData,
 } from 'types/system/marketplaceAllowlist';
+import {
+  MarketplaceListingAdminData,
+  MarketplaceListingDetailData,
+} from 'types/system/marketplaceListings';
 import { AdminStats, UserListData } from 'types/users';
 
 import BaseSystemAPI from '../Base';
@@ -190,6 +194,67 @@ export default class AdminAPI extends BaseSystemAPI {
   > {
     return this.client.get(
       `${AdminAPI.#urlPrefix}/marketplace_allowlist_rules`,
+    );
+  }
+
+  /**
+   * Fetches every marketplace listing with its version chain and provenance.
+   */
+  indexMarketplaceListings(): Promise<
+    AxiosResponse<{ listings: MarketplaceListingAdminData[] }>
+  > {
+    return this.client.get(`${AdminAPI.#urlPrefix}/marketplace_listings`);
+  }
+
+  /**
+   * Fetches one listing's provenance, full version history and adoptions. Read-only — every
+   * mutation stays on the index.
+   */
+  fetchMarketplaceListing(
+    id: number,
+  ): Promise<AxiosResponse<MarketplaceListingDetailData>> {
+    return this.client.get(`${AdminAPI.#urlPrefix}/marketplace_listings/${id}`);
+  }
+
+  /**
+   * Permanently deletes a marketplace listing, its versions and their container snapshots.
+   * Irreversible.
+   */
+  deleteMarketplaceListing(id: number): Promise<AxiosResponse<void>> {
+    return this.client.delete(
+      `${AdminAPI.#urlPrefix}/marketplace_listings/${id}`,
+    );
+  }
+
+  /**
+   * Takes a listing off the marketplace, or puts it back. Reversible. Admin must unlist before
+   * deleting.
+   *
+   * Admin-side rather than through the course-side unlist because that one resolves the listing
+   * through its authoring assessment — which, once the origin is deleted, lives in the container
+   * course on the preview instance, and which an orphaned listing has no pointer to at all.
+   * Re-listing never cuts a version: it restores visibility over the version already held.
+   */
+  setMarketplaceListingPublished(
+    id: number,
+    published: boolean,
+  ): Promise<AxiosResponse<void>> {
+    return this.client.patch(
+      `${AdminAPI.#urlPrefix}/marketplace_listings/${id}`,
+      { published },
+    );
+  }
+
+  /**
+   * Duplicates an orphaned listing's latest snapshot into the marketplace's container course and
+   * makes it the new source assessment. There is no destination to choose. Asynchronous — the
+   * response carries a `jobUrl` for the client to poll.
+   */
+  restoreMarketplaceListingAuthoring(
+    id: number,
+  ): Promise<AxiosResponse<{ status: string; jobUrl: string }>> {
+    return this.client.post(
+      `${AdminAPI.#urlPrefix}/marketplace_listings/${id}/restore_authoring`,
     );
   }
 

--- a/client/app/bundles/system/admin/admin/AdminNavigator.tsx
+++ b/client/app/bundles/system/admin/admin/AdminNavigator.tsx
@@ -37,6 +37,10 @@ const translations = defineMessages({
     id: 'system.admin.admin.AdminNavigator.marketplace',
     defaultMessage: 'Marketplace Access',
   },
+  marketplaceListings: {
+    id: 'system.admin.admin.AdminNavigator.marketplaceListings',
+    defaultMessage: 'Marketplace Listings',
+  },
   systemAdminPanel: {
     id: 'system.admin.admin.AdminNavigator.systemAdminPanel',
     defaultMessage: 'System Admin Panel',
@@ -73,6 +77,11 @@ const AdminNavigator = (): JSX.Element => {
           icon: <Storefront />,
           title: t(translations.marketplace),
           path: '/admin/marketplace_allowlist_rules',
+        },
+        {
+          icon: <Storefront />,
+          title: t(translations.marketplaceListings),
+          path: '/admin/marketplace_listings',
         },
         {
           icon: <Chat />,

--- a/client/app/bundles/system/admin/admin/components/buttons/MarketplaceListingVisibilityButton.tsx
+++ b/client/app/bundles/system/admin/admin/components/buttons/MarketplaceListingVisibilityButton.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Button } from '@mui/material';
+import { AxiosError } from 'axios';
+import { MarketplaceListingAdminData } from 'types/system/marketplaceListings';
+
+import SystemAPI from 'api/system';
+import Prompt, { PromptText } from 'lib/components/core/dialogs/Prompt';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  listing: MarketplaceListingAdminData;
+  /** Called once the flip lands: `state` changes, and with it whether the row can be deleted. */
+  onChanged: () => void;
+}
+
+const translations = defineMessages({
+  unlist: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.unlist',
+    defaultMessage: 'Unlist',
+  },
+  list: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.list',
+    defaultMessage: 'List',
+  },
+  unlistTitle: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.unlistTitle',
+    defaultMessage: 'Take this listing off the marketplace?',
+  },
+  listTitle: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.listTitle',
+    defaultMessage: 'Put this listing back on the marketplace?',
+  },
+  unlistExplanation: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.unlistExplanation',
+    defaultMessage:
+      'It stops appearing in the marketplace and can no longer be copied or previewed. Nothing is deleted, and courses that already copied it are unaffected.',
+  },
+  unlistReversible: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.unlistReversible',
+    defaultMessage:
+      'This is reversible — you can list it again at any time. It is also what has to happen before a listing can be deleted permanently.',
+  },
+  listExplanation: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.listExplanation',
+    defaultMessage:
+      'It appears in the marketplace again, serving the version it already holds. No new version is published.',
+  },
+  unlisted: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.unlisted',
+    defaultMessage: 'Listing taken off the marketplace.',
+  },
+  listed: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.listed',
+    defaultMessage: 'Listing is back on the marketplace.',
+  },
+  failed: {
+    id: 'system.admin.admin.MarketplaceListingVisibilityButton.failed',
+    defaultMessage: 'Could not change the listing’s visibility.',
+  },
+});
+
+const MarketplaceListingVisibilityButton = ({
+  listing,
+  onChanged,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const listed = listing.state === 'published';
+
+  const submit = async (): Promise<void> => {
+    setSubmitting(true);
+    try {
+      await SystemAPI.admin.setMarketplaceListingPublished(listing.id, !listed);
+      toast.success(t(listed ? translations.unlisted : translations.listed));
+      setOpen(false);
+      onChanged();
+    } catch (error) {
+      const message =
+        error instanceof AxiosError
+          ? error.response?.data?.errors?.[0]
+          : undefined;
+      toast.error(message ?? t(translations.failed));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        className="whitespace-nowrap"
+        color={listed ? 'error' : 'primary'}
+        onClick={(): void => setOpen(true)}
+        size="small"
+        variant="text"
+      >
+        {t(listed ? translations.unlist : translations.list)}
+      </Button>
+
+      <Prompt
+        contentClassName="space-y-4"
+        disabled={submitting}
+        onClickPrimary={submit}
+        onClose={(): void => setOpen(false)}
+        open={open}
+        primaryColor={listed ? 'error' : 'primary'}
+        primaryLabel={t(listed ? translations.unlist : translations.list)}
+        title={t(listed ? translations.unlistTitle : translations.listTitle)}
+      >
+        <PromptText>
+          {t(
+            listed
+              ? translations.unlistExplanation
+              : translations.listExplanation,
+          )}
+        </PromptText>
+
+        {listed && <PromptText>{t(translations.unlistReversible)}</PromptText>}
+      </Prompt>
+    </>
+  );
+};
+
+export default MarketplaceListingVisibilityButton;

--- a/client/app/bundles/system/admin/admin/components/buttons/MarketplaceRestoreAuthoringButton.tsx
+++ b/client/app/bundles/system/admin/admin/components/buttons/MarketplaceRestoreAuthoringButton.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Button } from '@mui/material';
+import { AxiosError } from 'axios';
+import { MarketplaceListingAdminData } from 'types/system/marketplaceListings';
+
+import SystemAPI from 'api/system';
+import Prompt, { PromptText } from 'lib/components/core/dialogs/Prompt';
+import Link from 'lib/components/core/Link';
+import pollJob from 'lib/helpers/jobHelpers';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const JOB_POLL_INTERVAL_MS = 2000;
+
+interface Props {
+  listing: MarketplaceListingAdminData;
+  /**
+   * Called once the rebuild job completes: `state`, `authoringAssessmentUrl` and `marketplaceHosted`
+   * all change.
+   */
+  onRestored: () => void;
+}
+
+const translations = defineMessages({
+  restore: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.restore',
+    defaultMessage: 'Rebuild source assessment',
+  },
+  confirm: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.confirm',
+    defaultMessage: 'Rebuild',
+  },
+  explanation: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.explanation',
+    defaultMessage:
+      "The latest published version is copied into the marketplace's own container course as a new, editable source assessment, so that new versions can be published from it again.",
+  },
+  intoContainer: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.intoContainer',
+    defaultMessage:
+      'No live course is touched, and the published versions themselves are left unchanged.',
+  },
+  completed: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.completed',
+    defaultMessage: 'Source assessment rebuilt in the marketplace container.',
+  },
+  viewRestored: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.viewRestored',
+    defaultMessage: 'View assessment',
+  },
+  failed: {
+    id: 'system.admin.admin.MarketplaceRestoreAuthoringButton.failed',
+    defaultMessage: 'Could not rebuild the source assessment.',
+  },
+});
+
+const MarketplaceRestoreAuthoringButton = ({
+  listing,
+  onRestored,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const close = (): void => {
+    setOpen(false);
+  };
+
+  const submit = async (): Promise<void> => {
+    setSubmitting(true);
+    try {
+      const response = await SystemAPI.admin.restoreMarketplaceListingAuthoring(
+        listing.id,
+      );
+      pollJob(
+        response.data.jobUrl,
+        // pollJob's *completion* callback — the duplication has finished by now, so the list can be
+        // refetched and `redirectUrl` points at the assessment that was just created.
+        (data) => {
+          toast.success(
+            <>
+              {t(translations.completed)}
+              {data.redirectUrl && (
+                <>
+                  {' '}
+                  <Link href={data.redirectUrl}>
+                    {t(translations.viewRestored)}
+                  </Link>
+                </>
+              )}
+            </>,
+          );
+          setSubmitting(false);
+          close();
+          onRestored();
+        },
+        () => {
+          toast.error(t(translations.failed));
+          setSubmitting(false);
+        },
+        JOB_POLL_INTERVAL_MS,
+      );
+    } catch (error) {
+      const message =
+        error instanceof AxiosError
+          ? error.response?.data?.errors?.[0]
+          : undefined;
+      toast.error(message ?? t(translations.failed));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        className="whitespace-nowrap"
+        onClick={(): void => setOpen(true)}
+        size="small"
+        variant="text"
+      >
+        {t(translations.restore)}
+      </Button>
+
+      <Prompt
+        contentClassName="space-y-4"
+        disabled={submitting}
+        onClickPrimary={submit}
+        onClose={close}
+        open={open}
+        primaryLabel={t(translations.confirm)}
+        title={t(translations.restore)}
+      >
+        <PromptText>{t(translations.explanation)}</PromptText>
+
+        <PromptText>{t(translations.intoContainer)}</PromptText>
+      </Prompt>
+    </>
+  );
+};
+
+export default MarketplaceRestoreAuthoringButton;

--- a/client/app/bundles/system/admin/admin/components/tables/MarketplaceListingsTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/MarketplaceListingsTable.tsx
@@ -1,0 +1,512 @@
+import { defineMessages } from 'react-intl';
+import { StorefrontOutlined } from '@mui/icons-material';
+import { Chip, Tooltip, Typography } from '@mui/material';
+import {
+  MarketplaceListingAdminData,
+  MarketplaceListingState,
+} from 'types/system/marketplaceListings';
+
+import DeleteButton from 'lib/components/core/buttons/DeleteButton';
+import { PromptText } from 'lib/components/core/dialogs/Prompt';
+import Link from 'lib/components/core/Link';
+import Table, { ColumnTemplate } from 'lib/components/table';
+import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDate, formatLongDateTime } from 'lib/moment';
+
+import MarketplaceListingVisibilityButton from '../buttons/MarketplaceListingVisibilityButton';
+import MarketplaceRestoreAuthoringButton from '../buttons/MarketplaceRestoreAuthoringButton';
+
+interface Props {
+  listings: MarketplaceListingAdminData[];
+  /** Permanent purge, not unlisting. Resolves once the list has been refetched. */
+  onDelete: (id: number) => Promise<void>;
+  onRestored: () => void;
+  /** The reversible unlist/list flip, which changes `state` and with it what else the row offers. */
+  onVisibilityChanged: () => void;
+}
+
+/**
+ * Filter-menu bucket for a listing with no recorded source instance. Publishing always records one,
+ * so a row lands here only once that instance is DELETED — the FK nullifies both the instance and the
+ * source course, leaving the denormalised course name as the whole of the row's provenance. It is a
+ * real bucket rather than an omission so an admin hunting a problem still sees those rows.
+ */
+const NO_INSTANCE = '';
+
+/**
+ * A filter facet, deliberately NOT a fifth `MarketplaceListingState`. Marketplace-hosted answers WHERE
+ * the authoring copy lives, while the state values answer whether the listing is on the marketplace —
+ * and the two cross, so a row contributes both to the State filter menu and matches either
+ * independently. The value cannot collide with a real state.
+ */
+const MARKETPLACE_HOSTED = 'marketplace_hosted';
+
+/**
+ * The complement of `MARKETPLACE_HOSTED`, and a filter value only, not a chip, because it is the
+ * ordinary state of the marketplace listings.
+ */
+const NOT_MARKETPLACE_HOSTED = 'not_marketplace_hosted';
+
+/**
+ * A filter facet for listings with no source assessment at all. Unlike the marketplace-hosted pair,
+ * it is contributed ONLY by the rows it describes, so it appears in the menu just when something is
+ * wrong: an orphan is not a state the system produces any more — losing a source assessment re-points
+ * the listing inside the same transaction — so a value matching nothing on a healthy deployment would
+ * advertise a fault as an ordinary way for a listing to be. It has no complement for the same reason.
+ */
+const ORPHANED = 'orphaned';
+
+type StateFilterValue =
+  | MarketplaceListingState
+  | typeof MARKETPLACE_HOSTED
+  | typeof NOT_MARKETPLACE_HOSTED
+  | typeof ORPHANED;
+
+const translations = defineMessages({
+  colId: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colId',
+    defaultMessage: 'ID',
+  },
+  colTitle: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colTitle',
+    defaultMessage: 'Original assessment',
+  },
+  colSource: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colSource',
+    defaultMessage: 'Source course',
+  },
+  colInstance: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colInstance',
+    defaultMessage: 'Instance',
+  },
+  colVersion: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colVersion',
+    defaultMessage: 'Version',
+  },
+  colAdoptions: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colAdoptions',
+    defaultMessage: 'Adoptions',
+  },
+  colState: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colState',
+    defaultMessage: 'State',
+  },
+  colActions: {
+    id: 'system.admin.admin.MarketplaceListingsTable.colActions',
+    defaultMessage: 'Actions',
+  },
+  statePublished: {
+    id: 'system.admin.admin.MarketplaceListingsTable.statePublished',
+    defaultMessage: 'Published',
+  },
+  stateUnlisted: {
+    id: 'system.admin.admin.MarketplaceListingsTable.stateUnlisted',
+    defaultMessage: 'Unlisted',
+  },
+  deletedSuffix: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deletedSuffix',
+    defaultMessage: '(deleted)',
+  },
+  assessmentDeletedHint: {
+    id: 'system.admin.admin.MarketplaceListingsTable.assessmentDeletedHint',
+    defaultMessage:
+      'The assessment this listing was originally published from has been deleted. The listing is unaffected: it goes on serving its last published version, and a source assessment is saved in the marketplace’s preview course so new versions can still be published.',
+  },
+  courseDeletedHint: {
+    id: 'system.admin.admin.MarketplaceListingsTable.courseDeletedHint',
+    defaultMessage:
+      'The course this listing was published from has been deleted. Its name is kept as a record of where the content came from.',
+  },
+  marketplaceHosted: {
+    id: 'system.admin.admin.MarketplaceListingsTable.marketplaceHosted',
+    defaultMessage: 'Marketplace-hosted',
+  },
+  notMarketplaceHosted: {
+    id: 'system.admin.admin.MarketplaceListingsTable.notMarketplaceHosted',
+    defaultMessage: 'Not marketplace-hosted',
+  },
+  marketplaceHostedHint: {
+    id: 'system.admin.admin.MarketplaceListingsTable.marketplaceHostedHint',
+    defaultMessage:
+      "This listing's source assessment lives in the marketplace's own preview course, not in the course it was originally published from - the original was deleted, so the marketplace saved one to keep publishing from.",
+  },
+  orphaned: {
+    id: 'system.admin.admin.MarketplaceListingsTable.orphaned',
+    defaultMessage: 'Orphaned',
+  },
+  // Names the fault AND the remedy: a chip reading "Orphaned" beside a Published listing otherwise
+  // leaves an admin unable to tell whether the listing is serving, whether to act, or which action.
+  orphanedHint: {
+    id: 'system.admin.admin.MarketplaceListingsTable.orphanedHint',
+    defaultMessage:
+      'This listing has no source assessment, which should not happen: one is rebuilt automatically whenever an assessment or the course holding it is deleted. Rebuild it from the latest published version, or delete the listing if there is no version left to rebuild from.',
+  },
+  openSourceAssessment: {
+    id: 'system.admin.admin.MarketplaceListingsTable.openSourceAssessment',
+    defaultMessage: 'Open source assessment',
+  },
+  filterNoInstance: {
+    id: 'system.admin.admin.MarketplaceListingsTable.filterNoInstance',
+    defaultMessage: 'Instance not recorded',
+  },
+  searchText: {
+    id: 'system.admin.admin.MarketplaceListingsTable.searchText',
+    defaultMessage: 'Search listings by assessment title or source course',
+  },
+  emptyTitle: {
+    id: 'system.admin.admin.MarketplaceListingsTable.emptyTitle',
+    defaultMessage: 'No assessments have been published yet.',
+  },
+  unknown: {
+    id: 'system.admin.admin.MarketplaceListingsTable.unknown',
+    defaultMessage: '—',
+  },
+  deleteTitle: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deleteTitle',
+    defaultMessage: 'Delete this listing permanently?',
+  },
+  deleteConfirm: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deleteConfirm',
+    defaultMessage:
+      'The listing, all of its versions and the snapshots those versions hold in the preview container will be deleted permanently. This cannot be undone. To merely take the listing off the marketplace, unlist it instead.',
+  },
+  deleteConfirmUnlisted: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deleteConfirmUnlisted',
+    defaultMessage:
+      'The listing, all of its versions and the snapshots those versions hold in the preview container will be deleted permanently. The source assessment is not affected and can be published again. This cannot be undone.',
+  },
+  deleteTooltip: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deleteTooltip',
+    defaultMessage: 'Delete permanently',
+  },
+  deleteBlockedTooltip: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deleteBlockedTooltip',
+    defaultMessage:
+      'A published listing cannot be deleted. Unlist it first, so the reversible step comes before the irreversible one.',
+  },
+  deleteAdoptionWarning: {
+    id: 'system.admin.admin.MarketplaceListingsTable.deleteAdoptionWarning',
+    defaultMessage:
+      '{count, plural, one {# course has} other {# courses have}} adopted this listing. Their existing copies will not be affected, but the adoption history will be destroyed.',
+  },
+});
+
+const MarketplaceListingsTable = ({
+  listings,
+  onDelete,
+  onRestored,
+  onVisibilityChanged,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  const stateDisplay: Record<MarketplaceListingState, string> = {
+    published: t(translations.statePublished),
+    unlisted: t(translations.stateUnlisted),
+  };
+
+  const stateColors = {
+    published: 'success',
+    unlisted: 'default',
+  } as const;
+
+  // Mirrors `Listing#orphaned?`, which is about the AUTHORING copy and not about the origin: a
+  // rebuilt listing has a fresh copy in the container and is no longer orphaned, even though its
+  // original source assessment is gone for good. The url is null exactly when the copy is missing.
+  const isOrphaned = (listing: MarketplaceListingAdminData): boolean =>
+    listing.authoringAssessmentUrl === null;
+
+  // Mirrors `Listing#purgeable?`: a listing that is off the marketplace, orphaned or unlisted. A
+  // published listing has to be unlisted first, which keeps the reversible step ahead of the
+  // irreversible one. Adoption count plays no part — a deliberate deletion of an adopted listing is
+  // allowed; the confirm dialog is where that fact is surfaced, not a disabled button.
+  const isPurgeable = (listing: MarketplaceListingAdminData): boolean =>
+    isOrphaned(listing) || listing.state === 'unlisted';
+
+  // A deleted origin is struck through AND suffixed: the strikethrough carries at a glance, the
+  // suffix carries for anyone who cannot see it, and the tooltip carries the part neither can — that
+  // the listing itself is fine. "Deleted" beside a live, serving listing reads as "broken" without it.
+  const deletedOrigin = (name: string, hint: string): JSX.Element => (
+    <Tooltip title={hint}>
+      <Typography color="text.secondary" component="span" variant="body2">
+        <span className="line-through">{name}</span>{' '}
+        {t(translations.deletedSuffix)}
+      </Typography>
+    </Tooltip>
+  );
+
+  const columns: ColumnTemplate<MarketplaceListingAdminData>[] = [
+    {
+      of: 'id',
+      title: t(translations.colId),
+      sortable: true,
+      // The second entrance to the version history, and the only unconditional one. The Version cell
+      // beside it links only when a version exists, so a listing that has never published one had no
+      // route to its own page at all. Surfacing the id also gives the container's "Listing ID n"
+      // chips something to resolve against.
+      cell: (listing) => (
+        <Link
+          to={`/admin/marketplace_listings/${listing.id}`}
+          underline="hover"
+        >
+          {listing.id}
+        </Link>
+      ),
+    },
+    {
+      of: 'title',
+      title: t(translations.colTitle),
+      sortable: true,
+      searchable: true,
+      cell: (listing): JSX.Element | string => {
+        const title = listing.title ?? t(translations.unknown);
+
+        if (listing.sourceAssessmentDeleted)
+          return deletedOrigin(title, t(translations.assessmentDeletedHint));
+
+        return listing.authoringAssessmentUrl ? (
+          <Link href={listing.authoringAssessmentUrl} underline="hover">
+            {title}
+          </Link>
+        ) : (
+          title
+        );
+      },
+    },
+    {
+      id: 'source',
+      title: t(translations.colSource),
+      sortable: true,
+      searchable: true,
+      // Deliberately not filterable over courses.
+      accessorFn: (listing) => listing.sourceCourseName ?? '',
+      cell: (listing): JSX.Element | string => {
+        const name = listing.sourceCourseName ?? t(translations.unknown);
+
+        if (listing.sourceCourseDeleted)
+          return deletedOrigin(name, t(translations.courseDeletedHint));
+
+        return listing.sourceCourseId && listing.sourceInstanceHost ? (
+          <Link
+            href={`//${listing.sourceInstanceHost}/courses/${listing.sourceCourseId}/assessments`}
+            underline="hover"
+          >
+            {listing.sourceCourseName ?? `#${listing.sourceCourseId}`}
+          </Link>
+        ) : (
+          name
+        );
+      },
+    },
+    {
+      id: 'instance',
+      title: t(translations.colInstance),
+      sortable: true,
+      filterable: true,
+      accessorFn: (listing) => listing.sourceInstanceName ?? '',
+      filterProps: {
+        getValue: (listing) => [listing.sourceInstanceName ?? NO_INSTANCE],
+        getLabel: (value: string) =>
+          value === NO_INSTANCE ? t(translations.filterNoInstance) : value,
+        shouldInclude: (listing, filterValue?: string[]) =>
+          !filterValue?.length ||
+          filterValue.includes(listing.sourceInstanceName ?? NO_INSTANCE),
+      },
+      cell: (listing) =>
+        listing.sourceInstanceName && listing.sourceInstanceHost ? (
+          <Link href={`//${listing.sourceInstanceHost}/`} underline="hover">
+            {listing.sourceInstanceName}
+          </Link>
+        ) : (
+          listing.sourceInstanceName ?? t(translations.unknown)
+        ),
+    },
+    {
+      id: 'version',
+      title: t(translations.colVersion),
+      // The entrance to the version history, which is the only index into the container course.
+      //
+      // Date, not date+time: this table shows ONE version per listing, so there is no sibling to
+      // disambiguate against and the time would be noise. It stays reachable on hover.
+      cell: (listing) =>
+        listing.currentVersionPublishedAt ? (
+          <Tooltip
+            describeChild
+            disableInteractive
+            title={formatLongDateTime(listing.currentVersionPublishedAt)}
+          >
+            <Link
+              to={`/admin/marketplace_listings/${listing.id}`}
+              underline="hover"
+            >
+              {formatLongDate(listing.currentVersionPublishedAt)}
+            </Link>
+          </Tooltip>
+        ) : (
+          t(translations.unknown)
+        ),
+    },
+    {
+      of: 'adoptions',
+      title: t(translations.colAdoptions),
+      sortable: true,
+      sortProps: { sort: (a, b): number => a.adoptions - b.adoptions },
+      cell: (listing) =>
+        listing.adoptions > 0 ? (
+          <Link
+            to={`/admin/marketplace_listings/${listing.id}`}
+            underline="hover"
+          >
+            {listing.adoptions}
+          </Link>
+        ) : (
+          listing.adoptions.toString()
+        ),
+    },
+    {
+      of: 'state',
+      title: t(translations.colState),
+      filterable: true,
+      filterProps: {
+        // Every row contributes exactly one hosting value alongside its state, so the pair is always
+        // both offered and complete — selecting neither is the same as selecting both. Orphaned is
+        // contributed only by the rows it describes; see the constant.
+        getValue: (listing) => [
+          listing.state,
+          listing.marketplaceHosted
+            ? MARKETPLACE_HOSTED
+            : NOT_MARKETPLACE_HOSTED,
+          ...(isOrphaned(listing) ? [ORPHANED] : []),
+        ],
+        getLabel: (value: StateFilterValue): string => {
+          if (value === MARKETPLACE_HOSTED)
+            return t(translations.marketplaceHosted);
+          if (value === NOT_MARKETPLACE_HOSTED)
+            return t(translations.notMarketplaceHosted);
+          if (value === ORPHANED) return t(translations.orphaned);
+
+          return stateDisplay[value];
+        },
+        shouldInclude: (listing, filterValue?: StateFilterValue[]) =>
+          !filterValue?.length ||
+          filterValue.includes(listing.state) ||
+          filterValue.includes(
+            listing.marketplaceHosted
+              ? MARKETPLACE_HOSTED
+              : NOT_MARKETPLACE_HOSTED,
+          ) ||
+          (isOrphaned(listing) && filterValue.includes(ORPHANED)),
+      },
+      cell: (listing) => (
+        <div className="flex flex-col items-start gap-0.5">
+          <Chip
+            color={stateColors[listing.state]}
+            label={stateDisplay[listing.state]}
+            size="small"
+          />
+          {/* Filled and in the alarm colour, unlike the marketplace-hosted marker beside it: that one
+              is provenance, this one is a fault nothing but a bypassed callback can produce. The state
+              chip stays as it is — an orphan goes on serving its last published version. */}
+          {isOrphaned(listing) && (
+            <Tooltip title={t(translations.orphanedHint)}>
+              <Chip
+                color="error"
+                label={t(translations.orphaned)}
+                size="small"
+              />
+            </Tooltip>
+          )}
+          {listing.marketplaceHosted && (
+            <Tooltip title={t(translations.marketplaceHostedHint)}>
+              <Chip
+                label={t(translations.marketplaceHosted)}
+                size="small"
+                variant="outlined"
+              />
+            </Tooltip>
+          )}
+        </div>
+      ),
+    },
+    {
+      id: 'actions',
+      title: t(translations.colActions),
+      cell: (listing) => (
+        <div className="flex items-center gap-2">
+          {listing.authoringAssessmentUrl && (
+            <Link
+              className="whitespace-nowrap"
+              href={listing.authoringAssessmentUrl}
+              underline="hover"
+            >
+              {t(translations.openSourceAssessment)}
+            </Link>
+          )}
+
+          <MarketplaceListingVisibilityButton
+            listing={listing}
+            onChanged={onVisibilityChanged}
+          />
+
+          {isOrphaned(listing) &&
+            listing.currentVersionPublishedAt !== null && (
+              <MarketplaceRestoreAuthoringButton
+                listing={listing}
+                onRestored={onRestored}
+              />
+            )}
+
+          <DeleteButton
+            confirmMessage={
+              <>
+                <PromptText>
+                  {isOrphaned(listing)
+                    ? t(translations.deleteConfirm)
+                    : t(translations.deleteConfirmUnlisted)}
+                </PromptText>
+
+                {listing.adoptions > 0 && (
+                  <PromptText>
+                    {t(translations.deleteAdoptionWarning, {
+                      count: listing.adoptions,
+                    })}
+                  </PromptText>
+                )}
+              </>
+            }
+            disabled={!isPurgeable(listing)}
+            onClick={(): Promise<void> => onDelete(listing.id)}
+            title={t(translations.deleteTitle)}
+            tooltip={
+              isPurgeable(listing)
+                ? t(translations.deleteTooltip)
+                : t(translations.deleteBlockedTooltip)
+            }
+          />
+        </div>
+      ),
+    },
+  ];
+
+  const emptyState = (
+    <div className="flex flex-col items-center gap-1 px-6 py-10 text-center">
+      <StorefrontOutlined sx={{ fontSize: '3rem', color: 'action.disabled' }} />
+
+      <Typography color="text.secondary" variant="body2">
+        {t(translations.emptyTitle)}
+      </Typography>
+    </div>
+  );
+
+  return (
+    <Table
+      columns={columns}
+      data={listings}
+      getRowId={(listing): string => listing.id.toString()}
+      renderEmpty={emptyState}
+      search={{ searchPlaceholder: t(translations.searchText) }}
+      toolbar={{ show: true }}
+    />
+  );
+};
+
+export default MarketplaceListingsTable;

--- a/client/app/bundles/system/admin/admin/pages/MarketplaceListingShow.tsx
+++ b/client/app/bundles/system/admin/admin/pages/MarketplaceListingShow.tsx
@@ -1,0 +1,460 @@
+import { FC, useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+import {
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  MarketplaceListingDetailData,
+  MarketplaceListingState,
+} from 'types/system/marketplaceListings';
+
+import SystemAPI from 'api/system';
+import Page from 'lib/components/core/layouts/Page';
+import Link from 'lib/components/core/Link';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDateTime } from 'lib/moment';
+
+const translations = defineMessages({
+  header: {
+    id: 'system.admin.admin.MarketplaceListingShow.header',
+    defaultMessage: 'Marketplace Listing',
+  },
+  fetchFailure: {
+    id: 'system.admin.admin.MarketplaceListingShow.fetchFailure',
+    defaultMessage: 'Failed to load this marketplace listing.',
+  },
+  sourceCourse: {
+    id: 'system.admin.admin.MarketplaceListingShow.sourceCourse',
+    defaultMessage: 'Source course',
+  },
+  instance: {
+    id: 'system.admin.admin.MarketplaceListingShow.instance',
+    defaultMessage: 'Instance',
+  },
+  versionHistory: {
+    id: 'system.admin.admin.MarketplaceListingShow.versionHistory',
+    defaultMessage: 'Version history',
+  },
+  colVersion: {
+    id: 'system.admin.admin.MarketplaceListingShow.colVersion',
+    defaultMessage: 'Version',
+  },
+  colPublisher: {
+    id: 'system.admin.admin.MarketplaceListingShow.colPublisher',
+    defaultMessage: 'Published by',
+  },
+  colContent: {
+    id: 'system.admin.admin.MarketplaceListingShow.colContent',
+    defaultMessage: 'Content',
+  },
+  viewVersion: {
+    id: 'system.admin.admin.MarketplaceListingShow.viewVersion',
+    defaultMessage: 'View {version} content',
+  },
+  // "Latest", matching the container's chip and the `apply_latest_version` route. The message id is
+  // left alone: renaming it would orphan the key in every locale file for a copy change.
+  currentBadge: {
+    id: 'system.admin.admin.MarketplaceListingShow.currentBadge',
+    defaultMessage: 'Latest',
+  },
+  noVersions: {
+    id: 'system.admin.admin.MarketplaceListingShow.noVersions',
+    defaultMessage: 'No versions have been published yet.',
+  },
+  adoptions: {
+    id: 'system.admin.admin.MarketplaceListingShow.adoptions',
+    defaultMessage: 'Adoptions',
+  },
+  colCourse: {
+    id: 'system.admin.admin.MarketplaceListingShow.colCourse',
+    defaultMessage: 'Course',
+  },
+  colVersionHeld: {
+    id: 'system.admin.admin.MarketplaceListingShow.colVersionHeld',
+    defaultMessage: 'Version held',
+  },
+  colAdoptedAt: {
+    id: 'system.admin.admin.MarketplaceListingShow.colAdoptedAt',
+    defaultMessage: 'Adopted',
+  },
+  noAdoptions: {
+    id: 'system.admin.admin.MarketplaceListingShow.noAdoptions',
+    defaultMessage: 'No courses have adopted this listing yet.',
+  },
+  statePublished: {
+    id: 'system.admin.admin.MarketplaceListingShow.statePublished',
+    defaultMessage: 'Published',
+  },
+  stateUnlisted: {
+    id: 'system.admin.admin.MarketplaceListingShow.stateUnlisted',
+    defaultMessage: 'Unlisted',
+  },
+  deletedSuffix: {
+    id: 'system.admin.admin.MarketplaceListingShow.deletedSuffix',
+    defaultMessage: '(deleted)',
+  },
+  // Rendered ONLY when the original is gone. While it exists there is nothing to say: the heading
+  // names it and "Open source assessment" opens it, so a field repeating the heading's own text
+  // would be noise — and the label is what lets this state the deletion without repeating it either.
+  originalAssessment: {
+    id: 'system.admin.admin.MarketplaceListingShow.originalAssessment',
+    defaultMessage: 'Original assessment',
+  },
+  originalDeleted: {
+    id: 'system.admin.admin.MarketplaceListingShow.originalDeleted',
+    defaultMessage: 'deleted',
+  },
+  assessmentDeletedHint: {
+    id: 'system.admin.admin.MarketplaceListingShow.assessmentDeletedHint',
+    defaultMessage:
+      'The assessment this listing was originally published from has been deleted. The listing is unaffected: it goes on serving its last published version, and a source assessment is saved in the marketplace’s preview course so new versions can still be published.',
+  },
+  courseDeletedHint: {
+    id: 'system.admin.admin.MarketplaceListingShow.courseDeletedHint',
+    defaultMessage:
+      'The course this listing was published from has been deleted. Its name is kept as a record of where the content came from.',
+  },
+  openSourceAssessment: {
+    id: 'system.admin.admin.MarketplaceListingShow.openSourceAssessment',
+    defaultMessage: 'Open source assessment',
+  },
+  marketplaceHosted: {
+    id: 'system.admin.admin.MarketplaceListingShow.marketplaceHosted',
+    defaultMessage: 'Marketplace-hosted',
+  },
+  marketplaceHostedHint: {
+    id: 'system.admin.admin.MarketplaceListingShow.marketplaceHostedHint',
+    defaultMessage:
+      "This listing's source assessment lives in the marketplace's own preview course, not in the course it was originally published from - the original was deleted, so the marketplace saved one to keep publishing from.",
+  },
+  orphaned: {
+    id: 'system.admin.admin.MarketplaceListingShow.orphaned',
+    defaultMessage: 'Orphaned',
+  },
+  orphanedHint: {
+    id: 'system.admin.admin.MarketplaceListingShow.orphanedHint',
+    defaultMessage:
+      'This listing has no source assessment, which should not happen: one is rebuilt automatically whenever an assessment or the course holding it is deleted. Rebuild it from the latest published version on the listings page, or delete the listing if there is no version left to rebuild from.',
+  },
+  unknown: {
+    id: 'system.admin.admin.MarketplaceListingShow.unknown',
+    defaultMessage: '—',
+  },
+});
+
+const STATE_COLORS = {
+  published: 'success',
+  unlisted: 'default',
+} as const;
+
+interface LoadedListing {
+  listingId: string;
+  data: MarketplaceListingDetailData;
+}
+
+const MarketplaceListingShow: FC = () => {
+  const { t } = useTranslation();
+  const { listingId } = useParams();
+  const [loadedListing, setLoadedListing] = useState<LoadedListing>();
+  const [failed, setFailed] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!listingId) {
+      setLoadedListing(undefined);
+      setFailed(false);
+      setLoading(false);
+      return (): void => {};
+    }
+
+    let active = true;
+    setLoadedListing(undefined);
+    setFailed(false);
+    setLoading(true);
+
+    SystemAPI.admin
+      .fetchMarketplaceListing(Number(listingId))
+      .then((response) => {
+        if (active) setLoadedListing({ listingId, data: response.data });
+      })
+      .catch(() => {
+        if (active) setFailed(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [listingId]);
+
+  // Marketplace visibility, and only that. Whether either origin still exists is reported on the
+  // provenance line below, because a listing can be published and have a deleted origin at once.
+  const stateLabel = (state: MarketplaceListingState): string =>
+    state === 'published'
+      ? t(translations.statePublished)
+      : t(translations.stateUnlisted);
+
+  const deletedOrigin = (name: string, hint: string): JSX.Element => (
+    <Tooltip title={hint}>
+      <span>
+        <span className="line-through">{name}</span>{' '}
+        {t(translations.deletedSuffix)}
+      </span>
+    </Tooltip>
+  );
+
+  const date = (value: string | null): string =>
+    value ? formatLongDateTime(value) : t(translations.unknown);
+  const listing =
+    loadedListing && loadedListing.listingId === listingId
+      ? loadedListing.data
+      : undefined;
+
+  if (loading) return <LoadingIndicator />;
+
+  if (failed || !listing) {
+    return (
+      <Page backTo="/admin/marketplace_listings" title={t(translations.header)}>
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.fetchFailure)}
+        </Typography>
+      </Page>
+    );
+  }
+
+  // Links to the instance's own landing page, matching the index table's Instance column. Plain text
+  // once the origin instance has been deleted, which takes the host with it.
+  const sourceInstanceName = (): JSX.Element | string => {
+    if (!listing.sourceInstanceName || !listing.sourceInstanceHost)
+      return listing.sourceInstanceName ?? t(translations.unknown);
+
+    return (
+      <Link href={`//${listing.sourceInstanceHost}/`} underline="hover">
+        {listing.sourceInstanceName}
+      </Link>
+    );
+  };
+
+  const sourceCourseName = (): JSX.Element | string => {
+    const name = listing.sourceCourseName ?? t(translations.unknown);
+
+    if (listing.sourceCourseDeleted)
+      return deletedOrigin(name, t(translations.courseDeletedHint));
+
+    return listing.sourceCourseId && listing.sourceInstanceHost ? (
+      <Link
+        href={`//${listing.sourceInstanceHost}/courses/${listing.sourceCourseId}/assessments`}
+        underline="hover"
+      >
+        {listing.sourceCourseName ?? `#${listing.sourceCourseId}`}
+      </Link>
+    ) : (
+      name
+    );
+  };
+
+  return (
+    <Page backTo="/admin/marketplace_listings" title={t(translations.header)}>
+      <div className="mb-6 flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Typography variant="h6">
+            {listing.title ?? t(translations.unknown)}
+          </Typography>
+
+          <Chip
+            color={STATE_COLORS[listing.state]}
+            label={stateLabel(listing.state)}
+            size="small"
+          />
+
+          {/* The same fault marker the index carries, so an admin who followed a red chip here is not
+              met by a page that looks healthy. The remedy lives on the index, and the hint says so:
+              every mutation stays there. */}
+          {listing.authoringAssessmentUrl === null && (
+            <Tooltip title={t(translations.orphanedHint)}>
+              <Chip
+                color="error"
+                label={t(translations.orphaned)}
+                size="small"
+              />
+            </Tooltip>
+          )}
+
+          {listing.marketplaceHosted && (
+            <Tooltip title={t(translations.marketplaceHostedHint)}>
+              <Chip
+                label={t(translations.marketplaceHosted)}
+                size="small"
+                variant="outlined"
+              />
+            </Tooltip>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-x-8 gap-y-1">
+          <Typography color="text.secondary" variant="body2">
+            {t(translations.sourceCourse)}: {sourceCourseName()}
+          </Typography>
+
+          <Typography color="text.secondary" variant="body2">
+            {t(translations.instance)}: {sourceInstanceName()}
+          </Typography>
+
+          {listing.sourceAssessmentDeleted && (
+            <Typography color="text.secondary" variant="body2">
+              {t(translations.originalAssessment)}:{' '}
+              <Tooltip title={t(translations.assessmentDeletedHint)}>
+                <span className="underline decoration-dotted">
+                  {t(translations.originalDeleted)}
+                </span>
+              </Tooltip>
+            </Typography>
+          )}
+
+          {listing.authoringAssessmentUrl && (
+            <Typography variant="body2">
+              <Link href={listing.authoringAssessmentUrl} underline="hover">
+                {t(translations.openSourceAssessment)}
+              </Link>
+            </Typography>
+          )}
+        </div>
+      </div>
+
+      <Typography className="mb-2" variant="subtitle1">
+        {t(translations.versionHistory)}
+      </Typography>
+
+      {listing.versions.length === 0 ? (
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.noVersions)}
+        </Typography>
+      ) : (
+        <Table
+          aria-label={t(translations.versionHistory)}
+          className="mb-8"
+          size="small"
+        >
+          <TableHead>
+            <TableRow>
+              <TableCell>{t(translations.colVersion)}</TableCell>
+              <TableCell>{t(translations.colPublisher)}</TableCell>
+              <TableCell>{t(translations.colContent)}</TableCell>
+            </TableRow>
+          </TableHead>
+
+          <TableBody>
+            {listing.versions.map((version) => (
+              <TableRow key={version.publishedAt}>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {date(version.publishedAt)}
+                    {version.isCurrent && (
+                      <Chip
+                        color="primary"
+                        label={t(translations.currentBadge)}
+                        size="small"
+                      />
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  {version.publisherName ?? t(translations.unknown)}
+                </TableCell>
+                <TableCell>
+                  {version.snapshotUrl ? (
+                    <Link
+                      external
+                      href={version.snapshotUrl}
+                      opensInNewTab
+                      underline="hover"
+                    >
+                      {t(translations.viewVersion, {
+                        version: date(version.publishedAt),
+                      })}
+                    </Link>
+                  ) : (
+                    t(translations.unknown)
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Typography className="mb-2" variant="subtitle1">
+        {t(translations.adoptions)}
+      </Typography>
+
+      {listing.adoptions.length === 0 ? (
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.noAdoptions)}
+        </Typography>
+      ) : (
+        <Table aria-label={t(translations.adoptions)} size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t(translations.colCourse)}</TableCell>
+              <TableCell>{t(translations.colVersionHeld)}</TableCell>
+              <TableCell>{t(translations.colAdoptedAt)}</TableCell>
+              <TableCell>{t(translations.colContent)}</TableCell>
+            </TableRow>
+          </TableHead>
+
+          <TableBody>
+            {listing.adoptions.map((adoption) => (
+              <TableRow key={adoption.id}>
+                <TableCell>
+                  {adoption.destinationCourseId &&
+                  adoption.destinationCourseHost ? (
+                    <Link
+                      href={`//${adoption.destinationCourseHost}/courses/${adoption.destinationCourseId}/assessments`}
+                      underline="hover"
+                    >
+                      {adoption.destinationCourseName ??
+                        `#${adoption.destinationCourseId}`}
+                    </Link>
+                  ) : (
+                    adoption.destinationCourseName ?? t(translations.unknown)
+                  )}
+                </TableCell>
+                <TableCell>{date(adoption.adoptedVersionAt)}</TableCell>
+                <TableCell>{date(adoption.adoptedAt)}</TableCell>
+                <TableCell>
+                  {adoption.snapshotUrl && adoption.adoptedVersionAt ? (
+                    <Link
+                      external
+                      href={adoption.snapshotUrl}
+                      opensInNewTab
+                      underline="hover"
+                    >
+                      {t(translations.viewVersion, {
+                        version: date(adoption.adoptedVersionAt),
+                      })}
+                    </Link>
+                  ) : (
+                    t(translations.unknown)
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Page>
+  );
+};
+
+export default MarketplaceListingShow;

--- a/client/app/bundles/system/admin/admin/pages/MarketplaceListingsIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/MarketplaceListingsIndex.tsx
@@ -1,0 +1,102 @@
+import { FC, useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Typography } from '@mui/material';
+import { AxiosError } from 'axios';
+import { MarketplaceListingAdminData } from 'types/system/marketplaceListings';
+
+import SystemAPI from 'api/system';
+import Page from 'lib/components/core/layouts/Page';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import MarketplaceListingsTable from '../components/tables/MarketplaceListingsTable';
+
+const translations = defineMessages({
+  header: {
+    id: 'system.admin.admin.MarketplaceListingsIndex.header',
+    defaultMessage: 'Marketplace Listings',
+  },
+  subtitle: {
+    id: 'system.admin.admin.MarketplaceListingsIndex.subtitle',
+    defaultMessage:
+      'Every published assessment, the version currently served, and how many courses have copied it. Publish a new version from the source assessment - if the original is deleted, a source assessment is saved in the marketplace’s preview course so new versions can still be published.',
+  },
+  fetchFailure: {
+    id: 'system.admin.admin.MarketplaceListingsIndex.fetchFailure',
+    defaultMessage: 'Failed to load marketplace listings.',
+  },
+  deleteSuccess: {
+    id: 'system.admin.admin.MarketplaceListingsIndex.deleteSuccess',
+    defaultMessage: 'Listing deleted permanently.',
+  },
+  deleteFailure: {
+    id: 'system.admin.admin.MarketplaceListingsIndex.deleteFailure',
+    defaultMessage: 'Failed to delete the listing.',
+  },
+});
+
+const MarketplaceListingsIndex: FC = () => {
+  const { t } = useTranslation();
+  const [listings, setListings] = useState<MarketplaceListingAdminData[]>([]);
+  const [loading, setLoading] = useState(true);
+  // "We do not know what is listed", which an empty `listings` cannot say on its own: the table's
+  // empty state is a claim about the marketplace, and a failed fetch has no standing to make it.
+  // Set on refetch failures too — rows that predate a mutation are as unknown as no rows at all.
+  const [failed, setFailed] = useState(false);
+
+  const fetchListings = (): Promise<void> =>
+    SystemAPI.admin
+      .indexMarketplaceListings()
+      .then((response) => {
+        setListings(response.data.listings);
+        setFailed(false);
+      })
+      .catch(() => {
+        setFailed(true);
+        toast.error(t(translations.fetchFailure));
+      });
+
+  useEffect(() => {
+    fetchListings().finally(() => setLoading(false));
+  }, []);
+
+  const handleDelete = async (id: number): Promise<void> => {
+    try {
+      await SystemAPI.admin.deleteMarketplaceListing(id);
+      toast.success(t(translations.deleteSuccess));
+      await fetchListings();
+    } catch (error) {
+      const message =
+        error instanceof AxiosError
+          ? error.response?.data?.errors?.[0]
+          : undefined;
+      toast.error(message ?? t(translations.deleteFailure));
+    }
+  };
+
+  if (loading) return <LoadingIndicator />;
+
+  return (
+    <Page title={t(translations.header)}>
+      <Typography className="mb-4" color="text.secondary" variant="body2">
+        {t(translations.subtitle)}
+      </Typography>
+
+      {failed ? (
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.fetchFailure)}
+        </Typography>
+      ) : (
+        <MarketplaceListingsTable
+          listings={listings}
+          onDelete={handleDelete}
+          onRestored={fetchListings}
+          onVisibilityChanged={fetchListings}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default MarketplaceListingsIndex;

--- a/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceListingShow.test.tsx
+++ b/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceListingShow.test.tsx
@@ -1,0 +1,578 @@
+import { createMockAdapter } from 'mocks/axiosMock';
+import { act, render, waitFor, within } from 'test-utils';
+import TestApp from 'utilities/TestApp';
+
+import SystemAPI from 'api/system';
+
+import MarketplaceListingShow from '../MarketplaceListingShow';
+
+const SHOW_URL = '/admin/marketplace_listings/1';
+const SECOND_SHOW_URL = '/admin/marketplace_listings/2';
+const CONTAINER_V1 = 'http://preview.example.org/courses/7/assessments/101';
+const CONTAINER_V2 = 'http://preview.example.org/courses/7/assessments/102';
+const LISTING_TITLE = 'Recursion Drill';
+const SECOND_LISTING_TITLE = 'Sorting Drill';
+const MARKETPLACE_HOSTED = 'Marketplace-hosted';
+const MARKETPLACE_HOSTED_HINT =
+  "This listing's source assessment lives in the marketplace's own preview course, not in the course it was originally published from - the original was deleted, so the marketplace saved one to keep publishing from.";
+const ORPHANED = 'Orphaned';
+const ORPHANED_HINT =
+  'This listing has no source assessment, which should not happen: one is rebuilt automatically whenever an assessment or the course holding it is deleted. Rebuild it from the latest published version on the listings page, or delete the listing if there is no version left to rebuild from.';
+const AUTHORING_URL = 'http://main.example.org/courses/9/assessments/12';
+const CONTAINER_AUTHORING_URL =
+  'http://preview.example.org/courses/7/assessments/200';
+const OPEN_ACTION = 'Open source assessment';
+const DELETED_SUFFIX = '(deleted)';
+const SOURCE_COURSE_NAME = 'Intro to Programming';
+const VERSION_HISTORY = 'Version history';
+const INSTANCE_NAME = 'Main Campus';
+const ASSESSMENT_DELETED_HINT =
+  'The assessment this listing was originally published from has been deleted. The listing is unaffected: it goes on serving its last published version, and a source assessment is saved in the marketplace’s preview course so new versions can still be published.';
+let mockListingId = '1';
+
+// Under TZ=Asia/Singapore these render as '15 Jan 2026, 6:00pm' and '20 Jun 2026, 6:00pm'.
+const V1_AT = '2026-01-15T10:00:00.000Z';
+const V1_LABEL = '15 Jan 2026, 6:00pm';
+const V2_AT = '2026-06-20T10:00:00.000Z';
+const V2_LABEL = '20 Jun 2026, 6:00pm';
+
+// `TestApp` mounts the component directly inside a `MemoryRouter` with no matching
+// `<Route path=":listingId">`, so `useParams()` would otherwise be empty and the page would never
+// fetch. Mock it to supply the route param — the same idiom as
+// `course/marketplace/pages/ListingPreview/__test__/index.test.tsx`.
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: (): { listingId: string } => ({ listingId: mockListingId }),
+}));
+
+const mock = createMockAdapter(SystemAPI.admin.client);
+
+beforeEach(() => {
+  mock.reset();
+  mockListingId = '1';
+});
+
+const detail = (overrides = {}): unknown => ({
+  id: 1,
+  title: LISTING_TITLE,
+  currentVersionPublishedAt: V2_AT,
+  state: 'published',
+  marketplaceHosted: false,
+  sourceAssessmentDeleted: false,
+  sourceCourseDeleted: false,
+  authoringAssessmentUrl: AUTHORING_URL,
+  sourceCourseId: 9,
+  sourceCourseName: SOURCE_COURSE_NAME,
+  sourceInstanceName: INSTANCE_NAME,
+  sourceInstanceHost: 'main.example.org',
+  versions: [
+    {
+      publishedAt: V1_AT,
+      publisherName: 'Ada Admin',
+      isCurrent: false,
+      snapshotUrl: CONTAINER_V1,
+    },
+    {
+      publishedAt: V2_AT,
+      publisherName: 'Bob Admin',
+      isCurrent: true,
+      snapshotUrl: CONTAINER_V2,
+    },
+  ],
+  adoptions: [
+    {
+      id: 5,
+      destinationCourseId: 77,
+      destinationCourseName: 'Adopting Course',
+      destinationCourseHost: 'other.example.org',
+      adoptedVersionAt: V1_AT,
+      adoptedAt: '2026-02-01T10:00:00.000Z',
+      snapshotUrl: CONTAINER_V1,
+    },
+  ],
+  ...overrides,
+});
+
+const renderPage = (): ReturnType<typeof render> =>
+  render(<MarketplaceListingShow />, { at: [SHOW_URL] });
+
+it('names the listing and its provenance', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.getByText(SOURCE_COURSE_NAME)).toBeInTheDocument();
+  expect(page.getByText(new RegExp(INSTANCE_NAME))).toBeInTheDocument();
+});
+
+// The heading is the LISTING's identity, so it is plain text in every state — never a link (whose
+// typography would shrink it inside the h6) and never struck through (which would say the listing is
+// dead while it serves normally). "Open source assessment" beside it is the entrance.
+it('keeps the heading plain text and puts the entrance beside it', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(
+    page.queryByRole('link', { name: LISTING_TITLE }),
+  ).not.toBeInTheDocument();
+  expect(page.getByRole('link', { name: OPEN_ACTION })).toHaveAttribute(
+    'href',
+    AUTHORING_URL,
+  );
+});
+
+it('links the source course on its own instance host', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(
+    await page.findByRole('link', { name: SOURCE_COURSE_NAME }),
+  ).toHaveAttribute('href', '//main.example.org/courses/9/assessments');
+});
+
+// Same rule as the index table's Instance column: the instance is only reachable on its own host.
+it('links the instance to its own host', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(
+    await page.findByRole('link', { name: INSTANCE_NAME }),
+  ).toHaveAttribute('href', '//main.example.org/');
+});
+
+it('leaves the instance as plain text when none was recorded', async () => {
+  mock
+    .onGet(SHOW_URL)
+    .reply(200, detail({ sourceInstanceName: null, sourceInstanceHost: null }));
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(
+    page.queryByRole('link', { name: INSTANCE_NAME }),
+  ).not.toBeInTheDocument();
+});
+
+// Stated on the provenance line under its own label, NOT on the heading: a label carries the meaning
+// without a strikethrough and without repeating the title, which the heading already shows.
+it('reports a deleted original on the provenance line, leaving the heading intact', async () => {
+  mock.onGet(SHOW_URL).reply(
+    200,
+    detail({
+      sourceAssessmentDeleted: true,
+      marketplaceHosted: true,
+      authoringAssessmentUrl: CONTAINER_AUTHORING_URL,
+    }),
+  );
+
+  const page = renderPage();
+
+  const heading = await page.findByText(LISTING_TITLE);
+  expect(heading).not.toHaveClass('line-through');
+  expect(page.getByText(/Original assessment/)).toBeInTheDocument();
+  expect(page.getByLabelText(ASSESSMENT_DELETED_HINT)).toHaveTextContent(
+    'deleted',
+  );
+  // The entrance follows the source assessment to the preview course.
+  expect(page.getByRole('link', { name: OPEN_ACTION })).toHaveAttribute(
+    'href',
+    CONTAINER_AUTHORING_URL,
+  );
+});
+
+it('says nothing about the original while it still exists', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.queryByText(/Original assessment/)).not.toBeInTheDocument();
+});
+
+// The course NAME survives its deletion and is worth keeping on screen, so unlike the assessment it
+// is struck through in place rather than replaced by a bare "deleted".
+it('strikes out and unlinks a deleted source course', async () => {
+  mock.onGet(SHOW_URL).reply(
+    200,
+    detail({
+      sourceAssessmentDeleted: true,
+      sourceCourseDeleted: true,
+      sourceCourseId: null,
+      authoringAssessmentUrl: null,
+    }),
+  );
+
+  const page = renderPage();
+
+  expect(await page.findByText(SOURCE_COURSE_NAME)).toHaveClass('line-through');
+  expect(
+    page.queryByRole('link', { name: SOURCE_COURSE_NAME }),
+  ).not.toBeInTheDocument();
+  // Nothing to open while the listing has no source assessment at all.
+  expect(
+    page.queryByRole('link', { name: OPEN_ACTION }),
+  ).not.toBeInTheDocument();
+  expect(page.getByText(DELETED_SUFFIX, { exact: false })).toBeInTheDocument();
+});
+
+// The Source course line keeps naming the ORIGIN course after a rebuild — that provenance is a
+// historical fact the rebuild leaves alone — so the marker is what stops this page reading as though
+// the source assessment were still sitting in that course.
+it('marks a marketplace-hosted listing alongside its state, keeping the origin provenance', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail({ marketplaceHosted: true }));
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.getByText('Published')).toBeInTheDocument();
+  expect(page.getByLabelText(MARKETPLACE_HOSTED_HINT)).toHaveTextContent(
+    MARKETPLACE_HOSTED,
+  );
+  expect(page.getByText(SOURCE_COURSE_NAME)).toBeInTheDocument();
+});
+
+// An admin arrives here from the index's red chip, so the page has to carry the same fault marker —
+// otherwise following the alarm lands on a page that reads as healthy. The remedy stays on the index,
+// which is where every mutation lives.
+it('marks an orphaned listing here too, and says where the remedy is', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail({ authoringAssessmentUrl: null }));
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.getByLabelText(ORPHANED_HINT)).toHaveTextContent(ORPHANED);
+  // Visibility is a separate axis: an orphan goes on serving its last published version.
+  expect(page.getByText('Published')).toBeInTheDocument();
+});
+
+it('shows no orphan marker for a listing that has a source assessment', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.queryByText(ORPHANED)).not.toBeInTheDocument();
+});
+
+it('shows no marketplace-hosted marker for a listing with its own source course', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.queryByText(MARKETPLACE_HOSTED)).not.toBeInTheDocument();
+});
+
+// Every version is listed, including the current one — the point of the page is the whole chain.
+it('lists every version with its publisher and marks the current one', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+
+  const history = page.getByRole('table', { name: VERSION_HISTORY });
+  const rows = within(history).getAllByRole('row').slice(1);
+
+  expect(rows).toHaveLength(2);
+  expect(within(rows[0]).getByText(V1_LABEL)).toBeInTheDocument();
+  expect(within(rows[0]).getByText('Ada Admin')).toBeInTheDocument();
+  expect(within(rows[1]).getByText(V2_LABEL)).toBeInTheDocument();
+  expect(within(rows[1]).getByText('Bob Admin')).toBeInTheDocument();
+
+  // Only the served version carries the badge. "Latest", not "Current": the adoptions table below
+  // has a "Version held" column, so *current* invites the question "current to whom?" — and the
+  // container's chips and the `apply_latest_version` route already say latest.
+  expect(within(rows[1]).getByText('Latest')).toBeInTheDocument();
+  expect(within(rows[0]).queryByText('Latest')).not.toBeInTheDocument();
+
+  // The Version column now carries the publish datetime, so a separate Published column would
+  // repeat it verbatim.
+  expect(within(rows[0]).getAllByRole('cell')).toHaveLength(3);
+});
+
+// The snapshot lives in the container course on the preview host, and the admin returns to this page
+// afterwards — so the link must not replace it.
+it('links each version to its container snapshot in a new tab', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+
+  const history = page.getByRole('table', { name: VERSION_HISTORY });
+  const link = within(history).getByRole('link', {
+    name: `View ${V1_LABEL} content`,
+  });
+  expect(link).toHaveAttribute('href', CONTAINER_V1);
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+it('renders a version with no surviving snapshot as plain text, not a link', async () => {
+  mock.onGet(SHOW_URL).reply(200, {
+    ...(detail() as object),
+    versions: [
+      {
+        publishedAt: V1_AT,
+        publisherName: 'Ada Admin',
+        isCurrent: true,
+        snapshotUrl: null,
+      },
+    ],
+  });
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(
+    within(page.getByRole('table', { name: VERSION_HISTORY })).queryByRole(
+      'link',
+      { name: `View ${V1_LABEL} content` },
+    ),
+  ).not.toBeInTheDocument();
+});
+
+it('reports which version each adopting course holds', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+
+  const adoptions = page.getByRole('table', { name: 'Adoptions' });
+  const rows = within(adoptions).getAllByRole('row').slice(1);
+
+  expect(rows).toHaveLength(1);
+  expect(within(rows[0]).getByText('Adopting Course')).toBeInTheDocument();
+  expect(within(rows[0]).getByText(V1_LABEL)).toBeInTheDocument();
+});
+
+// Unusual but valid, so it reports rather than the section vanishing.
+it('shows an inline empty state when nothing has adopted the listing', async () => {
+  mock.onGet(SHOW_URL).reply(200, { ...(detail() as object), adoptions: [] });
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(
+    page.getByText('No courses have adopted this listing yet.'),
+  ).toBeInTheDocument();
+  expect(
+    page.queryByRole('table', { name: 'Adoptions' }),
+  ).not.toBeInTheDocument();
+});
+
+// Losing the origin removes the authoring copy, not the history — and not the listing's place on the
+// marketplace either, since the copy is rebuilt automatically.
+it('still renders the history, and stays published, when the origin was deleted', async () => {
+  mock.onGet(SHOW_URL).reply(200, {
+    ...(detail() as object),
+    sourceAssessmentDeleted: true,
+    marketplaceHosted: true,
+    authoringAssessmentUrl: CONTAINER_AUTHORING_URL,
+  });
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.getByText('Published')).toBeInTheDocument();
+  expect(
+    within(page.getByRole('table', { name: VERSION_HISTORY })).getAllByRole(
+      'row',
+    ),
+  ).toHaveLength(3);
+});
+
+it('reports an unlisted listing as unlisted', async () => {
+  mock.onGet(SHOW_URL).reply(200, {
+    ...(detail() as object),
+    state: 'unlisted',
+  });
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+  expect(page.getByText('Unlisted')).toBeInTheDocument();
+});
+
+it('renders an empty history without crashing when there is no version', async () => {
+  mock.onGet(SHOW_URL).reply(200, {
+    ...(detail() as object),
+    currentVersionPublishedAt: null,
+    versions: [],
+  });
+
+  const page = renderPage();
+
+  expect(
+    await page.findByText('No versions have been published yet.'),
+  ).toBeInTheDocument();
+});
+
+it('uses an em dash for unknown values', async () => {
+  mock.onGet(SHOW_URL).reply(200, {
+    ...(detail() as object),
+    title: null,
+    sourceCourseName: null,
+    sourceInstanceName: null,
+    versions: [
+      {
+        publishedAt: null,
+        publisherName: null,
+        isCurrent: true,
+        snapshotUrl: null,
+      },
+    ],
+    adoptions: [
+      {
+        id: 5,
+        destinationCourseId: null,
+        destinationCourseName: null,
+        destinationCourseHost: null,
+        adoptedVersionAt: null,
+        adoptedAt: null,
+        snapshotUrl: null,
+      },
+    ],
+  });
+
+  const page = renderPage();
+
+  expect(await page.findByText('Marketplace Listing')).toBeInTheDocument();
+  expect(page.getAllByText('—').length).toBeGreaterThan(1);
+});
+
+it('toasts and renders nothing when the fetch fails', async () => {
+  mock.onGet(SHOW_URL).reply(500);
+
+  const page = renderPage();
+
+  expect(
+    await page.findByText('Failed to load this marketplace listing.'),
+  ).toBeInTheDocument();
+});
+
+it('loads a new listing after the previous listing failed', async () => {
+  mock.onGet(SHOW_URL).reply(500);
+  mock.onGet(SECOND_SHOW_URL).reply(
+    200,
+    detail({
+      id: 2,
+      title: SECOND_LISTING_TITLE,
+    }),
+  );
+
+  const page = renderPage();
+  await page.findByText('Failed to load this marketplace listing.');
+
+  mockListingId = '2';
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp at={[SHOW_URL]}>
+      <MarketplaceListingShow />
+    </TestApp>,
+  );
+
+  expect(await page.findByText(SECOND_LISTING_TITLE)).toBeInTheDocument();
+  expect(
+    page.queryByText('Failed to load this marketplace listing.'),
+  ).not.toBeInTheDocument();
+});
+
+it('does not keep the previous listing visible while a new listing loads', async () => {
+  let resolveSecondRequest: (response: [number, unknown]) => void;
+  mock.onGet(SHOW_URL).reply(200, detail());
+  mock.onGet(SECOND_SHOW_URL).reply(
+    () =>
+      new Promise((resolve) => {
+        resolveSecondRequest = resolve;
+      }),
+  );
+
+  const page = renderPage();
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+
+  mockListingId = '2';
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp at={[SHOW_URL]}>
+      <MarketplaceListingShow />
+    </TestApp>,
+  );
+
+  expect(page.queryByText(LISTING_TITLE)).not.toBeInTheDocument();
+  await waitFor(() => expect(resolveSecondRequest).toBeDefined());
+
+  await act(async () => {
+    resolveSecondRequest!([
+      200,
+      detail({
+        id: 2,
+        title: SECOND_LISTING_TITLE,
+      }),
+    ]);
+  });
+
+  expect(await page.findByText(SECOND_LISTING_TITLE)).toBeInTheDocument();
+});
+
+it('keeps the new listing when a superseded request fails late', async () => {
+  let resolveFirstRequest: (response: [number]) => void;
+  mock.onGet(SHOW_URL).reply(
+    () =>
+      new Promise((resolve) => {
+        resolveFirstRequest = resolve;
+      }),
+  );
+  mock.onGet(SECOND_SHOW_URL).reply(
+    200,
+    detail({
+      id: 2,
+      title: SECOND_LISTING_TITLE,
+    }),
+  );
+
+  const page = renderPage();
+  await waitFor(() => expect(resolveFirstRequest).toBeDefined());
+
+  mockListingId = '2';
+  // rerender bypasses test-utils' TestApp wrapper, so re-wrap to keep providers.
+  page.rerender(
+    <TestApp at={[SHOW_URL]}>
+      <MarketplaceListingShow />
+    </TestApp>,
+  );
+
+  expect(await page.findByText(SECOND_LISTING_TITLE)).toBeInTheDocument();
+
+  await act(async () => {
+    resolveFirstRequest!([500]);
+  });
+
+  expect(page.getByText(SECOND_LISTING_TITLE)).toBeInTheDocument();
+  expect(
+    page.queryByText('Failed to load this marketplace listing.'),
+  ).not.toBeInTheDocument();
+});
+
+// The history is where two cuts sit side by side, so the time is what tells a same-day pair apart —
+// and no ordinal survives anywhere on the page.
+it('names versions by datetime and carries no ordinal', async () => {
+  mock.onGet(SHOW_URL).reply(200, detail());
+
+  const page = renderPage();
+
+  expect(await page.findByText(LISTING_TITLE)).toBeInTheDocument();
+
+  const history = page.getByRole('table', { name: VERSION_HISTORY });
+  expect(within(history).queryByText(/^v\d+$/)).not.toBeInTheDocument();
+
+  const adoptions = page.getByRole('table', { name: 'Adoptions' });
+  expect(within(adoptions).queryByText(/^v\d+$/)).not.toBeInTheDocument();
+});

--- a/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceListingsIndex.test.tsx
+++ b/client/app/bundles/system/admin/admin/pages/__test__/MarketplaceListingsIndex.test.tsx
@@ -1,0 +1,1680 @@
+import userEvent from '@testing-library/user-event';
+import { createMockAdapter } from 'mocks/axiosMock';
+import { fireEvent, render, waitFor, within } from 'test-utils';
+
+import GlobalAPI from 'api';
+import SystemAPI from 'api/system';
+import toast from 'lib/hooks/toast';
+
+import MarketplaceListingsIndex from '../MarketplaceListingsIndex';
+
+// The restore completion toast is a ReactNode (it carries a link), so capture it and render it
+// rather than mounting a ToastContainer.
+jest.mock('lib/hooks/toast', () => ({ success: jest.fn(), error: jest.fn() }));
+
+const INDEX_URL = '/admin/marketplace_listings';
+const SEARCH_PLACEHOLDER =
+  'Search listings by assessment title or source course';
+const RECURSION_DRILL = 'Recursion Drill';
+const ARRAYS_WARMUP = 'Arrays Warmup';
+const RETIRED_QUIZ = 'Retired Quiz';
+const RESTORE_ACTION = 'Rebuild source assessment';
+const OPEN_ACTION = 'Open source assessment';
+const MAIN_CAMPUS = 'Main Campus';
+const SATELLITE_CAMPUS = 'Satellite Campus';
+const ASSESSMENT_DELETED_HINT =
+  'The assessment this listing was originally published from has been deleted. The listing is unaffected: it goes on serving its last published version, and a source assessment is saved in the marketplace’s preview course so new versions can still be published.';
+const COURSE_DELETED_HINT =
+  'The course this listing was published from has been deleted. Its name is kept as a record of where the content came from.';
+const DELETED_SUFFIX = '(deleted)';
+const SOURCE_COURSE_NAME = 'Intro to Programming';
+const MARKETPLACE_HOSTED = 'Marketplace-hosted';
+const MARKETPLACE_HOSTED_HINT =
+  "This listing's source assessment lives in the marketplace's own preview course, not in the course it was originally published from - the original was deleted, so the marketplace saved one to keep publishing from.";
+const ORPHANED = 'Orphaned';
+const ORPHANED_HINT =
+  'This listing has no source assessment, which should not happen: one is rebuilt automatically whenever an assessment or the course holding it is deleted. Rebuild it from the latest published version, or delete the listing if there is no version left to rebuild from.';
+const ID_COLUMN = 0;
+const TITLE_COLUMN = 1;
+const SOURCE_COLUMN = 2;
+const INSTANCE_COLUMN = 3;
+const VERSION_COLUMN = 4;
+const ADOPTIONS_COLUMN = 5;
+const STATE_COLUMN = 6;
+const AUTHORING_URL = 'http://main.coursemology.org/courses/9/assessments/12';
+const DELETE_BLOCKED_TOOLTIP =
+  'A published listing cannot be deleted. Unlist it first, so the reversible step comes before the irreversible one.';
+// pollJob keeps its interval running after the component unmounts (see its own docstring), so a
+// poller started by one test outlives that test. Every test therefore gets its OWN job url: a stray
+// poller then finds no handler registered for it and cannot satisfy — or break — the next test's
+// assertions by resolving against that test's job handler.
+const UNWATCHED_JOB_URL = '/jobs/unwatched';
+const COMPLETED_JOB_URL = '/jobs/completed';
+const ERRORED_JOB_URL = '/jobs/errored';
+const RESTORED_URL = '/courses/77/assessments/321';
+
+const mock = createMockAdapter(SystemAPI.admin.client);
+// pollJob polls the *jobs* endpoint, which lives on a different axios client to the admin API.
+const jobsMock = createMockAdapter(GlobalAPI.jobs.client);
+
+beforeEach(() => {
+  mock.reset();
+  jobsMock.reset();
+  jest.clearAllMocks();
+});
+
+const listingAt = (overrides = {}): unknown => ({
+  id: 1,
+  title: RECURSION_DRILL,
+  currentVersionPublishedAt: '2026-07-24T07:04:00.000Z',
+  lastPublishedAt: '2026-07-20T10:00:00.000Z',
+  adoptions: 4,
+  sourceCourseId: 9,
+  sourceCourseName: SOURCE_COURSE_NAME,
+  sourceInstanceName: MAIN_CAMPUS,
+  sourceInstanceHost: 'main.coursemology.org',
+  state: 'published',
+  marketplaceHosted: false,
+  sourceAssessmentDeleted: false,
+  sourceCourseDeleted: false,
+  authoringAssessmentUrl: AUTHORING_URL,
+  ...overrides,
+});
+
+/**
+ * How many times the listings index itself has been fetched. Counted by url rather than off
+ * `mock.history.get.length`, which also holds the adapter's `/csrf_token` handshakes.
+ */
+const indexFetchCount = (): number =>
+  mock.history.get.filter((request) => request.url === INDEX_URL).length;
+
+/** Text of one column across every body row, in the order the rows are rendered. */
+const columnTexts = (
+  page: ReturnType<typeof render>,
+  columnIndex: number,
+): (string | null)[] =>
+  page
+    .getAllByRole('row')
+    .slice(1)
+    .map((row) => within(row).getAllByRole('cell')[columnIndex].textContent);
+
+/**
+ * Open one column's filter menu, click one of its items, then close the menu again — an open MUI menu
+ * marks the rest of the page `aria-hidden`, so the table rows are unqueryable until it is. Scoped to
+ * the column's own header cell: the table now carries two filter menus, both tooltipped "Filter".
+ */
+const clickFilterItem = async (
+  page: ReturnType<typeof render>,
+  columnIndex: number,
+  itemName: string,
+): Promise<void> => {
+  const header = page.getAllByRole('columnheader')[columnIndex];
+  fireEvent.click(within(header).getByRole('button', { name: 'Filter' }));
+  fireEvent.click(await page.findByRole('menuitem', { name: itemName }));
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(page.queryByRole('menu')).not.toBeInTheDocument());
+};
+
+const clickStateFilterItem = (
+  page: ReturnType<typeof render>,
+  itemName: string,
+): Promise<void> => clickFilterItem(page, STATE_COLUMN, itemName);
+
+const clickInstanceFilterItem = (
+  page: ReturnType<typeof render>,
+  itemName: string,
+): Promise<void> => clickFilterItem(page, INSTANCE_COLUMN, itemName);
+
+it('renders a listing row with its version, adoptions and provenance', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  expect(page.getByText('24 Jul 2026')).toBeInTheDocument();
+  expect(page.getByText('4')).toBeInTheDocument();
+  expect(page.getByText(SOURCE_COURSE_NAME)).toBeInTheDocument();
+});
+
+// The served vintage is the only entrance to the version history, which is in turn the only index
+// into the container course. One version per row means nothing to disambiguate against, so the time
+// would be pure noise in an already-crowded table — it stays reachable on hover instead.
+it('links the served vintage to the listing version history', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  // Queried by its visible text rather than by accessible name: the cell's Tooltip puts the full
+  // timestamp on the anchor, and dom-accessibility-api prefers that over the name-from-content, so a
+  // `name` query here would assert the tooltip's wording (and its timezone) instead of the link.
+  const link = (await page.findByText('24 Jul 2026')).closest('a');
+  expect(link).toHaveAttribute('href', '/admin/marketplace_listings/1');
+});
+
+it('carries no version ordinal anywhere in the row', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  expect(columnTexts(page, VERSION_COLUMN)).toEqual(['24 Jul 2026']);
+});
+
+it('renders the empty marker instead of a link when there is no version', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ currentVersionPublishedAt: null })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  expect(columnTexts(page, VERSION_COLUMN)).toEqual(['—']);
+  expect(
+    page.queryByRole('link', { name: '24 Jul 2026' }),
+  ).not.toBeInTheDocument();
+});
+
+// The link only navigates; the publishing itself happens on the assessment page, so the label says
+// what the action does rather than what the destination page offers.
+it('links Open source assessment to the authoring assessment', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  // The server hands back an ABSOLUTE url carrying the source course's own instance host, because a
+  // course id resolves nowhere else — so this must be followed as a plain href, not a client route.
+  const link = await page.findByRole('link', { name: OPEN_ACTION });
+  expect(link).toHaveAttribute(
+    'href',
+    'http://main.coursemology.org/courses/9/assessments/12',
+  );
+});
+
+// The title names the assessment, so it is the shortest route to it. Same absolute cross-instance url
+// as the Actions link, for the same reason: a course id resolves only on its origin instance's host.
+it('links the assessment title to its source assessment', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(
+    await page.findByRole('link', { name: RECURSION_DRILL }),
+  ).toHaveAttribute('href', AUTHORING_URL);
+});
+
+// The column describes the ORIGIN, so a deleted original leaves it struck through and unlinked. The
+// suffix is what carries the fact to anyone who cannot see the strikethrough.
+it('strikes out and unlinks a deleted source assessment', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toHaveClass('line-through');
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    `${RECURSION_DRILL} ${DELETED_SUFFIX}`,
+  ]);
+  expect(
+    page.queryByRole('link', { name: RECURSION_DRILL }),
+  ).not.toBeInTheDocument();
+});
+
+// The case that makes the rule worth stating: a REBUILT listing still has an authoring copy, and the
+// cell must not quietly fall through to it. That copy is a different assessment in the marketplace
+// container, so linking a column headed "Source assessment" at it would claim the origin survived.
+it('leaves a rebuilt listing’s source assessment unlinked, though a copy exists', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        marketplaceHosted: true,
+        authoringAssessmentUrl:
+          'http://preview.coursemology.org/courses/7/assessments/53',
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toHaveClass('line-through');
+  expect(
+    page.queryByRole('link', { name: RECURSION_DRILL }),
+  ).not.toBeInTheDocument();
+  // The copy keeps its own entrance, so nothing became unreachable.
+  expect(page.getByRole('link', { name: OPEN_ACTION })).toHaveAttribute(
+    'href',
+    'http://preview.coursemology.org/courses/7/assessments/53',
+  );
+});
+
+// A deleted course takes its assessment with it, so both columns mark — each with its own reason.
+it('strikes out and unlinks a deleted source course', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        authoringAssessmentUrl: null,
+        sourceCourseId: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  expect(columnTexts(page, SOURCE_COLUMN)).toEqual([
+    `Intro to Programming ${DELETED_SUFFIX}`,
+  ]);
+  expect(
+    page.queryByRole('link', { name: SOURCE_COURSE_NAME }),
+  ).not.toBeInTheDocument();
+});
+
+// "Deleted" beside a live, serving listing reads as "broken" on its own, so each mark carries the
+// sentence that says otherwise — and the two reasons are different, so they are two sentences.
+it('explains on each mark what the deletion did and did not affect', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        authoringAssessmentUrl: null,
+        sourceCourseId: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByLabelText(ASSESSMENT_DELETED_HINT)).toHaveTextContent(
+    RECURSION_DRILL,
+  );
+  expect(page.getByLabelText(COURSE_DELETED_HINT)).toHaveTextContent(
+    SOURCE_COURSE_NAME,
+  );
+});
+
+// Deleting the origin no longer changes whether the listing is on the marketplace: the authoring copy
+// is rebuilt automatically, so the listing goes on serving and goes on saying so.
+it('keeps a listing published when its origin was deleted', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        marketplaceHosted: true,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText('Published')).toBeInTheDocument();
+  expect(page.queryByText('Orphaned')).not.toBeInTheDocument();
+});
+
+// "4 adoptions" raises "which courses?", and the listing page is the only place that answers it.
+it('links a non-zero adoption count to the listing page', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({ id: 42, adoptions: 4 }),
+      listingAt({ id: 43, title: ARRAYS_WARMUP, adoptions: 0 }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByRole('link', { name: '4' })).toHaveAttribute(
+    'href',
+    '/admin/marketplace_listings/42',
+  );
+
+  // Zero stays plain text — there is no adoption list to go and look at, and the id beside it is
+  // already the unconditional entrance to the same page.
+  expect(columnTexts(page, ADOPTIONS_COLUMN)).toEqual(['4', '0']);
+  expect(page.queryByRole('link', { name: '0' })).not.toBeInTheDocument();
+});
+
+// `Course` is tenanted by instance, so a course id resolves ONLY on its own instance's host — a
+// relative link 404s for every listing published from another instance.
+it('links the source course on its own instance host', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ sourceInstanceHost: 'satellite.coursemology.org' })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  const link = await page.findByRole('link', { name: SOURCE_COURSE_NAME });
+  expect(link).toHaveAttribute(
+    'href',
+    '//satellite.coursemology.org/courses/9/assessments',
+  );
+});
+
+// The exact column set, in order: the source course's teaching period was dropped from this table —
+// an admin auditing listings never asked "which term?", and the column cost width the actions needed.
+it('names the instance in its own column beside the source course', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  // Just "Instance" — adjacency to "Source course" carries whose instance it is.
+  expect(
+    page.getAllByRole('columnheader').map((header) => header.textContent),
+  ).toEqual([
+    'ID',
+    'Original assessment',
+    'Source course',
+    'Instance',
+    'Version',
+    'Adoptions',
+    'State',
+    'Actions',
+  ]);
+
+  expect(columnTexts(page, INSTANCE_COLUMN)).toEqual([MAIN_CAMPUS]);
+});
+
+// The instance is only reachable on its own host, so the cell goes there rather than to a route on
+// the admin's host that would resolve to the wrong deployment.
+it('links the instance to its own host', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceInstanceName: SATELLITE_CAMPUS,
+        sourceInstanceHost: 'satellite.coursemology.org',
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(
+    await page.findByRole('link', { name: SATELLITE_CAMPUS }),
+  ).toHaveAttribute('href', '//satellite.coursemology.org/');
+});
+
+// Deleting an instance nullifies both the source course and the source instance, leaving nothing on
+// the row that locates the origin — so the row says so rather than silently omitting it.
+it('renders the empty marker for a listing with no recorded instance', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        authoringAssessmentUrl: null,
+        sourceCourseId: null,
+        sourceCourseName: 'Retired Course',
+        sourceInstanceName: null,
+        sourceInstanceHost: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  // The denormalised course name survives the course deletion; the instance was never recorded, so
+  // the Instance column says so instead of leaving the origin blank. Neither is a link — there is
+  // nothing left to navigate to.
+  expect(columnTexts(page, SOURCE_COLUMN)).toEqual([
+    `Retired Course ${DELETED_SUFFIX}`,
+  ]);
+  expect(columnTexts(page, INSTANCE_COLUMN)).toEqual(['—']);
+  expect(
+    page.queryByRole('link', { name: 'Retired Course' }),
+  ).not.toBeInTheDocument();
+});
+
+// Not a disabled placeholder either: nothing in the Actions cell mentions opening a copy that does
+// not exist, so the cell holds only actions that can actually be taken.
+it('hides the open action entirely while a listing has no authoring copy', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        authoringAssessmentUrl: null,
+        sourceCourseId: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const [assessmentDeleted, courseDeleted] = page.getAllByRole('row').slice(1);
+
+  [assessmentDeleted, courseDeleted].forEach((row) => {
+    expect(within(row).queryByText(OPEN_ACTION)).not.toBeInTheDocument();
+    // The restore and delete actions are what remains — the cell is not simply empty.
+    expect(
+      within(row).getByRole('button', { name: RESTORE_ACTION }),
+    ).toBeInTheDocument();
+  });
+});
+
+it('narrows the listings to those matching the searched assessment title', async () => {
+  const user = userEvent.setup();
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt(), listingAt({ id: 2, title: ARRAYS_WARMUP })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  await user.type(page.getByPlaceholderText(SEARCH_PLACEHOLDER), 'Arrays');
+
+  await waitFor(() =>
+    expect(page.queryByText(RECURSION_DRILL)).not.toBeInTheDocument(),
+  );
+  expect(page.getByText(ARRAYS_WARMUP)).toBeInTheDocument();
+});
+
+// Search deliberately spans TWO columns and no more: title and source course. Source course is
+// searchable instead of filterable because courses number in the hundreds — "listings from CS1010" is
+// a text query, not a set selection. This test previously pinned search as title-ONLY; it now pins
+// the widened scope, and still fails if a stray `searchable: true` reaches a third column.
+it('searches assessment titles and source courses, not the other columns', async () => {
+  const user = userEvent.setup();
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceCourseName: 'Data Structures',
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const search = page.getByPlaceholderText(SEARCH_PLACEHOLDER);
+  const bothRows = [RECURSION_DRILL, ARRAYS_WARMUP];
+
+  // The source course of the second row only.
+  await user.type(search, 'Data Struct');
+
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual([ARRAYS_WARMUP]),
+  );
+
+  await user.clear(search);
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual(bothRows),
+  );
+
+  // The instance, which both rows carry: a two-value, low-cardinality dimension belongs behind the
+  // Instance column's FILTER, so putting it in the free-text box would invite typing "Main Campus"
+  // instead of filtering. Search must not match it even though the column is right beside the one it
+  // does match.
+  await user.type(search, MAIN_CAMPUS);
+
+  await waitFor(() => expect(columnTexts(page, TITLE_COLUMN)).toEqual([]));
+
+  await user.clear(search);
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual(bothRows),
+  );
+
+  // The served vintage, which both rows also carry: an unsearchable column must match neither.
+  await user.type(search, '24 Jul');
+
+  await waitFor(() => expect(columnTexts(page, TITLE_COLUMN)).toEqual([]));
+});
+
+it('sorts the listings by assessment title in both directions', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt(), listingAt({ id: 2, title: ARRAYS_WARMUP })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+  ]);
+
+  fireEvent.click(page.getByRole('button', { name: 'Original assessment' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+      ARRAYS_WARMUP,
+      RECURSION_DRILL,
+    ]),
+  );
+
+  fireEvent.click(page.getByRole('button', { name: 'Original assessment' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+      RECURSION_DRILL,
+      ARRAYS_WARMUP,
+    ]),
+  );
+});
+
+// Sorting groups the table by origin, which is the other half of what a per-course filter would have
+// given — without a menu that grows with the table.
+it('sorts the listings by source course in both directions', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({ sourceCourseName: SOURCE_COURSE_NAME }),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceCourseName: 'Data Structures',
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  fireEvent.click(page.getByRole('button', { name: 'Source course' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+      ARRAYS_WARMUP,
+      RECURSION_DRILL,
+    ]),
+  );
+
+  fireEvent.click(page.getByRole('button', { name: 'Source course' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+      RECURSION_DRILL,
+      ARRAYS_WARMUP,
+    ]),
+  );
+});
+
+// Sorting by instance comes free with the column, and groups the table by deployment.
+it('sorts the listings by instance in both directions', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceInstanceName: SATELLITE_CAMPUS,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  fireEvent.click(page.getByRole('button', { name: 'Instance' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, INSTANCE_COLUMN)).toEqual([
+      MAIN_CAMPUS,
+      SATELLITE_CAMPUS,
+    ]),
+  );
+
+  fireEvent.click(page.getByRole('button', { name: 'Instance' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, INSTANCE_COLUMN)).toEqual([
+      SATELLITE_CAMPUS,
+      MAIN_CAMPUS,
+    ]),
+  );
+});
+
+// A handful of instances, stable values, and the natural slice for an admin auditing one deployment's
+// contributions. The "not recorded" bucket is real, not an omission: it is where a listing lands once
+// the instance it was published from has been deleted.
+it('filters the listings by the source instance, including the unrecorded bucket', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceInstanceName: SATELLITE_CAMPUS,
+        sourceInstanceHost: 'satellite.coursemology.org',
+      }),
+      listingAt({
+        id: 3,
+        title: RETIRED_QUIZ,
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        authoringAssessmentUrl: null,
+        sourceCourseId: null,
+        sourceInstanceName: null,
+        sourceInstanceHost: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  await clickInstanceFilterItem(page, SATELLITE_CAMPUS);
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([ARRAYS_WARMUP]);
+
+  await clickInstanceFilterItem(page, 'Instance not recorded');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    ARRAYS_WARMUP,
+    `${RETIRED_QUIZ} ${DELETED_SUFFIX}`,
+  ]);
+
+  await clickInstanceFilterItem(page, 'Clear filter');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+    `${RETIRED_QUIZ} ${DELETED_SUFFIX}`,
+  ]);
+});
+
+// Two independent menus in two different header cells: filtering by instance must not disturb the
+// state filter, and neither may hijack the other's selection.
+it('keeps the state and source instance filters independent', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        state: 'unlisted',
+        sourceInstanceName: SATELLITE_CAMPUS,
+      }),
+      listingAt({ id: 3, title: RETIRED_QUIZ, state: 'unlisted' }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  await clickStateFilterItem(page, 'Unlisted');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    ARRAYS_WARMUP,
+    RETIRED_QUIZ,
+  ]);
+
+  await clickInstanceFilterItem(page, MAIN_CAMPUS);
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([RETIRED_QUIZ]);
+});
+
+it('sorts adoptions numerically rather than lexicographically', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({ id: 1, title: 'Nine Adopters', adoptions: 9 }),
+      listingAt({ id: 2, title: 'Twelve Adopters', adoptions: 12 }),
+      listingAt({ id: 3, title: 'Four Adopters', adoptions: 4 }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText('Nine Adopters')).toBeInTheDocument();
+
+  fireEvent.click(page.getByRole('button', { name: 'Adoptions' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, ADOPTIONS_COLUMN)).toEqual(['12', '9', '4']),
+  );
+
+  fireEvent.click(page.getByRole('button', { name: 'Adoptions' }));
+
+  await waitFor(() =>
+    expect(columnTexts(page, ADOPTIONS_COLUMN)).toEqual(['4', '9', '12']),
+  );
+});
+
+it('filters the listings by the states selected in the State column, and restores them all when the filter is cleared', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({ id: 2, title: ARRAYS_WARMUP, state: 'unlisted' }),
+      listingAt({
+        id: 3,
+        title: 'Legacy Quiz',
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  await clickStateFilterItem(page, 'Unlisted');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([ARRAYS_WARMUP]);
+
+  await clickStateFilterItem(page, 'Published');
+
+  // Both states selected is every row — including the one whose origin was deleted, which is
+  // published like any other.
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+    `Legacy Quiz ${DELETED_SUFFIX}`,
+  ]);
+
+  await clickStateFilterItem(page, 'Clear filter');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+    `Legacy Quiz ${DELETED_SUFFIX}`,
+  ]);
+});
+
+// The State column answers marketplace visibility and nothing else, so a deleted origin leaves no
+// mark on it at all — the two Source columns carry that, and only they do.
+it('tells the two deletion cases apart in the Source columns, not the State column', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        marketplaceHosted: true,
+      }),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        marketplaceHosted: true,
+        sourceCourseId: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const [assessmentDeleted, courseDeleted] = page.getAllByRole('row').slice(1);
+
+  // Both mark their assessment; only the second also lost its course.
+  expect(
+    within(assessmentDeleted).getByLabelText(ASSESSMENT_DELETED_HINT),
+  ).toBeInTheDocument();
+  expect(
+    within(assessmentDeleted).queryByLabelText(COURSE_DELETED_HINT),
+  ).not.toBeInTheDocument();
+  expect(
+    within(courseDeleted).getByLabelText(COURSE_DELETED_HINT),
+  ).toBeInTheDocument();
+
+  // Both keep a healthy listing's state chip and neither is marked broken: the rebuild happened, so
+  // the only extra marker either carries says WHERE its copy now lives.
+  [assessmentDeleted, courseDeleted].forEach((row) => {
+    const state = within(row).getAllByRole('cell')[STATE_COLUMN];
+    expect(within(state).getByText('Published')).toBeInTheDocument();
+    expect(within(state).queryByText(ORPHANED)).not.toBeInTheDocument();
+  });
+});
+
+// The State column used to carry the whole "Orphaned — assessment deleted" phrase in one chip, which
+// made it greedy enough to squeeze Actions to ~90px and wrap every label onto three lines. Actions now
+// sit on ONE row and each label is unbreakable, so a row's height never depends on its action count.
+it('keeps every action label on one line in a single row', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  const openLink = await page.findByRole('link', { name: OPEN_ACTION });
+  expect(openLink).toHaveClass('whitespace-nowrap');
+
+  const restoreButton = page.getByRole('button', { name: RESTORE_ACTION });
+  expect(restoreButton).toHaveClass('whitespace-nowrap');
+
+  [openLink, restoreButton].forEach((action) => {
+    const row = action.closest('div');
+    expect(row).toHaveClass('flex');
+    expect(row).not.toHaveClass('flex-wrap');
+  });
+
+  // Fixed slot order — list/unlist, then restore, then delete — so no action moves between rows.
+  // Scoped to this row: every row carries the visibility and delete actions now, published included.
+  const row = restoreButton.closest('tr')!;
+  const actions = Array.from(restoreButton.parentElement!.children);
+  expect(actions[0]).toHaveTextContent('Unlist');
+  expect(actions[1]).toBe(restoreButton);
+  expect(actions[2]).toContainElement(
+    within(row).getByTestId('DeleteIconButton'),
+  );
+});
+
+// The reversible half of the maintenance pair. It is admin-side and keyed on the listing id, because
+// the course-side unlist resolves the listing through its authoring assessment — which a listing
+// whose source was deleted no longer has, so that path cannot reach exactly the rows that need it.
+it('unlists a published listing and refetches', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+  mock.onPatch(`${INDEX_URL}/1`).reply(200);
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: 'Unlist' }));
+
+  const dialog = await page.findByRole('dialog');
+  expect(
+    within(dialog).getByText(/stops appearing in the marketplace/),
+  ).toBeVisible();
+  // Unlisting is what has to happen before a deletion, so the dialog says so.
+  expect(within(dialog).getByText(/reversible/)).toBeVisible();
+
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Unlist' }));
+
+  await waitFor(() => expect(mock.history.patch).toHaveLength(1));
+  expect(JSON.parse(mock.history.patch[0].data)).toEqual({ published: false });
+  // The row's state changes server-side, and with it whether the row can be deleted at all.
+  await waitFor(() => expect(indexFetchCount()).toBe(2));
+});
+
+it('lists an unlisted listing again', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ state: 'unlisted' })],
+  });
+  mock.onPatch(`${INDEX_URL}/1`).reply(200);
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: 'List' }));
+
+  const dialog = await page.findByRole('dialog');
+  // Re-listing serves the version already held — it must never read as publishing a new one.
+  expect(
+    within(dialog).getByText(/serving the version it already holds/),
+  ).toBeVisible();
+
+  fireEvent.click(within(dialog).getByRole('button', { name: 'List' }));
+
+  await waitFor(() => expect(mock.history.patch).toHaveLength(1));
+  expect(JSON.parse(mock.history.patch[0].data)).toEqual({ published: true });
+});
+
+// One button, flipping with the state it reads: offering both at once would leave one permanently
+// inert, and a listing is either on the marketplace or it is not.
+it('offers only the opposite action on each row', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({ id: 2, title: ARRAYS_WARMUP, state: 'unlisted' }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const [published, unlisted] = page.getAllByRole('row').slice(1);
+
+  expect(
+    within(published).getByRole('button', { name: 'Unlist' }),
+  ).toBeInTheDocument();
+  expect(
+    within(published).queryByRole('button', { name: 'List' }),
+  ).not.toBeInTheDocument();
+  expect(
+    within(unlisted).getByRole('button', { name: 'List' }),
+  ).toBeInTheDocument();
+});
+
+it('surfaces the server’s reason when it refuses to list', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({ state: 'unlisted', currentVersionPublishedAt: null }),
+    ],
+  });
+  mock.onPatch(`${INDEX_URL}/1`).reply(422, {
+    errors: ['This listing has no published version to serve.'],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: 'List' }));
+  fireEvent.click(
+    within(await page.findByRole('dialog')).getByRole('button', {
+      name: 'List',
+    }),
+  );
+
+  await waitFor(() =>
+    expect(toast.error).toHaveBeenCalledWith(
+      'This listing has no published version to serve.',
+    ),
+  );
+});
+
+// Deletion follows `Listing#purgeable?`: enabled wherever the listing is off the marketplace —
+// orphaned or unlisted — and never on a published one, which must be unlisted first. The button is
+// on every row either way, so its tooltip can state that rule. Adoption count gates nothing, so
+// every purgeable row's delete action is enabled regardless of how many courses adopted it.
+it('offers permanent deletion off the marketplace only, regardless of adoption history', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 4,
+      }),
+      listingAt({
+        id: 3,
+        title: RETIRED_QUIZ,
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+      // Unlisted keeps its source assessment, so unlike the orphans it still carries an open action.
+      listingAt({
+        id: 4,
+        title: 'Unlisted Quiz',
+        state: 'unlisted',
+        adoptions: 0,
+      }),
+      listingAt({
+        id: 5,
+        title: 'Unlisted And Adopted',
+        state: 'unlisted',
+        adoptions: 2,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const [published, adopted, unadopted, unlisted, unlistedAdopted] = page
+    .getAllByRole('row')
+    .slice(1);
+
+  // A published listing is unlisted, never deleted — so the icon is present but inert, and says why
+  // on hover rather than leaving the admin to guess at a control that simply is not there.
+  expect(within(published).getByTestId('DeleteIconButton')).toBeDisabled();
+  expect(
+    within(published).getByLabelText(DELETE_BLOCKED_TOOLTIP),
+  ).toBeInTheDocument();
+
+  [adopted, unadopted, unlisted, unlistedAdopted].forEach((row) => {
+    expect(within(row).getByTestId('DeleteIconButton')).toBeEnabled();
+    expect(
+      within(row).getByLabelText('Delete permanently'),
+    ).toBeInTheDocument();
+  });
+});
+
+// A disabled MUI IconButton swallows pointer events, so the tooltip only fires because DeleteButton
+// wraps it in a `span` — and the whole point of keeping the icon is that hovering it explains the
+// rule. Clicking must still do nothing: no confirm dialog, no request.
+it('opens no confirm dialog from the disabled delete on a published listing', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+
+  expect(page.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(mock.history.delete).toHaveLength(0);
+});
+
+// Adoption count is decision-relevant even though it no longer disables anything: a deliberate
+// deletion needs the facts at the moment of deciding, so the confirm dialog states how many courses
+// adopted the listing and that their copies are unaffected — layered on top of whichever of the
+// orphaned/unlisted messages applies, not replacing it.
+it('warns in the confirm dialog how many courses adopted the listing, layered on the base message', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 3,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+
+  const dialog = await page.findByRole('dialog');
+  // The base orphaned message is still present …
+  expect(
+    within(dialog).getByText(/all of its versions and the snapshots/),
+  ).toBeVisible();
+  // … with the adoption warning layered on top, not swapped in for it.
+  expect(
+    within(dialog).getByText(
+      /3 courses have adopted this listing\. Their existing copies will not be affected, but the adoption history will be destroyed\./,
+    ),
+  ).toBeVisible();
+});
+
+it('does not show an adoption warning in the confirm dialog when nothing adopted the listing', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ state: 'unlisted', adoptions: 0 })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+
+  const dialog = await page.findByRole('dialog');
+  expect(
+    within(dialog).queryByText(/adopted this listing/),
+  ).not.toBeInTheDocument();
+});
+
+// The two cases destroy different things, so they cannot share one warning: an orphan has already
+// lost its source, whereas an unlisted listing keeps it — and telling someone to unlist a listing
+// that is already unlisted is no advice at all.
+it('warns that an unlisted deletion spares the source assessment', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ state: 'unlisted', adoptions: 0 })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+
+  const dialog = await page.findByRole('dialog');
+  expect(
+    within(dialog).getByText(/all of its versions and the snapshots/),
+  ).toBeVisible();
+  expect(
+    within(dialog).getByText(
+      /source assessment is not affected and can be published again/,
+    ),
+  ).toBeVisible();
+  expect(
+    within(dialog).queryByText(/unlist it instead/),
+  ).not.toBeInTheDocument();
+});
+
+it('warns what a permanent deletion destroys, then deletes and refetches', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+  mock.onDelete(`${INDEX_URL}/1`).reply(200);
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+
+  const dialog = await page.findByRole('dialog');
+  expect(
+    within(dialog).getByText(/all of its versions and the snapshots/),
+  ).toBeVisible();
+  expect(within(dialog).getByText(/cannot be undone/)).toBeVisible();
+
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+  await waitFor(() => expect(mock.history.delete).toHaveLength(1));
+  expect(mock.history.delete[0].url).toBe(`${INDEX_URL}/1`);
+  // The row is gone only because the list refetched — the client never patches it locally.
+  await waitFor(() => expect(indexFetchCount()).toBe(2));
+});
+
+it('surfaces the server’s reason when it refuses a permanent deletion', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+  mock.onDelete(`${INDEX_URL}/1`).reply(422, {
+    errors: ['This listing has been adopted by other courses.'],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+  fireEvent.click(
+    within(await page.findByRole('dialog')).getByRole('button', {
+      name: 'Delete',
+    }),
+  );
+
+  await waitFor(() =>
+    expect(toast.error).toHaveBeenCalledWith(
+      'This listing has been adopted by other courses.',
+    ),
+  );
+});
+
+// There is no destination to choose: the copy always lands in the marketplace's own container, so
+// the dialog is a plain confirm.
+it('restores without asking for a destination course', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+  mock
+    .onPost(`${INDEX_URL}/1/restore_authoring`)
+    .reply(200, { status: 'submitted', jobUrl: UNWATCHED_JOB_URL });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: RESTORE_ACTION }));
+
+  const dialog = await page.findByRole('dialog');
+  expect(within(dialog).queryByRole('combobox')).not.toBeInTheDocument();
+
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Rebuild' }));
+
+  await waitFor(() => expect(mock.history.post).toHaveLength(1));
+  // No destination is sent at all — the server owns the only correct destination.
+  expect(mock.history.post[0].data).toBeUndefined();
+});
+
+it('tells the admin the copy lands in the marketplace container', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        sourceCourseDeleted: true,
+        authoringAssessmentUrl: null,
+        sourceCourseId: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: RESTORE_ACTION }));
+
+  const dialog = await page.findByRole('dialog');
+  expect(
+    within(dialog).getByText(/marketplace's own container course/),
+  ).toBeVisible();
+  // The picker is gone for BOTH orphan states — a deleted origin course no longer changes anything.
+  expect(within(dialog).queryByRole('combobox')).not.toBeInTheDocument();
+});
+
+it('toasts a link to the restored assessment and refetches once the job completes', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+  mock
+    .onPost(`${INDEX_URL}/1/restore_authoring`)
+    .reply(200, { status: 'submitted', jobUrl: COMPLETED_JOB_URL });
+  jobsMock
+    .onGet(COMPLETED_JOB_URL)
+    .reply(200, { status: 'completed', redirectUrl: RESTORED_URL });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: RESTORE_ACTION }));
+  fireEvent.click(
+    within(await page.findByRole('dialog')).getByRole('button', {
+      name: 'Rebuild',
+    }),
+  );
+
+  // pollJob polls every 2s — longer than waitFor's 1s default.
+  await waitFor(() => expect(toast.success).toHaveBeenCalled(), {
+    timeout: 6000,
+  });
+
+  const message = (toast.success as unknown as jest.Mock).mock.calls[0][0];
+  const toasted = render(<div>{message}</div>);
+
+  expect(
+    await toasted.findByText(
+      /Source assessment rebuilt in the marketplace container\./,
+    ),
+  ).toBeInTheDocument();
+  expect(
+    toasted.getByRole('link', { name: 'View assessment' }),
+  ).toHaveAttribute('href', RESTORED_URL);
+
+  // The listing's state and authoring url both change server-side, so the list must refetch.
+  await waitFor(() => expect(indexFetchCount()).toBe(2));
+}, 10000);
+
+it('reports a failed restore job without claiming success', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+  mock
+    .onPost(`${INDEX_URL}/1/restore_authoring`)
+    .reply(200, { status: 'submitted', jobUrl: ERRORED_JOB_URL });
+  jobsMock.onGet(ERRORED_JOB_URL).reply(200, { status: 'errored' });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByRole('button', { name: RESTORE_ACTION }));
+  fireEvent.click(
+    within(await page.findByRole('dialog')).getByRole('button', {
+      name: 'Rebuild',
+    }),
+  );
+
+  await waitFor(() => expect(toast.error).toHaveBeenCalled(), {
+    timeout: 6000,
+  });
+
+  expect(toast.error).toHaveBeenCalledWith(
+    'Could not rebuild the source assessment.',
+  );
+  expect(toast.success).not.toHaveBeenCalled();
+}, 10000);
+
+it('offers no restore for an orphan with no version to restore from', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        currentVersionPublishedAt: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  // Deletion is still on offer — it is the version, not the orphan state, that restore needs.
+  expect(await page.findByTestId('DeleteIconButton')).toBeInTheDocument();
+  expect(
+    page.queryByRole('button', { name: RESTORE_ACTION }),
+  ).not.toBeInTheDocument();
+});
+
+// A rebuilt listing keeps naming its ORIGIN course in the Source course column — that provenance is a
+// historical fact the rebuild deliberately leaves alone — so without this marker its row is
+// indistinguishable from a listing whose source assessment really is still in that course.
+it('marks a marketplace-hosted listing apart from one with its own source course', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        marketplaceHosted: true,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const [ownSource, hosted] = page.getAllByRole('row').slice(1);
+
+  // Both are on the marketplace, so both keep the same state chip: the marker is what separates them.
+  expect(within(ownSource).getByText('Published')).toBeInTheDocument();
+  expect(within(hosted).getByText('Published')).toBeInTheDocument();
+
+  expect(within(hosted).getByText(MARKETPLACE_HOSTED)).toBeInTheDocument();
+  expect(
+    within(ownSource).queryByText(MARKETPLACE_HOSTED),
+  ).not.toBeInTheDocument();
+});
+
+it('explains on the marker what marketplace-hosted means', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ marketplaceHosted: true })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByLabelText(MARKETPLACE_HOSTED_HINT)).toHaveTextContent(
+    MARKETPLACE_HOSTED,
+  );
+});
+
+// Visibility and authoring location are independent axes, and the marker is a facet rather than a
+// state value precisely so this holds: a marketplace-hosted listing that is later unlisted still
+// reports both facts, and each is separately filterable.
+it('keeps the state chip when a marketplace-hosted listing is unlisted', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ state: 'unlisted', marketplaceHosted: true })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText('Unlisted')).toBeInTheDocument();
+  expect(page.getByText(MARKETPLACE_HOSTED)).toBeInTheDocument();
+});
+
+it('filters on the marketplace-hosted facet independently of the state values', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({ id: 2, title: ARRAYS_WARMUP, marketplaceHosted: true }),
+      listingAt({
+        id: 3,
+        title: RETIRED_QUIZ,
+        state: 'unlisted',
+        marketplaceHosted: true,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  // Cuts across published and unlisted alike — which is the point of asking for it as its own facet.
+  await clickStateFilterItem(page, MARKETPLACE_HOSTED);
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    ARRAYS_WARMUP,
+    RETIRED_QUIZ,
+  ]);
+
+  await clickStateFilterItem(page, MARKETPLACE_HOSTED);
+  await clickStateFilterItem(page, 'Unlisted');
+
+  // The state values still filter on state alone: the hosted published row is excluded here.
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([RETIRED_QUIZ]);
+
+  await clickStateFilterItem(page, 'Clear filter');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+    RETIRED_QUIZ,
+  ]);
+});
+
+// The complement, which is the half an admin auditing who-owns-what actually needs: "which listings
+// still depend on course staff". Labelled as a negation and NOT chipped on the rows — it is the
+// ordinary state of the world, and a second noun beside Published/Unlisted would read as a state.
+it('filters on the negation of the marketplace-hosted facet', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({ id: 2, title: ARRAYS_WARMUP, marketplaceHosted: true }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  // Only the exception is marked on the row; the ordinary case carries no chip of its own.
+  expect(page.getAllByText(MARKETPLACE_HOSTED)).toHaveLength(1);
+
+  await clickStateFilterItem(page, 'Not marketplace-hosted');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([RECURSION_DRILL]);
+
+  await clickStateFilterItem(page, MARKETPLACE_HOSTED);
+
+  // Both halves selected is every row — the pair is exhaustive.
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+  ]);
+});
+
+// An orphan is no longer a state the system produces: deleting a source assessment re-points the
+// listing inside the same transaction. One reaching the table therefore means the model layer was
+// bypassed, so it is chipped in the alarm colour rather than left to be inferred from a missing link.
+it('marks an orphaned listing apart from a healthy one', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const [healthy, orphaned] = page.getAllByRole('row').slice(1);
+
+  expect(within(orphaned).getByText(ORPHANED)).toBeInTheDocument();
+  expect(within(healthy).queryByText(ORPHANED)).not.toBeInTheDocument();
+  // Visibility is a separate axis: an orphan goes on serving its last version, so its state chip is
+  // untouched and the marker sits beside it.
+  expect(within(orphaned).getByText('Published')).toBeInTheDocument();
+});
+
+// The marker names a fault, so it has to carry what to do about it — a chip reading "Orphaned" beside
+// a Published listing otherwise leaves an admin with no idea whether to act or which action to take.
+it('explains on the orphan marker that it should not happen, and what to do', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ authoringAssessmentUrl: null })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByLabelText(ORPHANED_HINT)).toHaveTextContent(ORPHANED);
+});
+
+// The debugging affordance the chip exists for: "show me everything that is broken", answerable in
+// one click on a table an admin arrives at with hundreds of healthy rows.
+it('filters on the orphaned facet, cutting across the state values', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [
+      listingAt(),
+      listingAt({
+        id: 2,
+        title: ARRAYS_WARMUP,
+        authoringAssessmentUrl: null,
+      }),
+      listingAt({
+        id: 3,
+        title: RETIRED_QUIZ,
+        state: 'unlisted',
+        authoringAssessmentUrl: null,
+      }),
+    ],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  await clickStateFilterItem(page, ORPHANED);
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    ARRAYS_WARMUP,
+    RETIRED_QUIZ,
+  ]);
+
+  await clickStateFilterItem(page, 'Clear filter');
+
+  expect(columnTexts(page, TITLE_COLUMN)).toEqual([
+    RECURSION_DRILL,
+    ARRAYS_WARMUP,
+    RETIRED_QUIZ,
+  ]);
+});
+
+// Offered only when there is something to look at, unlike the marketplace-hosted pair: a filter value
+// that matches nothing on a healthy deployment would advertise a fault state as ordinary, and the
+// menu it shares is the one an admin uses for the routine published/unlisted split.
+it('offers no orphaned filter value when nothing is orphaned', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt()] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+
+  const header = page.getAllByRole('columnheader')[STATE_COLUMN];
+  fireEvent.click(within(header).getByRole('button', { name: 'Filter' }));
+
+  expect(
+    await page.findByRole('menuitem', { name: 'Published' }),
+  ).toBeInTheDocument();
+  expect(
+    page.queryByRole('menuitem', { name: ORPHANED }),
+  ).not.toBeInTheDocument();
+
+  await userEvent.keyboard('{Escape}');
+});
+
+it('shows the empty state when there are no listings', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(
+    await page.findByText('No assessments have been published yet.'),
+  ).toBeInTheDocument();
+});
+
+// The empty state is a claim about the marketplace ("nothing has been published"), not about the
+// request. A failed fetch also leaves the list empty, so rendering the table there would make the
+// page assert something it does not know. The failure is reported in the table's place.
+it('reports the failure instead of the empty state when the listings cannot be loaded', async () => {
+  mock.onGet(INDEX_URL).reply(500);
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(
+    await page.findByText('Failed to load marketplace listings.'),
+  ).toBeInTheDocument();
+  expect(
+    page.queryByText('No assessments have been published yet.'),
+  ).not.toBeInTheDocument();
+});
+
+// A refetch failure is the same unknown as a first-load failure: the rows on screen predate the
+// mutation that just succeeded, so presenting them as current would be a lie about live state.
+it('stops presenting stale rows once a refetch fails', async () => {
+  mock.onGet(INDEX_URL).replyOnce(200, {
+    listings: [
+      listingAt({
+        sourceAssessmentDeleted: true,
+        authoringAssessmentUrl: null,
+        adoptions: 0,
+      }),
+    ],
+  });
+  mock.onDelete(`${INDEX_URL}/1`).reply(200);
+  mock.onGet(INDEX_URL).reply(500);
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  fireEvent.click(await page.findByTestId('DeleteIconButton'));
+  fireEvent.click(
+    within(await page.findByRole('dialog')).getByRole('button', {
+      name: 'Delete',
+    }),
+  );
+
+  expect(
+    await page.findByText('Failed to load marketplace listings.'),
+  ).toBeInTheDocument();
+  expect(page.queryByText(RECURSION_DRILL)).not.toBeInTheDocument();
+});
+
+// The id is a primary key, not a position: deleting a listing renumbers nothing. It is surfaced
+// because it is the only thing that separates two listings sharing a title and a source course,
+// and because the container's version chips name listings by it.
+it('shows each listing id', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt({ id: 42 })] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByText(RECURSION_DRILL)).toBeInTheDocument();
+  expect(columnTexts(page, ID_COLUMN)).toEqual(['42']);
+});
+
+it('links the id to the listing history page', async () => {
+  mock.onGet(INDEX_URL).reply(200, { listings: [listingAt({ id: 42 })] });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByRole('link', { name: '42' })).toHaveAttribute(
+    'href',
+    '/admin/marketplace_listings/42',
+  );
+});
+
+// The Version cell is only a link when a version exists, so before this column a listing that had
+// never published one had NO route to its own history page from anywhere in the application.
+it('links the id even when the listing has never published a version', async () => {
+  mock.onGet(INDEX_URL).reply(200, {
+    listings: [listingAt({ id: 42, currentVersionPublishedAt: null })],
+  });
+
+  const page = render(<MarketplaceListingsIndex />, { at: [INDEX_URL] });
+
+  expect(await page.findByRole('link', { name: '42' })).toHaveAttribute(
+    'href',
+    '/admin/marketplace_listings/42',
+  );
+  expect(columnTexts(page, VERSION_COLUMN)).toEqual(['—']);
+});

--- a/client/app/routers/courseless/systemAdmin.tsx
+++ b/client/app/routers/courseless/systemAdmin.tsx
@@ -79,6 +79,28 @@ const systemAdminRouter: Translated<RouteObject> = (_) => ({
       }),
     },
     {
+      path: 'marketplace_listings',
+      lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
+        Component: (
+          await import(
+            /* webpackChunkName: 'MarketplaceListingsIndex' */
+            'bundles/system/admin/admin/pages/MarketplaceListingsIndex'
+          )
+        ).default,
+      }),
+    },
+    {
+      path: 'marketplace_listings/:listingId',
+      lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
+        Component: (
+          await import(
+            /* webpackChunkName: 'MarketplaceListingShow' */
+            'bundles/system/admin/admin/pages/MarketplaceListingShow'
+          )
+        ).default,
+      }),
+    },
+    {
       path: 'get_help',
       lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => ({
         Component: (

--- a/client/app/types/system/courses.ts
+++ b/client/app/types/system/courses.ts
@@ -8,6 +8,7 @@ export interface CourseListData {
   createdAt: string;
   activeUserCount: number;
   userCount: number;
+  preview: boolean;
   instance: InstanceMiniEntity;
   owners: UserBasicMiniEntity[];
 }

--- a/client/app/types/system/marketplaceListings.ts
+++ b/client/app/types/system/marketplaceListings.ts
@@ -1,0 +1,90 @@
+/**
+ * Marketplace VISIBILITY, and nothing else. The origin's fate is reported by `sourceAssessmentDeleted`
+ * / `sourceCourseDeleted` instead of by an `orphaned` state value, because the two cross: a listing
+ * whose source assessment was deleted is rebuilt into the marketplace container and goes on being
+ * published, so one enum cannot carry both facts.
+ */
+export type MarketplaceListingState = 'published' | 'unlisted';
+
+export interface MarketplaceListingAdminData {
+  id: number;
+  title: string | null;
+  currentVersionPublishedAt: string | null;
+  lastPublishedAt: string | null;
+  adoptions: number;
+  sourceCourseId: number | null;
+  sourceCourseName: string | null;
+  /**
+   * The instance the source course belonged to. Publishing always records it, so it is null only
+   * once that instance has been deleted — after which nothing on the row locates the origin.
+   */
+  sourceInstanceName: string | null;
+  /** The origin instance's host: a course id only resolves there, never on the admin's own host. */
+  sourceInstanceHost: string | null;
+  state: MarketplaceListingState;
+  /**
+   * Whether the authoring copy lives in the marketplace's own container course rather than in a
+   * course somebody owns — true after a rebuild, and for anything authored in the container
+   * directly. Separate from state, which reports whether the listing is listed or unlisted.
+   */
+  marketplaceHosted: boolean;
+  /**
+   * Whether the assessment this listing was published FROM has been deleted. Outlives the repair:
+   * the authoring copy is rebuilt in the container, so this stays true while `state` reads
+   * `published` — which is why it cannot be a state value.
+   */
+  sourceAssessmentDeleted: boolean;
+  /** Whether the origin course has been deleted. Its denormalised name survives it. */
+  sourceCourseDeleted: boolean;
+  authoringAssessmentUrl: string | null;
+}
+
+export interface MarketplaceListingVersionData {
+  /**
+   * When this version's CONTENT was published, not when anyone copied it. This IS the version's
+   * identity — there is no ordinal.
+   */
+  publishedAt: string | null;
+  publisherName: string | null;
+  isCurrent: boolean;
+  /**
+   * Absolute URL into the container course on the preview instance. Null when the snapshot no
+   * longer resolves — a version row without a link rather than a broken one.
+   */
+  snapshotUrl: string | null;
+}
+
+export interface MarketplaceListingAdoptionData {
+  id: number;
+  destinationCourseId: number | null;
+  destinationCourseName: string | null;
+  /** Adopters span instances, and a course id only resolves on its own instance's host. */
+  destinationCourseHost: string | null;
+  adoptedVersionAt: string | null;
+  adoptedAt: string | null;
+  /** The snapshot of the version this course holds, so an admin can inspect what it actually got. */
+  snapshotUrl: string | null;
+}
+
+/** Provenance, full version history and every adoption for one listing. Read-only. */
+export interface MarketplaceListingDetailData {
+  id: number;
+  title: string | null;
+  currentVersionPublishedAt: string | null;
+  state: MarketplaceListingState;
+  /** See `MarketplaceListingAdminData.marketplaceHosted`. */
+  marketplaceHosted: boolean;
+  /** See `MarketplaceListingAdminData.sourceAssessmentDeleted`. */
+  sourceAssessmentDeleted: boolean;
+  /** See `MarketplaceListingAdminData.sourceCourseDeleted`. */
+  sourceCourseDeleted: boolean;
+  /** Absolute url of the copy an admin would edit, or null while the listing has none. */
+  authoringAssessmentUrl: string | null;
+  sourceCourseId: number | null;
+  sourceCourseName: string | null;
+  sourceInstanceName: string | null;
+  sourceInstanceHost: string | null;
+  /** Ascending by publish date. Empty for a listing that has never been published. */
+  versions: MarketplaceListingVersionData[];
+  adoptions: MarketplaceListingAdoptionData[];
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,9 @@ Rails.application.routes.draw do
       end
       get 'marketplace_access' => 'marketplace_access#index'
       resources :marketplace_access_blocks, only: [:create, :destroy]
+      resources :marketplace_listings, only: [:index, :show, :update, :destroy] do
+        post :restore_authoring, on: :member
+      end
       resources :instances, only: [:index, :create, :update, :destroy]
       resources :users, only: [:index, :update, :destroy]
       resources :courses, only: [:index, :destroy]

--- a/spec/controllers/system/admin/courses_controller_spec.rb
+++ b/spec/controllers/system/admin/courses_controller_spec.rb
@@ -31,6 +31,36 @@ RSpec.describe System::Admin::CoursesController, type: :controller do
       end
     end
 
+    # The hidden marketplace preview container is a `preview: true` course and the system-admin index
+    # is cross-instance, so it appears here like any other course. Course pickers key off this flag to
+    # leave it out of their options (never off a host or instance id), so the payload must carry it.
+    describe '#index payload' do
+      render_views
+
+      let!(:container) do
+        ActsAsTenant.without_tenant do
+          Course::Assessment::Marketplace::PreviewContainerService.container_course
+        end
+      end
+      let!(:ordinary_course) { create(:course) }
+
+      before { controller_sign_in(controller, admin) }
+
+      def row_for(course)
+        response.parsed_body['courses'].find { |c| c['id'] == course.id }
+      end
+
+      it 'flags the preview container and only the preview container' do
+        get :index, as: :json, params: { search: container.title }
+
+        expect(row_for(container)['preview']).to be(true)
+
+        get :index, as: :json, params: { search: ordinary_course.title }
+
+        expect(row_for(ordinary_course)['preview']).to be(false)
+      end
+    end
+
     describe '#destroy' do
       let!(:course_to_delete) { create(:course) }
       let!(:course_stub) do

--- a/spec/controllers/system/admin/marketplace_listings_controller_spec.rb
+++ b/spec/controllers/system/admin/marketplace_listings_controller_spec.rb
@@ -1,0 +1,697 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe System::Admin::MarketplaceListingsController, type: :controller do
+  render_views
+
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, course: course) }
+    let(:admin) { create(:administrator) }
+
+    # The real container, never `create(:course, preview: true)`: at most one preview course may exist
+    # per instance (`index_courses_on_instance_id_one_preview`), and these examples run in
+    # `Instance.default` — so a spec minting its own would commit it (specs are not transactional) and
+    # every later run would collide with the row the last one left behind.
+    def container_course
+      ActsAsTenant.without_tenant do
+        Course::Assessment::Marketplace::PreviewContainerService.container_course
+      end
+    end
+
+    # @return [Course::Assessment] an assessment authored directly in the container course
+    def assessment_in_container
+      container = container_course
+      ActsAsTenant.with_tenant(container.instance) { create(:assessment, course: container) }
+    end
+
+    # The only way a listing is orphaned now that `Course::Assessment` re-points inside the destroy
+    # transaction: the column is nulled underneath the model layer, as
+    # `fk_caml_authoring_assessment_id` does when a delete bypasses the callback.
+    def orphan!(listing)
+      listing.update_column(:authoring_assessment_id, nil)
+      listing.reload
+    end
+
+    describe 'GET #index' do
+      subject { get :index, format: :json }
+
+      before { controller_sign_in(controller, admin) }
+
+      def row_for(listing)
+        response.parsed_body['listings'].find { |l| l['id'] == listing.id }
+      end
+
+      it 'lists a published listing with its published vintage, provenance and adoption count' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        create(:course_assessment_marketplace_adoption, listing: listing)
+
+        subject
+
+        row = row_for(listing)
+        expect(row).to have_key('currentVersionPublishedAt')
+        expect(row).not_to have_key('currentVersion')
+        expect(Time.zone.parse(row['currentVersionPublishedAt'])).
+          to be_within(1.second).of(listing.current_version.published_at)
+        expect(row['adoptions']).to eq(1)
+        expect(row['sourceCourseName']).to eq(course.title)
+        expect(row['state']).to eq('published')
+      end
+
+      it 'carries the source instance, so two same-named courses can be told apart' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+
+        subject
+
+        row = row_for(listing)
+        expect(row['sourceInstanceName']).to eq(instance.name)
+        expect(row['sourceInstanceHost']).to eq(instance.host)
+      end
+
+      # The marketplace is cross-instance while `Course` is `acts_as_tenant :instance`, so a course id
+      # resolves ONLY on its own instance's host. A path (or the admin's own host) 404s for every
+      # listing published from elsewhere, which is why the url is absolute and carries that host.
+      context 'when the source course lives in another instance' do
+        let(:other_instance) { create(:instance) }
+        let(:other_course) { ActsAsTenant.with_tenant(other_instance) { create(:course) } }
+        let(:other_assessment) do
+          ActsAsTenant.with_tenant(other_instance) { create(:assessment, course: other_course) }
+        end
+
+        it 'builds the authoring url on that instance host' do
+          listing = Course::Assessment::Marketplace::PublishService.publish(other_assessment, admin)
+
+          subject
+
+          # Asserted as prefix + suffix rather than one literal: the test env's
+          # `default_url_options` injects a port that production does not have.
+          url = row_for(listing)['authoringAssessmentUrl']
+          expect(url).to start_with("http://#{other_instance.host}")
+          expect(url).
+            to end_with("/courses/#{other_course.id}/assessments/#{other_assessment.id}")
+        end
+
+        it 'reports that instance as the source, not the admin’s own' do
+          listing = Course::Assessment::Marketplace::PublishService.publish(other_assessment, admin)
+
+          subject
+
+          row = row_for(listing)
+          expect(row['sourceInstanceName']).to eq(other_instance.name)
+          expect(row['sourceInstanceHost']).to eq(other_instance.host)
+          expect(row['sourceInstanceHost']).not_to eq(instance.host)
+        end
+      end
+
+      # `Instance#host` carries the port the app is publicly served on, which is not the port the
+      # request reached Rails on whenever a proxy sits in front — i.e. every development setup. A
+      # controller's `url_options` always supplies `port: request.optional_port`, and Rails reads a
+      # port out of `host:` only when no `:port` key is present, so the request's port silently won.
+      #
+      # Reproduced by moving the request off the instance's port, which is what the proxy does.
+      it 'keeps the port carried by the instance host, not the one the request arrived on' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        request.host = 'localhost:3999'
+
+        subject
+
+        expect(row_for(listing)['authoringAssessmentUrl']).to start_with("http://#{instance.host}/")
+      end
+
+      it 'reports no instance for a listing orphaned before the instance was ever recorded' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        listing.update_columns(authoring_assessment_id: nil, source_course_id: nil,
+                               source_instance_id: nil)
+
+        subject
+
+        row = row_for(listing)
+        expect(row['sourceInstanceName']).to be_nil
+        expect(row['sourceInstanceHost']).to be_nil
+      end
+
+      it 'serves the snapshot title, not the authoring title' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        assessment.update!(title: 'Renamed after publish')
+
+        subject
+
+        expect(row_for(listing)['title']).not_to eq('Renamed after publish')
+      end
+
+      it 'flags an unlisted listing' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        listing.update!(published: false)
+
+        subject
+
+        expect(row_for(listing)['state']).to eq('unlisted')
+      end
+
+      it 'flags a listing orphaned by an assessment deletion and offers no authoring url' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        listing.update!(authoring_assessment: nil)
+
+        subject
+
+        row = row_for(listing)
+        expect(row['state']).to eq('published')
+        expect(row['sourceAssessmentDeleted']).to be(true)
+        expect(row['sourceCourseDeleted']).to be(false)
+        expect(row['authoringAssessmentUrl']).to be_nil
+      end
+
+      # Reported alongside `state` rather than folded into it: the two answer different questions, and
+      # the provenance columns keep naming the ORIGIN course even after a rebuild, so this is the only
+      # thing in the payload that says where the copy an admin would edit actually lives.
+      it 'marks a listing whose authoring copy lives in the container as marketplace-hosted' do
+        listing = Course::Assessment::Marketplace::PublishService.
+                  publish(assessment_in_container, admin)
+
+        subject
+
+        expect(row_for(listing)['marketplaceHosted']).to be(true)
+        expect(row_for(listing)['state']).to eq('published')
+      end
+
+      it 'does not mark a listing whose authoring copy is in an ordinary course' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+
+        subject
+
+        expect(row_for(listing)['marketplaceHosted']).to be(false)
+      end
+
+      # The whole origin course went, so the FK nullified `source_course_id` too. Identifiable
+      # provenance differs from a plain assessment deletion, which is why it is its own boolean.
+      it 'flags a listing orphaned by a course deletion' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        listing.update!(authoring_assessment: nil, source_course: nil)
+
+        subject
+
+        row = row_for(listing)
+        expect(row['state']).to eq('published')
+        expect(row['sourceAssessmentDeleted']).to be(true)
+        expect(row['sourceCourseDeleted']).to be(true)
+        expect(row['sourceCourseName']).to eq(course.title)
+      end
+
+      it 'reports no deletion facts for a healthy listing with an intact authoring copy' do
+        listing = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+
+        subject
+
+        row = row_for(listing)
+        expect(row['sourceAssessmentDeleted']).to be(false)
+        expect(row['sourceCourseDeleted']).to be(false)
+      end
+
+      it 'only ever reports published or unlisted as the state' do
+        listed = Course::Assessment::Marketplace::PublishService.publish(assessment, admin)
+        unlisted = Course::Assessment::Marketplace::PublishService.
+                   publish(create(:assessment, course: course), admin)
+        unlisted.update!(published: false)
+
+        subject
+
+        expect(row_for(listed)['state']).to eq('published')
+        expect(row_for(unlisted)['state']).to eq('unlisted')
+        expect(response.parsed_body['listings'].map { |l| l['state'] }.uniq.sort).
+          to eq(%w[published unlisted])
+      end
+    end
+
+    describe 'POST #restore_authoring' do
+      # `have_enqueued_job` requires the :test adapter; the test env defaults to :background_thread.
+      with_active_job_queue_adapter(:test) do
+        let(:listing) { create(:course_assessment_marketplace_listing, :versioned, course: course) }
+
+        before { controller_sign_in(controller, admin) }
+
+        def restore(overrides = {})
+          post :restore_authoring, params: { id: listing.id, format: :json }.merge(overrides)
+        end
+
+        context 'when the listing is orphaned and versioned' do
+          before { orphan!(listing) }
+
+          it 'enqueues the restore job and returns a pollable jobUrl' do
+            expect { restore }.
+              to have_enqueued_job(Course::Assessment::Marketplace::RestoreAuthoringJob).
+              with(listing.id, current_user: admin)
+            expect(response.parsed_body['jobUrl']).to be_present
+          end
+
+          # No destination is accepted any more: the container is the only destination, so a stray
+          # param must not be able to redirect the copy into somebody's live course.
+          it 'ignores a destination_course_id param entirely' do
+            other_course = create(:course)
+
+            expect { restore(destination_course_id: other_course.id) }.
+              to have_enqueued_job(Course::Assessment::Marketplace::RestoreAuthoringJob).
+              with(listing.id, current_user: admin)
+          end
+        end
+
+        it 'rejects a listing that still has its authoring copy' do
+          expect { restore }.
+            not_to have_enqueued_job(Course::Assessment::Marketplace::RestoreAuthoringJob)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.parsed_body['errors'].first).to match(/Only an orphaned listing/)
+        end
+
+        it 'rejects an orphaned listing with no version to restore from' do
+          listing = create(:course_assessment_marketplace_listing, course: course)
+          orphan!(listing)
+
+          expect { restore(id: listing.id) }.
+            not_to have_enqueued_job(Course::Assessment::Marketplace::RestoreAuthoringJob)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.parsed_body['errors'].first).to match(/no published version/)
+        end
+      end
+    end
+
+    describe 'DELETE #destroy (permanent purge)' do
+      let(:listing) { create(:course_assessment_marketplace_listing, :versioned, course: course) }
+
+      before { controller_sign_in(controller, admin) }
+
+      def purge
+        delete :destroy, params: { id: listing.id, format: :json }
+      end
+
+      it 'deletes an orphaned listing with no adoptions, along with its snapshots' do
+        snapshot = listing.current_version.assessment
+        orphan!(listing)
+
+        expect { purge }.
+          to change { Course::Assessment::Marketplace::Listing.where(id: listing.id).count }.by(-1).
+          and change { Course::Assessment.where(id: snapshot.id).count }.by(-1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'deletes an unlisted listing with no adoptions, along with its snapshots' do
+        snapshot = listing.current_version.assessment
+        listing.update!(published: false)
+
+        expect { purge }.
+          to change { Course::Assessment::Marketplace::Listing.where(id: listing.id).count }.by(-1).
+          and change { Course::Assessment.where(id: snapshot.id).count }.by(-1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      # Unlisting is the reversible step, so it is the one an admin has to take first.
+      it 'refuses a published listing and says to unlist it first' do
+        expect { purge }.
+          not_to(change { Course::Assessment::Marketplace::Listing.where(id: listing.id).count })
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['errors'].first).to match(/Unlist it first/)
+      end
+
+      it 'deletes an unlisted listing that has been adopted, along with its adoption rows' do
+        adoption = create(:course_assessment_marketplace_adoption, listing: listing)
+        duplicated_assessment = adoption.duplicated_assessment
+        listing.update!(published: false)
+
+        expect { purge }.
+          to change { Course::Assessment::Marketplace::Listing.where(id: listing.id).count }.by(-1).
+          and change { Course::Assessment::Marketplace::Adoption.where(id: adoption.id).count }.by(-1)
+        expect(response).to have_http_status(:ok)
+        # A purge must never reach into another course's content.
+        expect(duplicated_assessment.reload).to be_persisted
+      end
+
+      it 'deletes an orphaned listing that has been adopted, along with its adoption rows' do
+        adoption = create(:course_assessment_marketplace_adoption, listing: listing)
+        duplicated_assessment = adoption.duplicated_assessment
+        orphan!(listing)
+
+        expect { purge }.
+          to change { Course::Assessment::Marketplace::Listing.where(id: listing.id).count }.by(-1).
+          and change { Course::Assessment::Marketplace::Adoption.where(id: adoption.id).count }.by(-1)
+        expect(response).to have_http_status(:ok)
+        expect(duplicated_assessment.reload).to be_persisted
+      end
+    end
+
+    # The admin-side counterpart of the course-side unlist. It exists separately because that one
+    # resolves the listing through its AUTHORING assessment, so it cannot reach an orphaned listing at
+    # all — which is precisely the listing an admin most often has to take off the marketplace.
+    describe 'PATCH #update (list / unlist)' do
+      let(:listing) { create(:course_assessment_marketplace_listing, :versioned, course: course) }
+
+      before { controller_sign_in(controller, admin) }
+
+      def set_published(value, id: listing.id)
+        patch :update, params: { id: id, published: value, format: :json }
+      end
+
+      it 'unlists a published listing' do
+        expect { set_published(false) }.to change { listing.reload.published }.from(true).to(false)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'lists an unlisted listing again, serving the version it already had' do
+        version = listing.current_version
+        listing.update!(published: false)
+
+        expect { set_published(true) }.to change { listing.reload.published }.from(false).to(true)
+        expect(response).to have_http_status(:ok)
+        # Re-listing restores VISIBILITY only. It must never cut a version, or an unlist/list round
+        # trip would mint a vintage nobody published — same rule PublishService follows.
+        expect(listing.current_version).to eq(version)
+        expect(listing.versions.count).to eq(1)
+      end
+
+      # The case the course-side unlist cannot serve at all.
+      it 'unlists an orphaned listing' do
+        listing.authoring_assessment.destroy!
+
+        expect { set_published(false) }.to change { listing.reload.published }.from(true).to(false)
+        expect(response).to have_http_status(:ok)
+      end
+
+      # An orphan goes on serving its snapshot, so there is nothing incoherent about it being listed.
+      it 'lists an orphaned listing that still holds a version' do
+        listing.authoring_assessment.destroy!
+        listing.update!(published: false)
+
+        expect { set_published(true) }.to change { listing.reload.published }.from(false).to(true)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'refuses to list a listing that has never published a version' do
+        versionless = create(:course_assessment_marketplace_listing, course: course, published: false)
+
+        expect { set_published(true, id: versionless.id) }.
+          not_to(change { versionless.reload.published })
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body['errors'].first).to match(/no published version/)
+      end
+
+      # Nothing else on a listing is the admin's to edit here: provenance is historical fact and the
+      # version pointer belongs to the publish path.
+      it 'ignores every attribute other than published' do
+        expect do
+          patch :update, params: { id: listing.id, published: false, title: 'Renamed',
+                                   source_course_name: 'Elsewhere', format: :json }
+        end.
+          not_to(change { listing.reload.source_course_name })
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'GET #show' do
+      let(:listing) do
+        create(:course_assessment_marketplace_listing, :versioned, course: course,
+                                                                   source_course: course,
+                                                                   source_instance: instance)
+      end
+
+      before { controller_sign_in(controller, admin) }
+
+      def show
+        get :show, params: { id: listing.id, format: :json }
+      end
+
+      it 'reports provenance, the served vintage and the assessment title' do
+        show
+
+        body = response.parsed_body
+        expect(response).to have_http_status(:ok)
+        expect(body['id']).to eq(listing.id)
+        expect(body['title']).to eq(listing.current_version.assessment.title)
+        expect(body).to have_key('currentVersionPublishedAt')
+        expect(body).not_to have_key('currentVersion')
+        expect(Time.zone.parse(body['currentVersionPublishedAt'])).
+          to be_within(1.second).of(listing.current_version.published_at)
+        expect(body['state']).to eq('published')
+        expect(body['sourceInstanceName']).to eq(instance.name)
+        expect(body['marketplaceHosted']).to be(false)
+      end
+
+      it 'reports a container-hosted authoring copy, matching the index' do
+        listing.update!(authoring_assessment: assessment_in_container)
+
+        show
+
+        expect(response.parsed_body['marketplaceHosted']).to be(true)
+      end
+
+      it 'lists every version ascending, flagging the current one' do
+        v1_at = listing.current_version.published_at
+        v2_at = v1_at + 1.day
+        v3_at = v1_at + 2.days
+        create(:course_assessment_marketplace_listing_version,
+               listing: listing, published_at: v3_at, published_by: admin)
+        create(:course_assessment_marketplace_listing_version,
+               listing: listing, published_at: v2_at, published_by: admin)
+
+        show
+
+        versions = response.parsed_body['versions']
+        published_times = versions.map { |version| Time.zone.parse(version['publishedAt']) }
+        expect(published_times).to eq(published_times.sort)
+        expect(published_times).to all(be_present)
+        expect(published_times[0]).to be_within(1.second).of(v1_at)
+        expect(published_times[1]).to be_within(1.second).of(v2_at)
+        expect(published_times[2]).to be_within(1.second).of(v3_at)
+        expect(versions).to all(satisfy { |version| !version.key?('version') })
+        # v1 is the current version because the :versioned trait pointed the listing at it.
+        expect(versions.map { |v| v['isCurrent'] }).to eq([true, false, false])
+      end
+
+      it 'names who published each version' do
+        create(:course_assessment_marketplace_listing_version,
+               listing: listing, published_at: listing.current_version.published_at + 1.day,
+               published_by: admin)
+
+        show
+
+        expect(response.parsed_body['versions'].last['publisherName']).to eq(admin.name)
+      end
+
+      it 'dates v1 from the version publish date' do
+        published = 4.months.ago.change(usec: 0)
+        listing.current_version.update!(published_at: published)
+
+        show
+
+        expect(Time.zone.parse(response.parsed_body['versions'].first['publishedAt'])).
+          to be_within(1.second).of(published)
+      end
+
+      it 'links each version to its snapshot on the container host' do
+        show
+
+        snapshot = listing.current_version.assessment
+        url = response.parsed_body['versions'].first['snapshotUrl']
+        expect(url).to include("/assessments/#{snapshot.id}")
+        expect(url).to start_with('http')
+      end
+
+      # Same trap as the authoring url on the index — see the note there.
+      it 'keeps the port carried by the container host, not the one the request arrived on' do
+        container_host = ActsAsTenant.without_tenant do
+          Course::Assessment::Marketplace::PreviewContainerService.container_course.instance.host
+        end
+        request.host = 'localhost:3999'
+
+        show
+
+        expect(response.parsed_body['versions'].first['snapshotUrl']).
+          to start_with("http://#{container_host}/")
+      end
+
+      it 'reports adoptions with the vintage each course holds' do
+        adopter = create(:course)
+        create(:course_assessment_marketplace_adoption, listing: listing,
+                                                        destination_course: adopter,
+                                                        adopted_version_at: listing.current_version.published_at)
+
+        show
+
+        adoptions = response.parsed_body['adoptions']
+        expect(adoptions.size).to eq(1)
+        expect(adoptions.first['destinationCourseId']).to eq(adopter.id)
+        expect(adoptions.first['destinationCourseName']).to eq(adopter.title)
+        expect(adoptions.first).to have_key('adoptedVersionAt')
+        expect(adoptions.first).not_to have_key('adoptedVersion')
+        expect(Time.zone.parse(adoptions.first['adoptedVersionAt'])).
+          to be_within(1.second).of(listing.current_version.published_at)
+        expect(adoptions.first['adoptedAt']).to be_present
+      end
+
+      it 'reports destination provenance for an adoption in another instance' do
+        other_instance = create(:instance)
+        other_course = ActsAsTenant.with_tenant(other_instance) { create(:course) }
+        ActsAsTenant.with_tenant(other_instance) do
+          create(:course_assessment_marketplace_adoption, listing: listing,
+                                                          destination_course: other_course,
+                                                          adopted_version_at: listing.current_version.published_at)
+        end
+
+        show
+
+        adoption = response.parsed_body['adoptions'].first
+        expect(adoption['destinationCourseName']).to eq(other_course.title)
+        expect(adoption['destinationCourseHost']).to eq(other_instance.host)
+      end
+
+      # Unusual but valid, so it reports as an empty list rather than a missing key.
+      it 'reports an empty adoptions list when nobody has adopted it' do
+        show
+
+        expect(response.parsed_body['adoptions']).to eq([])
+      end
+
+      it 'still serves the full history for an orphaned listing' do
+        listing.authoring_assessment.destroy!
+
+        show
+
+        body = response.parsed_body
+        expect(response).to have_http_status(:ok)
+        expect(body['state']).to eq('published')
+        expect(body['sourceAssessmentDeleted']).to be(true)
+        expect(body['versions'].size).to eq(1)
+      end
+
+      # Cannot happen for a published listing, but the page must not 500 if it ever does.
+      it 'renders an empty history for a listing with no current version' do
+        unversioned = create(:course_assessment_marketplace_listing, course: course)
+
+        get :show, params: { id: unversioned.id, format: :json }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['currentVersionPublishedAt']).to be_nil
+        expect(response.parsed_body).not_to have_key('currentVersion')
+        expect(response.parsed_body['versions']).to eq([])
+      end
+
+      # A course MANAGER, not a student: managers hold a blanket `can :manage, Course` over their own
+      # course, so they are the user who proves the `:manage, :all` gate is what stops this.
+      it 'denies a course manager' do
+        manager = create(:course_manager, course: course).user
+        controller_sign_in(controller, manager)
+
+        expect { show }.to raise_exception(CanCan::AccessDenied)
+      end
+    end
+
+    describe 'authorization' do
+      # A course MANAGER, not a student: managers hold a blanket `can :manage, Course` and
+      # `can :manage, Course::Assessment` over their own course, so they are the user who proves the
+      # `:manage, :all` gate is what stops these actions.
+      let(:manager) { create(:course_manager, course: course).user }
+
+      it 'denies a non-administrator' do
+        controller_sign_in(controller, create(:course_manager, course: course).user)
+
+        expect { get :index, format: :json }.to raise_exception(CanCan::AccessDenied)
+      end
+
+      it 'denies a course manager the restore action' do
+        listing = create(:course_assessment_marketplace_listing, :versioned, course: course)
+        listing.authoring_assessment.destroy!
+        controller_sign_in(controller, manager)
+
+        expect do
+          post :restore_authoring, params: { id: listing.id, format: :json }
+        end.to raise_exception(CanCan::AccessDenied)
+      end
+
+      it 'denies a course manager the unlist' do
+        listing = create(:course_assessment_marketplace_listing, :versioned, course: course)
+        controller_sign_in(controller, manager)
+
+        expect do
+          patch :update, params: { id: listing.id, published: false, format: :json }
+        end.to raise_exception(CanCan::AccessDenied)
+      end
+
+      it 'denies a course manager the permanent delete' do
+        listing = create(:course_assessment_marketplace_listing, :versioned, course: course)
+        listing.authoring_assessment.destroy!
+        controller_sign_in(controller, manager)
+
+        expect { delete :destroy, params: { id: listing.id, format: :json } }.
+          to raise_exception(CanCan::AccessDenied)
+      end
+    end
+
+    describe 'version identity in the admin payloads' do
+      render_views
+
+      let(:admin) { create(:administrator) }
+      let(:listing) { create(:course_assessment_marketplace_listing, :versioned, published: true) }
+
+      before { controller_sign_in(controller, admin) }
+
+      it 'names the served vintage on the index, with no ordinal' do
+        listing
+
+        get :index, as: :json
+
+        row = response.parsed_body['listings'].find { |l| l['id'] == listing.id }
+        expect(row).to have_key('currentVersionPublishedAt')
+        expect(row).not_to have_key('currentVersion')
+        expect(Time.zone.parse(row['currentVersionPublishedAt'])).
+          to be_within(1.second).of(listing.current_version.published_at)
+      end
+
+      it 'names each version by publish date on the show page, with no ordinal' do
+        get :show, as: :json, params: { id: listing.id }
+
+        version = response.parsed_body['versions'].first
+        expect(version).to have_key('publishedAt')
+        expect(version).not_to have_key('version')
+        expect(version['isCurrent']).to be(true)
+      end
+
+      it 'links a version snapshot through its publish date key' do
+        get :show, as: :json, params: { id: listing.id }
+
+        expect(response.parsed_body['versions'].first['snapshotUrl']).to be_present
+      end
+
+      it 'names the vintage an adopter holds, with no ordinal' do
+        adoption = create(:course_assessment_marketplace_adoption,
+                          listing: listing,
+                          adopted_version_at: listing.current_version.published_at)
+
+        get :show, as: :json, params: { id: listing.id }
+
+        row = response.parsed_body['adoptions'].find { |a| a['id'] == adoption.id }
+        expect(row).to have_key('adoptedVersionAt')
+        expect(row).not_to have_key('adoptedVersion')
+        expect(Time.zone.parse(row['adoptedVersionAt'])).
+          to be_within(1.second).of(listing.current_version.published_at)
+      end
+
+      # The snapshot map is keyed by a canonicalised timestamp string. An adoption holding exactly
+      # the served vintage must therefore resolve to the same snapshot the version row links to.
+      it 'resolves the adopter snapshot link from the same key as the version row' do
+        create(:course_assessment_marketplace_adoption,
+               listing: listing, adopted_version_at: listing.current_version.published_at)
+
+        get :show, as: :json, params: { id: listing.id }
+
+        body = response.parsed_body
+        expect(body['adoptions'].first['snapshotUrl']).to eq(body['versions'].first['snapshotUrl'])
+      end
+
+      it 'leaves the snapshot link null for an adoption with an unknown vintage' do
+        create(:course_assessment_marketplace_adoption,
+               listing: listing, adopted_version_at: nil)
+
+        get :show, as: :json, params: { id: listing.id }
+
+        expect(response.parsed_body['adoptions'].first['snapshotUrl']).to be_nil
+      end
+    end
+  end
+end

--- a/spec/jobs/course/assessment/marketplace/restore_authoring_job_spec.rb
+++ b/spec/jobs/course/assessment/marketplace/restore_authoring_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+# The clone itself is `RestoreAuthoringService`'s contract and is covered there. What is job-level —
+# and only testable here — is the guarding it does around a repair that may run long after it was
+# asked for, and the url it hands back for the client to follow.
+RSpec.describe Course::Assessment::Marketplace::RestoreAuthoringJob, type: :job do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:source_course) { create(:course) }
+    let(:source_assessment) { create(:assessment, :with_mcq_question, course: source_course) }
+    let(:user) { create(:administrator) }
+    # Published through the real service so the snapshot genuinely lives in the container course in
+    # the preview instance: restoring must duplicate ACROSS instances, exactly as adoption does.
+    let(:listing) { Course::Assessment::Marketplace::PublishService.publish(source_assessment, user) }
+
+    def container
+      ActsAsTenant.without_tenant do
+        Course::Assessment::Marketplace::PreviewContainerService.container_course
+      end
+    end
+
+    def container_assessment_count
+      ActsAsTenant.without_tenant { container.assessments.count }
+    end
+
+    # The only way a listing is orphaned now that `Course::Assessment` re-points inside the destroy
+    # transaction: the column is nulled underneath the model layer, as the foreign key does when a
+    # delete bypasses the callback. That is the state this job exists to repair.
+    def orphan!(target = listing)
+      target.update_column(:authoring_assessment_id, nil)
+      target.reload
+    end
+
+    # `perform_now` cannot be asserted with `raise_error`: TrackableJob installs
+    # `rescue_from(StandardError)`, so a refusal surfaces as an errored Job record instead.
+    def run(target = listing)
+      job = described_class.new(target.id, current_user: user)
+      job.perform_now
+      job.job
+    end
+
+    context 'when the listing is orphaned with a version' do
+      before { orphan! }
+
+      it 'rebuilds the authoring copy in the container' do
+        expect { run }.to change { container_assessment_count }.by(1)
+        expect(listing.reload).not_to be_orphaned
+      end
+
+      # The client follows this after polling. It carries the CONTAINER's own host: the copy lives in
+      # the preview instance, so a relative path would resolve on nobody's host but the admin's.
+      it 'completes with a redirect url on the container instance' do
+        job = run
+
+        copy = ActsAsTenant.without_tenant { listing.reload.authoring_assessment }
+        expect(job.status).to eq('completed')
+        expect(job.redirect_to).to include(container.instance.host)
+        expect(job.redirect_to).to include("/assessments/#{copy.id}")
+      end
+    end
+
+    describe 'guards' do
+      # Completes rather than errors, and rebuilds nothing: the end state this job exists to reach is
+      # the one it found. A republish restores an authoring copy on its own and can land between
+      # enqueue and perform, so that race must not surface as a failure to whoever is watching.
+      it 'leaves a listing that already has an authoring copy alone' do
+        listing
+
+        expect { run }.not_to(change { container_assessment_count })
+        expect(run.status).to eq('completed')
+      end
+
+      it 'refuses an orphaned listing with no version to restore from' do
+        versionless = create(:course_assessment_marketplace_listing, course: source_course)
+        orphan!(versionless)
+
+        expect { run(versionless) }.not_to(change { container_assessment_count })
+        expect(run(versionless).status).to eq('errored')
+      end
+    end
+  end
+end

--- a/spec/services/course/assessment/marketplace/restore_authoring_service_spec.rb
+++ b/spec/services/course/assessment/marketplace/restore_authoring_service_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Marketplace::RestoreAuthoringService, type: :service do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    # The duplication itself enqueues nothing, but the env default is `:background_thread` — a real
+    # thread sharing this example's connection — and these examples assert on container row counts.
+    with_active_job_queue_adapter(:test) do
+      let(:source_course) { create(:course) }
+      let(:source_assessment) { create(:assessment, :with_mcq_question, course: source_course) }
+      let(:user) { create(:administrator) }
+      # Published through the real service so the snapshot genuinely lives in the container course in
+      # the preview instance: restoring must duplicate ACROSS instances, exactly as adoption does.
+      let(:listing) { Course::Assessment::Marketplace::PublishService.publish(source_assessment, user) }
+
+      def container
+        ActsAsTenant.without_tenant do
+          Course::Assessment::Marketplace::PreviewContainerService.container_course
+        end
+      end
+
+      def container_assessment_count
+        ActsAsTenant.without_tenant { container.assessments.count }
+      end
+
+      # The only way a listing is orphaned now that `Course::Assessment` re-points inside the destroy
+      # transaction: the column is nulled underneath the model layer, as `fk_caml_authoring_assessment_id`
+      # does when a delete bypasses the callback. That is the state this service exists to repair.
+      def orphan!(target = listing)
+        target.update_column(:authoring_assessment_id, nil)
+        target.reload
+      end
+
+      def restore(target = listing)
+        described_class.restore!(target, current_user: user)
+      end
+
+      describe '.restore!' do
+        before { orphan! }
+
+        it 'duplicates the snapshot into the container course' do
+          expect { restore }.to change { container_assessment_count }.by(1)
+        end
+
+        # A NEW assessment beside the snapshots, never one of them. Editing a snapshot would mutate a
+        # published version for every adopter with no version cut.
+        it 'creates a new assessment rather than reusing the snapshot' do
+          snapshot = ActsAsTenant.without_tenant { listing.current_version.assessment }
+
+          restore
+
+          copy = listing.reload.authoring_assessment
+          expect(copy.id).not_to eq(snapshot.id)
+          expect(snapshot.reload).to be_persisted
+          expect(listing.current_version.reload.assessment_id).to eq(snapshot.id)
+        end
+
+        # Pinned deliberately: this holds only because ObjectDuplicationService's object-mode default
+        # is `unpublish_all: true` and no caller overrides it. A published copy in the container would
+        # be visible to previewers, so this must fail loudly if that default ever changes.
+        it 'lands the copy as a draft' do
+          restore
+
+          expect(listing.reload.authoring_assessment.published).to be(false)
+        end
+
+        it 'points the listing at the new copy, un-orphaning it' do
+          restore
+
+          expect(listing.reload.authoring_assessment).to be_present
+          expect(listing.reload).not_to be_orphaned
+        end
+
+        it 'carries the snapshot content into the copy' do
+          snapshot_title = ActsAsTenant.without_tenant { listing.current_version.assessment.title }
+
+          restore
+
+          copy = listing.reload.authoring_assessment
+          expect(copy.title).to eq(snapshot_title)
+          expect(copy.questions.count).to eq(1)
+        end
+
+        # Everything descended from the original source stays comparable for plagiarism, so the copy
+        # inherits the snapshot's duplication root rather than starting a tree of its own. Matches the
+        # re-point that runs inside `Course::Assessment#destroy`.
+        it 'inherits the snapshot link tree' do
+          snapshot = ActsAsTenant.without_tenant { listing.current_version.assessment }
+
+          restore
+
+          copy = listing.reload.authoring_assessment
+          expect(copy.linkable_tree_id).to eq(snapshot.linkable_tree_id)
+        end
+
+        # Repairing maintenance access is not a course adopting the content.
+        it 'records no adoption' do
+          expect { restore }.not_to change(Course::Assessment::Marketplace::Adoption, :count)
+        end
+
+        # Provenance describes where the content originally came from. A repair must not rewrite that
+        # historical fact — the row goes on naming the origin course after the copy moves.
+        it 'leaves the provenance fields untouched' do
+          provenance = [:source_course_id, :source_course_name, :source_instance_id]
+          before_restore = listing.slice(*provenance)
+
+          restore
+
+          expect(listing.reload.slice(*provenance)).to eq(before_restore)
+        end
+
+        # The end-to-end proof for `#marketplace_hosted?`: the copy lands in the real container, so the
+        # admin table can tell a repaired listing from one that still has its own source course.
+        it 'reports the listing as marketplace-hosted afterwards' do
+          expect { restore }.to change { listing.reload.marketplace_hosted? }.from(false).to(true)
+        end
+
+        it 'cuts no version — restoring is not a republish' do
+          expect { restore }.not_to(change { listing.reload.current_version_id })
+        end
+
+        it 'lets the listing cut a new version again' do
+          restore
+
+          expect do
+            Course::Assessment::Marketplace::PublishService.publish_new_version(listing.reload, user)
+          end.to(change { listing.reload.current_version_id })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Gives system admins somewhere to manage marketplace listings. One table covers every listing across every instance, showing the version currently being served, how many courses adopted it, where it came from, and whether its source still exists. A per-listing page adds the full version history and adoption list.

It also adds the maintenance actions only an admin has: take a listing off the marketplace or put it back, permanently delete a listing that is off the marketplace, and rebuild the source assessment of a listing that has none. The unlist/re-list pair has to live here rather than on the course side because that action hangs off the authoring assessment, which after a rebuild lives in the marketplace's container course on the preview instance - a course an admin cannot reach from their own host.

Split into two commits along the backend/frontend seam so the API and the UI can each be reviewed on their own.

## Design decisions

- The admin unlist/re-list duplicates the course-side action rather than reusing it, for the reason in the summary, and re-listing does not route through the publish service: an unlist/re-list round trip must not mint a version nobody published. `published` is the only writable attribute on a listing - everything else is provenance or derived state, so there is nothing else an admin could legitimately edit here.
- Rebuilding a lost source assessment is a failsafe rather than the ordinary path, and shares its implementation with the automatic repair. Deleting a source assessment re-points the listing at a fresh clone inside the same destroy transaction, so a listing with no source assessment now means the model layer was bypassed. The clone itself moved into one service that both the destroy hook and the admin action call, so a hand-repaired listing is indistinguishable from an automatically re-pointed one. The admin action runs it as a job for the reason adoption's duplication is one: duplicating a large assessment can outlast a request.
- A listing with no source assessment is a marker and a filter facet, not a listing state. Whether a listing is on the marketplace and whether it still has a source assessment are separate axes that cross, so one enum cannot carry both. The facet is contributed only by the rows it describes, so the filter value shows up only when something is actually wrong, and the chip carries a hint saying it should not happen and which action to take.
- Delete appears on every row, disabled rather than absent while the listing is still published, so its tooltip can state the rule - unlist first, keeping the reversible step ahead of the irreversible one. A missing icon read as "this table cannot delete" and left nowhere to learn why. Adoption count gates nothing: deleting an adopted listing is allowed, and the confirmation dialog is where that consequence is surfaced.
- The column naming distinguishes the assessment a listing was first published from ("Original assessment") from the one it is published from now, which differ after a rebuild. The Actions link owns the live one; the column owns the historical one, which is what makes a struck-through cell literally true rather than a claim that the listing is broken.
- Links to a source assessment are absolute and carry the source instance's own host and port. A course id only resolves on its own instance's host, so a relative path would 404 for every listing published from another instance, and naming the port explicitly is required because a controller always supplies the port the request reached Rails on, which differs from the public one behind a proxy.

## Regression prevention

Covers: the index and show payloads including version history, adoption list, provenance and derived state; authorization sitting behind `:manage, :all` rather than an ability on the listing, since CanCan's `:manage` wildcard would otherwise let a course manager through; unlist and re-list, and that re-listing does not create a version; delete accepted only for a listing off the marketplace and rejected for a published one; the rebuild offered only for a listing that has no source assessment but still has a snapshot to copy from; cross-instance link construction, including the regression where the request's port silently replaced the instance's; and the admin course list gaining its marketplace column.

The rebuild has its own coverage on both halves. The shared service pins the clone's semantics: a new assessment beside the snapshots rather than one of them, landing as a draft, inheriting the snapshot's link tree, leaving provenance, the current version and the adoption rows untouched, and leaving the listing able to cut a new version again. The job pins what only it can: it completes without rebuilding when a republish restored the copy between enqueue and perform, refuses a listing with no version to rebuild from, and hands back a redirect url on the container's own host.

Frontend suites cover the table's derived cells and empty states, which actions each listing state offers, the disabled-delete tooltip, both maintenance buttons including their confirmation flows, the per-listing page's version and adoption rendering, and the missing-source marker on both surfaces - that it leaves the state chip alone, carries its remedy hint, filters across states, and is absent from the filter menu entirely when no listing is affected.

Specs that need the preview container now resolve the real one instead of creating a `preview: true` course of their own. Only one such course may exist per instance and specs here commit, so the previous fixtures poisoned the shared test database for every later run.

Manually verified before the rebuild moved onto the shared service: the listings table shows served version, adoption count, provenance and the Original assessment column; unlisting enables delete and re-listing works; deleting an unlisted or orphaned listing purges it; rebuilding an orphaned listing's source produces a copy in the container; and the source assessment link opens on the correct host for a cross-instance listing. The missing-source marker and filter facet are covered by tests only.

New surface, so nothing existing changes for admins beyond the added nav entry.
