### PR TITLE
feat(marketplace): preview auto-marking refresh, publish toast and attempt TTL

### DIFF
--- a/app/jobs/course/assessment/marketplace/preview_submission_reaping_job.rb
+++ b/app/jobs/course/assessment/marketplace/preview_submission_reaping_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# Reaps aged marketplace preview submissions on a TTL, scheduled weekly via `config/schedule.yml`
+# (`Course::Assessment::Marketplace::PreviewContainerService`'s container course is the only source of
+# these submissions). Never touches the container course, the assessment copies, or the previewers'
+# enrolments — those are deliberately persistent and reused across preview sessions.
+class Course::Assessment::Marketplace::PreviewSubmissionReapingJob < ApplicationJob
+  # Keyed on `updated_at` (last activity), not `created_at`, so an in-progress rehearsal is never
+  # reaped out from under someone still working, and async autograding has time to land before a
+  # destroy could race it.
+  #
+  # This is the floor on how long an attempt is kept, not the ceiling: the weekly cron means an aged
+  # submission may linger up to a week past it.
+  PREVIEW_SUBMISSION_TTL = 24.hours
+
+  # Cap deletions per run to avoid bricking the worker (mirrors UserEmailDatabaseCleanupJob). Note
+  # this caps a WEEK's reaping, not an hour's: if preview volume ever exceeds it, aged submissions
+  # accumulate faster than they are removed and the cron needs raising before this does.
+  REAP_BATCH_SIZE = 1000
+
+  def perform
+    ActsAsTenant.without_tenant do
+      reap_aged_preview_submissions
+    end
+  end
+
+  private
+
+  def reap_aged_preview_submissions
+    User.with_stamper(User.system) do
+      Course::Assessment::Submission.transaction do
+        aged_preview_submissions.group_by(&:assessment).each do |assessment, submissions|
+          creator_ids = []
+          submissions.each do |submission|
+            submission.destroy!
+            creator_ids << submission.creator_id
+          end
+
+          Course::Assessment::Submission::MonitoringService.destroy_all_by(assessment, creator_ids)
+        end
+      end
+    end
+  end
+
+  # Derived from the course, not a deep join: `Course::Assessment` is `acts_as` a
+  # `Course::LessonPlan::Item`, so a `joins(assessment: { tab: :category })` chain is fragile.
+  def aged_preview_submissions
+    preview_assessment_ids = Course.where(preview: true).flat_map { |course| course.assessments.pluck(:id) }
+
+    Course::Assessment::Submission.
+      includes(:assessment).
+      where(assessment_id: preview_assessment_ids).
+      where(updated_at: ...PREVIEW_SUBMISSION_TTL.ago).
+      limit(REAP_BATCH_SIZE)
+  end
+end

--- a/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
@@ -56,4 +56,12 @@ json.submission do
   json.basePoints assessment.base_exp
   json.bonusPoints assessment.time_bonus_exp
   json.pointsAwarded submission.current_points_awarded
+
+  # Marketplace preview sandbox only: hand back the auto-grading job this very request enqueued
+  # (Course::Assessment::Submission#auto_grading_job) so the preview page can poll it and show the
+  # marks in place. Absent outside a preview course, and absent on any request that did not itself
+  # finalise the submission.
+  if current_course.preview? && submission.auto_grading_job
+    json.autoGradingJobUrl job_path(submission.auto_grading_job.job)
+  end
 end

--- a/client/app/bundles/common/ErrorPage.tsx
+++ b/client/app/bundles/common/ErrorPage.tsx
@@ -18,9 +18,11 @@ import {
   Attributions,
   useSetAttributions,
 } from 'lib/components/wrappers/AttributionsProvider';
+import { useAppContext } from 'lib/containers/AppContainer';
 import { getCourseIdFromString } from 'lib/helpers/url-helpers';
 import {
   getForbiddenSourceURL,
+  getNotFoundSourceURL,
   getSuspendedSourceURL,
 } from 'lib/hooks/router/redirect';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
@@ -38,6 +40,11 @@ const translations = defineMessages({
     id: 'app.ErrorPage.notFoundSubtitle',
     defaultMessage:
       "Check if you've typed the correct address, try again later, or <home>go back home</home>.",
+  },
+  notFoundSubtitleWithoutHome: {
+    id: 'app.ErrorPage.notFoundSubtitleWithoutHome',
+    defaultMessage:
+      "Check if you've typed the correct address, or try again later.",
   },
   notFoundIllustrationAttribution: {
     id: 'app.ErrorPage.notFoundIllustrationAttribution',
@@ -135,6 +142,20 @@ const ErrorPage = (props: ErrorPageProps): JSX.Element => {
 const NotFoundPage = (): JSX.Element => {
   const { t } = useTranslation();
 
+  // A marketplace previewer has nowhere to go back to: `/` resolves to the preview container, their
+  // only course, and the sandbox lock denies it, so the link would land them on a 403. The link is
+  // dropped rather than repointed, and it takes a second message rather than a conditional chunk.
+  const { isPreviewRestricted } = useAppContext();
+
+  // Most viewers reach this page because no route matched their URL, and the address bar already
+  // reads what they typed. The rest are redirected here from a route that did match but whose record
+  // turned out missing, and arrive carrying that address — put it back, so both look the same.
+  const sourceURL = getNotFoundSourceURL(window.location.href);
+
+  useEffectOnce(() => {
+    if (sourceURL) window.history.replaceState(null, '', sourceURL);
+  });
+
   return (
     <ErrorPage
       attributions={[
@@ -166,13 +187,18 @@ const NotFoundPage = (): JSX.Element => {
       ]}
       illustrationAlt="Not found illustration"
       illustrationSrc={notFoundIllustration}
-      subtitle={t(translations.notFoundSubtitle, {
-        home: (chunk) => (
-          <Link to="/" variant="body1">
-            {chunk}
-          </Link>
-        ),
-      })}
+      subtitle={
+        isPreviewRestricted
+          ? t(translations.notFoundSubtitleWithoutHome)
+          : t(translations.notFoundSubtitle, {
+              home: (chunk) => (
+                <Link to="/" variant="body1">
+                  {chunk}
+                </Link>
+              ),
+            })
+      }
+      tip={sourceURL ?? undefined}
       title={t(translations.notFound)}
     />
   );

--- a/client/app/bundles/common/__test__/ErrorPage.test.tsx
+++ b/client/app/bundles/common/__test__/ErrorPage.test.tsx
@@ -1,0 +1,82 @@
+import { render } from 'test-utils';
+import { HomeLayoutData } from 'types/home';
+
+import ErrorPage from '../ErrorPage';
+
+// `NotFoundPage` renders inside `CourselessContainer`'s outlet, which forwards the root payload as the
+// outlet context `useAppContext()` reads. There is no outlet here, so the payload is supplied directly.
+const mockAppContext: HomeLayoutData = { locale: 'en', timeZone: null };
+
+jest.mock('lib/containers/AppContainer', () => ({
+  ...jest.requireActual('lib/containers/AppContainer'),
+  useAppContext: (): HomeLayoutData => mockAppContext,
+}));
+
+describe('NotFoundPage', () => {
+  beforeEach(() => {
+    delete mockAppContext.isPreviewRestricted;
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('offers a link home', async () => {
+    const page = render(<ErrorPage.NotFound />);
+
+    expect(
+      (await page.findByText('go back home')).closest('a'),
+    ).toHaveAttribute('href', '/');
+  });
+
+  it('omits the link home for a restricted previewer', async () => {
+    mockAppContext.isPreviewRestricted = true;
+
+    const page = render(<ErrorPage.NotFound />);
+
+    expect(
+      await page.findByText(
+        "Check if you've typed the correct address, or try again later.",
+      ),
+    ).toBeInTheDocument();
+    expect(page.queryByText('go back home')).not.toBeInTheDocument();
+  });
+
+  // A 404 raised after a route already matched arrives here by redirect, so the address bar reads
+  // `/404` rather than the page the viewer actually asked for. Putting it back is what makes this
+  // read like the catch-all's not-found page, which never leaves the address it was typed at.
+  describe('when redirected from a page whose record was missing', () => {
+    const sourceURL = '/courses/8/assessments/33/submissions/818/edit';
+
+    beforeEach(() => {
+      window.history.replaceState(
+        null,
+        '',
+        `/404?from=${encodeURIComponent(sourceURL)}`,
+      );
+    });
+
+    it('restores the address it was redirected from', async () => {
+      const page = render(<ErrorPage.NotFound />);
+
+      await page.findByText("That location doesn't exist in this universe...");
+
+      expect(window.location.pathname + window.location.search).toBe(sourceURL);
+    });
+
+    it('names that address rather than /404', async () => {
+      const page = render(<ErrorPage.NotFound />);
+
+      expect(await page.findByText(sourceURL)).toBeInTheDocument();
+      expect(page.queryByText('/404')).not.toBeInTheDocument();
+    });
+  });
+
+  // The catch-all reaches this page without a redirect, so there is nothing to restore and the
+  // address is already the right one to show.
+  it('leaves an address it was not redirected to alone', async () => {
+    window.history.replaceState(null, '', '/courses/8/nonsense');
+
+    const page = render(<ErrorPage.NotFound />);
+
+    expect(await page.findByText('/courses/8/nonsense')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/courses/8/nonsense');
+  });
+});

--- a/client/app/bundles/course/assessment/submission/actions/__test__/fetchSubmission.test.js
+++ b/client/app/bundles/course/assessment/submission/actions/__test__/fetchSubmission.test.js
@@ -1,0 +1,114 @@
+import CourseAPI from 'api/course';
+import { redirectToNotFound } from 'lib/hooks/router/redirect';
+
+import { fetchSubmission, loadSubmissionPage } from '../index';
+
+jest.mock('api/course');
+jest.mock('lib/hooks/router/redirect', () => ({
+  redirectToNotFound: jest.fn(),
+}));
+
+// Minimal stand-in for the redux-thunk middleware: recursively invokes any
+// dispatched thunk (function) and records every plain action object. Mirrors the
+// helper in publish.test.js and finalise.test.js.
+const runThunk = async (thunk) => {
+  const dispatched = [];
+  const dispatch = (action) => {
+    if (typeof action === 'function') return action(dispatch, () => ({}));
+    dispatched.push(action);
+    return action;
+  };
+  await thunk(dispatch, () => ({}));
+  return dispatched;
+};
+
+describe('fetchSubmission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hands the axios error to onError when the fetch fails', async () => {
+    const error = { response: { status: 404 } };
+    CourseAPI.assessment.submissions.edit.mockRejectedValue(error);
+    const onError = jest.fn();
+
+    await runThunk(fetchSubmission(42, undefined, onError));
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it('does not call onError when the fetch succeeds', async () => {
+    CourseAPI.assessment.submissions.edit.mockResolvedValue({
+      data: {
+        submission: { id: 42 },
+        questions: [],
+        answers: [],
+        history: { questions: [] },
+      },
+    });
+    const onError = jest.fn();
+
+    await runThunk(fetchSubmission(42, undefined, onError));
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches FETCH_SUBMISSION_FAILURE when onError is omitted', async () => {
+    CourseAPI.assessment.submissions.edit.mockRejectedValue({
+      response: { status: 500 },
+    });
+
+    const dispatched = await runThunk(fetchSubmission(42));
+
+    expect(
+      dispatched.some((action) => action.type === 'FETCH_SUBMISSION_FAILURE'),
+    ).toBe(true);
+  });
+});
+
+describe('loadSubmissionPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends the viewer to the not-found page when the fetch 404s', async () => {
+    CourseAPI.assessment.submissions.edit.mockRejectedValue({
+      response: { status: 404 },
+    });
+
+    await runThunk(loadSubmissionPage(42));
+
+    expect(redirectToNotFound).toHaveBeenCalled();
+  });
+
+  // Only a 404 means "no such submission under this assessment". This matters beyond tidiness: the
+  // marketplace preview banner reads the very same 404 as a purged sandbox and has its own message
+  // for it, which is why it refetches through `fetchSubmission` directly rather than through here.
+  it('stays on the page on any other failure', async () => {
+    CourseAPI.assessment.submissions.edit.mockRejectedValue({
+      response: { status: 500 },
+    });
+
+    const dispatched = await runThunk(loadSubmissionPage(42));
+
+    expect(redirectToNotFound).not.toHaveBeenCalled();
+    expect(
+      dispatched.some((action) => action.type === 'FETCH_SUBMISSION_FAILURE'),
+    ).toBe(true);
+  });
+
+  it('stays on the page when the fetch succeeds', async () => {
+    CourseAPI.assessment.submissions.edit.mockResolvedValue({
+      data: {
+        submission: { id: 42 },
+        questions: [],
+        answers: [],
+        history: { questions: [] },
+      },
+    });
+
+    await runThunk(loadSubmissionPage(42));
+
+    expect(redirectToNotFound).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/bundles/course/assessment/submission/actions/__test__/finalise.test.js
+++ b/client/app/bundles/course/assessment/submission/actions/__test__/finalise.test.js
@@ -1,0 +1,81 @@
+import CourseAPI from 'api/course';
+
+import { previewAutogradingStarted } from '../../reducers/previewAutograding';
+import { finalise } from '../index';
+
+jest.mock('api/course');
+
+// Minimal stand-in for the redux-thunk middleware: recursively invokes any
+// dispatched thunk (function) and records every plain action object. Mirrors the
+// helper in publish.test.js.
+const runThunk = async (thunk) => {
+  const dispatched = [];
+  const dispatch = (action) => {
+    if (typeof action === 'function') return action(dispatch, () => ({}));
+    dispatched.push(action);
+    return action;
+  };
+  await thunk(dispatch, () => ({}));
+  return dispatched;
+};
+
+const startedActions = (dispatched) =>
+  dispatched.filter((action) => action.type === previewAutogradingStarted.type);
+
+describe('finalise', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts polling when the response carries a preview auto-grading job url', async () => {
+    CourseAPI.assessment.submissions.update.mockResolvedValue({
+      data: {
+        submission: { autoGradingJobUrl: '/jobs/9' },
+        questions: [],
+        answers: [],
+      },
+    });
+
+    const dispatched = await runThunk(finalise(1, []));
+
+    expect(startedActions(dispatched)).toEqual([
+      previewAutogradingStarted({ jobUrl: '/jobs/9' }),
+    ]);
+  });
+
+  it('does not start polling outside a preview course, where the key is absent', async () => {
+    CourseAPI.assessment.submissions.update.mockResolvedValue({
+      data: { submission: {}, questions: [], answers: [] },
+    });
+
+    const dispatched = await runThunk(finalise(1, []));
+
+    expect(startedActions(dispatched)).toEqual([]);
+  });
+
+  it('does not start polling when finalising fails', async () => {
+    CourseAPI.assessment.submissions.update.mockRejectedValue(
+      new Error('network error'),
+    );
+
+    const dispatched = await runThunk(finalise(1, []));
+
+    expect(startedActions(dispatched)).toEqual([]);
+  });
+
+  it('still dispatches FINALISE_SUCCESS alongside the polling action', async () => {
+    CourseAPI.assessment.submissions.update.mockResolvedValue({
+      data: {
+        submission: { autoGradingJobUrl: '/jobs/9' },
+        questions: [],
+        answers: [],
+      },
+    });
+
+    const dispatched = await runThunk(finalise(1, []));
+
+    expect(
+      dispatched.some((action) => action.type === 'FINALISE_SUCCESS'),
+    ).toBe(true);
+  });
+});

--- a/client/app/bundles/course/assessment/submission/actions/__test__/publish.test.js
+++ b/client/app/bundles/course/assessment/submission/actions/__test__/publish.test.js
@@ -1,0 +1,67 @@
+import CourseAPI from 'api/course';
+import notificationActionTypes from 'lib/constants';
+
+import translations from '../../translations';
+import { publish } from '../index';
+
+jest.mock('api/course');
+
+// Minimal stand-in for the redux-thunk middleware: recursively invokes any
+// dispatched thunk (function) and records every plain action object. This lets
+// the test observe the full dispatch sequence of `publish` (including its
+// nested `setNotification` thunk) without mounting a real store/reducers.
+const runThunk = async (thunk) => {
+  const dispatched = [];
+  const dispatch = (action) => {
+    if (typeof action === 'function') return action(dispatch, () => ({}));
+    dispatched.push(action);
+    return action;
+  };
+  await thunk(dispatch, () => ({}));
+  return dispatched;
+};
+
+const okResponse = {
+  data: { submission: {}, questions: [], answers: [] },
+};
+
+describe('publish', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the generic update-success notification outside a preview course', async () => {
+    CourseAPI.assessment.submissions.update.mockResolvedValue(okResponse);
+
+    const dispatched = await runThunk(publish(1, [], 0, false));
+
+    const notification = dispatched.find(
+      (action) => action.type === notificationActionTypes.SET_NOTIFICATION,
+    );
+    expect(notification.message).toBe(translations.updateSuccess);
+  });
+
+  it('shows the preview-specific notification inside a preview course', async () => {
+    CourseAPI.assessment.submissions.update.mockResolvedValue(okResponse);
+
+    const dispatched = await runThunk(publish(1, [], 0, true));
+
+    const notification = dispatched.find(
+      (action) => action.type === notificationActionTypes.SET_NOTIFICATION,
+    );
+    expect(notification.message).toBe(translations.previewPublishSuccess);
+  });
+
+  it('does not show the preview-specific notification on failure', async () => {
+    CourseAPI.assessment.submissions.update.mockRejectedValue(
+      new Error('network error'),
+    );
+
+    const dispatched = await runThunk(publish(1, [], 0, true));
+
+    const notification = dispatched.find(
+      (action) => action.type === notificationActionTypes.SET_NOTIFICATION,
+    );
+    expect(notification.message).toBe(translations.getPastAnswersFailure);
+  });
+});

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -2,6 +2,7 @@ import GlobalAPI from 'api';
 import CourseAPI from 'api/course';
 import { setNotification } from 'lib/actions';
 import pollJob from 'lib/helpers/jobHelpers';
+import { redirectToNotFound } from 'lib/hooks/router/redirect';
 
 import actionTypes, { workflowStates } from '../constants';
 import {
@@ -65,7 +66,7 @@ export function getJobStatus(jobUrl) {
   return GlobalAPI.jobs.get(jobUrl);
 }
 
-export function fetchSubmission(id, onGetMonitoringSessionId) {
+export function fetchSubmission(id, onGetMonitoringSessionId, onError) {
   return (dispatch) => {
     dispatch({ type: actionTypes.FETCH_SUBMISSION_REQUEST });
 
@@ -102,11 +103,32 @@ export function fetchSubmission(id, onGetMonitoringSessionId) {
           }),
         );
       })
-      .catch(() => {
+      .catch((error) => {
         dispatch({ type: actionTypes.FETCH_SUBMISSION_FAILURE });
         dispatch(resetExistingAnswerFlags());
+        // Optional: lets a caller distinguish *why* the refetch failed. The marketplace preview
+        // banner uses it to tell a purged sandbox (404) apart from an ordinary failure.
+        onError?.(error);
       });
   };
+}
+
+// The submission page's own load, as opposed to a refetch from somewhere already on the page. A 404
+// here means there is no such submission under this assessment — a typed, stale or guessed URL —
+// and without this the page renders its normal shell with empty state, which reads as a broken page
+// rather than a wrong address.
+//
+// Deliberately a separate thunk rather than folding the 404 into `fetchSubmission`. The marketplace
+// preview banner refetches through `fetchSubmission` and reads the very same 404 as a purged sandbox,
+// for which it has its own message (`previewAutogradingSandboxGone`); redirecting on every 404
+// centrally would navigate that banner away instead.
+export function loadSubmissionPage(id, onGetMonitoringSessionId) {
+  return (dispatch) =>
+    dispatch(
+      fetchSubmission(id, onGetMonitoringSessionId, (error) => {
+        if (error?.response?.status === 404) redirectToNotFound();
+      }),
+    );
 }
 
 export function autogradeSubmission(id) {

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -263,7 +263,7 @@ export function unmark(submissionId) {
   };
 }
 
-export function publish(submissionId, grades, exp) {
+export function publish(submissionId, grades, exp, isPreview) {
   const payload = {
     submission: {
       answers: grades,
@@ -279,7 +279,13 @@ export function publish(submissionId, grades, exp) {
       .then((response) => response.data)
       .then((data) => {
         dispatch({ type: actionTypes.PUBLISH_SUCCESS, payload: data });
-        dispatch(setNotification(translations.updateSuccess));
+        dispatch(
+          setNotification(
+            isPreview
+              ? translations.previewPublishSuccess
+              : translations.updateSuccess,
+          ),
+        );
       })
       .catch((error) => {
         dispatch({ type: actionTypes.PUBLISH_FAILURE });

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -11,6 +11,7 @@ import {
 } from '../reducers/answerFlags';
 import { historyActions } from '../reducers/history';
 import { initiateLiveFeedbackChatPerQuestion } from '../reducers/liveFeedbackChats';
+import { previewAutogradingStarted } from '../reducers/previewAutograding';
 import { scribingActions } from '../reducers/scribing';
 import translations from '../translations';
 
@@ -170,6 +171,16 @@ export function finalise(submissionId, rawAnswers) {
           window.location = data.newSessionUrl;
         }
         dispatch({ type: actionTypes.FINALISE_SUCCESS, payload: data });
+        // Marketplace preview sandbox only: the backend hands back the auto-grading job it just
+        // enqueued, so PreviewAutogradingBanner can poll it and refresh the marks in place. The key
+        // is absent everywhere else, which is what keeps this inert in real courses.
+        if (data.submission?.autoGradingJobUrl) {
+          dispatch(
+            previewAutogradingStarted({
+              jobUrl: data.submission.autoGradingJobUrl,
+            }),
+          );
+        }
         dispatch(setNotification(translations.updateSuccess));
       })
       .catch((error) => {

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/PreviewAutogradingBanner.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/PreviewAutogradingBanner.tsx
@@ -1,0 +1,141 @@
+import { FC, useEffect } from 'react';
+import { Alert, Typography } from '@mui/material';
+
+import { fetchSubmission } from 'course/assessment/submission/actions';
+import {
+  previewAutogradingFailed,
+  previewAutogradingSandboxGone,
+  previewAutogradingSettled,
+} from 'course/assessment/submission/reducers/previewAutograding';
+import { getPreviewAutograding } from 'course/assessment/submission/selectors/previewAutograding';
+import translations from 'course/assessment/submission/translations';
+import { useCourseContext } from 'course/container/CourseLoader';
+import { setNotification } from 'lib/actions';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import { pollJobRequest } from 'lib/helpers/jobHelpers';
+import { getSubmissionId } from 'lib/helpers/url-helpers';
+import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 60000;
+
+/**
+ * Marketplace preview sandbox only. This banner polls the auto-grading job that
+ * `finalise` handed back and refetches the submission in place once it lands.
+ */
+const PreviewAutogradingBanner: FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  // Read defensively (optional chaining) — this page also mounts in test trees that may not sit
+  // under CourseContainer's outlet.
+  const isPreview = useCourseContext()?.isPreview;
+  const { jobUrl, status } = useAppSelector(getPreviewAutograding);
+  const submissionId = getSubmissionId();
+
+  useEffect(() => {
+    if (!isPreview || status !== 'polling' || !jobUrl) return undefined;
+
+    const startedAt = Date.now();
+    let cancelled = false;
+    let inFlight = false;
+
+    // A purge can destroy this attempt's assessment and cascade its submission mid-session. The
+    // `jobs` row survives that, so the poll still succeeds — the absence only shows up as a 404 on
+    // the refetch. A 403 is something else entirely (cross-previewer denial) and must not land here.
+    const refetchAndDetectPurge = async (): Promise<boolean> => {
+      let purged = false;
+
+      await dispatch(
+        fetchSubmission(
+          submissionId,
+          undefined,
+          (error?: { response?: { status?: number } }) => {
+            if (error?.response?.status === 404) purged = true;
+          },
+        ),
+      );
+
+      return purged;
+    };
+
+    const poller = setInterval(async () => {
+      // The deadline is checked BEFORE the `inFlight` guard, and that order is load-bearing: the jobs
+      // endpoint sets no axios timeout, so a hung request would otherwise pin `inFlight` true forever
+      // and every later tick would short-circuit before ever reaching this check — the 60s ceiling
+      // would never fire and the banner would spin indefinitely.
+      if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+        clearInterval(poller);
+        dispatch(previewAutogradingFailed());
+        return;
+      }
+      if (inFlight) return;
+
+      inFlight = true;
+
+      try {
+        const response = await pollJobRequest(jobUrl);
+        if (cancelled) return;
+
+        if (response.status === 'completed') {
+          clearInterval(poller);
+          // Decide what to say only AFTER the refetch resolves. Announcing success up front made a
+          // purged sandbox flash "evaluated" and then contradict itself with "no longer available".
+          const purged = await refetchAndDetectPurge();
+          if (cancelled) return;
+
+          if (purged) {
+            dispatch(previewAutogradingSandboxGone());
+          } else {
+            dispatch(previewAutogradingSettled());
+            dispatch(setNotification(translations.autogradeSubmissionSuccess));
+          }
+        } else if (response.status === 'errored') {
+          clearInterval(poller);
+          // The likeliest purge path: the assessment was destroyed before the job ran, so the job
+          // died on ActiveJob deserialization instead of completing. The refetch both surfaces any
+          // partial grading and tells us whether the sandbox is gone.
+          const purged = await refetchAndDetectPurge();
+          if (cancelled) return;
+
+          dispatch(
+            purged
+              ? previewAutogradingSandboxGone()
+              : previewAutogradingFailed(),
+          );
+        }
+      } catch {
+        if (!cancelled) {
+          clearInterval(poller);
+          dispatch(previewAutogradingFailed());
+        }
+      } finally {
+        inFlight = false;
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(poller);
+    };
+  }, [isPreview, status, jobUrl, submissionId, dispatch]);
+
+  if (!isPreview || status === 'idle') return null;
+
+  const polling = status === 'polling';
+
+  let message = translations.previewAutogradingStalled;
+  if (polling) message = translations.previewAutogradingInProgress;
+  if (status === 'gone') message = translations.previewAutogradingSandboxGone;
+
+  return (
+    <Alert
+      icon={polling ? <LoadingIndicator bare size={20} /> : undefined}
+      severity={polling ? 'info' : 'warning'}
+    >
+      <Typography variant="body2">{t(message)}</Typography>
+    </Alert>
+  );
+};
+
+export default PreviewAutogradingBanner;

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/__test__/PreviewAutogradingBanner.test.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/__test__/PreviewAutogradingBanner.test.tsx
@@ -1,0 +1,274 @@
+import { createMockAdapter } from 'mocks/axiosMock';
+import { render, waitFor } from 'test-utils';
+
+import GlobalAPI from 'api';
+import { fetchSubmission } from 'course/assessment/submission/actions';
+import { useCourseContext } from 'course/container/CourseLoader';
+import { setNotification } from 'lib/actions';
+
+import PreviewAutogradingBanner from '../PreviewAutogradingBanner';
+
+jest.mock('course/assessment/submission/actions', () => ({
+  fetchSubmission: jest.fn(() => (): Promise<void> => Promise.resolve()),
+}));
+
+jest.mock('course/container/CourseLoader', () => ({
+  useCourseContext: jest.fn(),
+}));
+
+jest.mock('lib/actions', () => ({
+  setNotification: jest.fn(() => (): void => {}),
+}));
+
+jest.mock('lib/helpers/url-helpers', () => ({
+  ...jest.requireActual('lib/helpers/url-helpers'),
+  getSubmissionId: (): string => '42',
+}));
+
+// The banner polls the *jobs* endpoint, which lives on its own axios client.
+const jobsMock = createMockAdapter(GlobalAPI.jobs.client);
+
+const mockFetchSubmission = fetchSubmission as jest.Mock;
+const mockUseCourseContext = useCourseContext as jest.Mock;
+const mockSetNotification = setNotification as jest.Mock;
+
+const stateWith = (previewAutograding: object): object => ({
+  assessments: { submission: { previewAutograding } },
+});
+
+const POLLING = { jobUrl: '/jobs/9', status: 'polling' };
+
+// The banner polls every 2s, which is longer than waitFor's 1s default — every wait here needs an
+// explicit longer timeout, and every test needs a raised jest timeout.
+const POLL_WAIT = { timeout: 8000 };
+
+const settle = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+
+beforeEach(() => {
+  jobsMock.reset();
+  jest.clearAllMocks();
+  mockFetchSubmission.mockImplementation(
+    () => (): Promise<void> => Promise.resolve(),
+  );
+  mockUseCourseContext.mockReturnValue({ isPreview: true });
+});
+
+describe('PreviewAutogradingBanner', () => {
+  it('renders nothing when no auto-grading is in flight', async () => {
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith({ jobUrl: null, status: 'idle' }),
+    });
+
+    await settle(3000);
+
+    expect(page.queryByText(/Auto-marking/)).not.toBeInTheDocument();
+    expect(jobsMock.history.get).toHaveLength(0);
+  }, 10000);
+
+  it('tells the previewer that auto-marking is running while the job is pending', async () => {
+    jobsMock.onGet('/jobs/9').reply(200, { status: 'submitted' });
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    expect(await page.findByText(/Auto-marking is running/)).toBeVisible();
+    await waitFor(
+      () => expect(jobsMock.history.get.length).toBeGreaterThan(0),
+      POLL_WAIT,
+    );
+    expect(mockFetchSubmission).not.toHaveBeenCalled();
+  }, 15000);
+
+  it('refetches the submission and clears itself when the job completes', async () => {
+    jobsMock.onGet('/jobs/9').reply(200, { status: 'completed' });
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    await waitFor(
+      () =>
+        expect(mockFetchSubmission).toHaveBeenCalledWith(
+          '42',
+          undefined,
+          expect.any(Function),
+        ),
+      POLL_WAIT,
+    );
+    await waitFor(
+      () =>
+        expect(
+          page.queryByText(/Auto-marking is running/),
+        ).not.toBeInTheDocument(),
+      POLL_WAIT,
+    );
+    expect(mockSetNotification).toHaveBeenCalled();
+  }, 15000);
+
+  it('tells the previewer to refresh when the job errors', async () => {
+    jobsMock
+      .onGet('/jobs/9')
+      .reply(200, { status: 'errored', message: 'boom' });
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    expect(
+      await page.findByText(/Auto-marking did not finish/, {}, POLL_WAIT),
+    ).toBeVisible();
+    expect(mockFetchSubmission).toHaveBeenCalledWith(
+      '42',
+      undefined,
+      expect.any(Function),
+    );
+  }, 15000);
+
+  it('tells the previewer to refresh when the job request itself fails', async () => {
+    jobsMock.onGet('/jobs/9').networkError();
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    expect(
+      await page.findByText(/Auto-marking did not finish/, {}, POLL_WAIT),
+    ).toBeVisible();
+  }, 15000);
+
+  it('keeps showing the failure notice without polling further', async () => {
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith({ jobUrl: null, status: 'failed' }),
+    });
+
+    expect(await page.findByText(/Auto-marking did not finish/)).toBeVisible();
+
+    await settle(3000);
+
+    expect(jobsMock.history.get).toHaveLength(0);
+  }, 10000);
+
+  it('renders nothing and never polls outside a preview course', async () => {
+    mockUseCourseContext.mockReturnValue({ isPreview: false });
+    jobsMock.onGet('/jobs/9').reply(200, { status: 'submitted' });
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    await settle(3000);
+
+    expect(page.queryByText(/Auto-marking/)).not.toBeInTheDocument();
+    expect(jobsMock.history.get).toHaveLength(0);
+  }, 10000);
+
+  it('renders nothing when mounted outside CourseContainer entirely', async () => {
+    mockUseCourseContext.mockReturnValue(undefined);
+    jobsMock.onGet('/jobs/9').reply(200, { status: 'submitted' });
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    await settle(3000);
+
+    expect(page.queryByText(/Auto-marking/)).not.toBeInTheDocument();
+    expect(jobsMock.history.get).toHaveLength(0);
+  }, 10000);
+
+  // Regression guard: `pollJob`'s default export orphans pollers across navigation (see its own
+  // docstring), and this feature has already shipped that bug once as stray `/assessments/null`
+  // requests. Deleting the effect's cleanup must fail this example.
+  it('stops polling once the page unmounts', async () => {
+    jobsMock.onGet('/jobs/9').reply(200, { status: 'submitted' });
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    await waitFor(
+      () => expect(jobsMock.history.get.length).toBeGreaterThan(0),
+      POLL_WAIT,
+    );
+
+    page.unmount();
+    const callsAtUnmount = jobsMock.history.get.length;
+
+    await settle(5000);
+
+    expect(jobsMock.history.get).toHaveLength(callsAtUnmount);
+  }, 20000);
+
+  // A purge destroys the snapshot assessment and cascades its submission. The jobs row survives, so
+  // the poll succeeds and only the refetch 404s.
+  it('says the preview is gone rather than telling the previewer to refresh, when the submission was purged', async () => {
+    jobsMock.onGet('/jobs/9').reply(200, { status: 'completed' });
+    mockFetchSubmission.mockImplementation(
+      (_id: string, _onSession: unknown, onError?: (e: unknown) => void) =>
+        (): Promise<void> => {
+          onError?.({ response: { status: 404 } });
+          return Promise.resolve();
+        },
+    );
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    expect(
+      await page.findByText(/no longer available/, {}, POLL_WAIT),
+    ).toBeVisible();
+    expect(page.queryByText(/Refresh this page/)).not.toBeInTheDocument();
+    expect(mockSetNotification).not.toHaveBeenCalled();
+  }, 15000);
+
+  // The likelier purge path: the assessment went away before the job ran, so the job errored on
+  // ActiveJob deserialization rather than completing.
+  it('promotes an errored job to gone when the submission was purged', async () => {
+    jobsMock
+      .onGet('/jobs/9')
+      .reply(200, { status: 'errored', message: 'boom' });
+    mockFetchSubmission.mockImplementation(
+      (_id: string, _onSession: unknown, onError?: (e: unknown) => void) =>
+        (): Promise<void> => {
+          onError?.({ response: { status: 404 } });
+          return Promise.resolve();
+        },
+    );
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    expect(
+      await page.findByText(/no longer available/, {}, POLL_WAIT),
+    ).toBeVisible();
+  }, 15000);
+
+  // Guards the `=== 404` check specifically: any other failure is an ordinary failure, not a purge.
+  it('keeps the ordinary failure notice when the refetch fails for a non-404 reason', async () => {
+    jobsMock
+      .onGet('/jobs/9')
+      .reply(200, { status: 'errored', message: 'boom' });
+    mockFetchSubmission.mockImplementation(
+      (_id: string, _onSession: unknown, onError?: (e: unknown) => void) =>
+        (): Promise<void> => {
+          onError?.({ response: { status: 500 } });
+          return Promise.resolve();
+        },
+    );
+
+    const page = render(<PreviewAutogradingBanner />, {
+      state: stateWith(POLLING),
+    });
+
+    expect(
+      await page.findByText(/Auto-marking did not finish/, {}, POLL_WAIT),
+    ).toBeVisible();
+    expect(page.queryByText(/no longer available/)).not.toBeInTheDocument();
+  }, 15000);
+});

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/PublishButton.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/PublishButton.tsx
@@ -11,6 +11,7 @@ import {
 import { getSubmissionFlags } from 'course/assessment/submission/selectors/submissionFlags';
 import { getSubmission } from 'course/assessment/submission/selectors/submissions';
 import translations from 'course/assessment/submission/translations';
+import { useCourseContext } from 'course/container/CourseLoader';
 import { getSubmissionId } from 'lib/helpers/url-helpers';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -24,6 +25,9 @@ const PublishButton: FC = () => {
   const questionWithGrades = useAppSelector(getQuestionWithGrades);
   const submissionFlags = useAppSelector(getSubmissionFlags);
   const expPoints = useAppSelector(getExperiencePoints);
+  // Read defensively (optional chaining) — this button also mounts in test/other
+  // trees that may not sit under CourseContainer's outlet.
+  const isPreview = useCourseContext()?.isPreview;
 
   const { delayedGradePublication } = assessment;
   const { graderView, workflowState } = submission;
@@ -39,7 +43,12 @@ const PublishButton: FC = () => {
 
   const handlePublish = (): void => {
     dispatch(
-      publish(submissionId, Object.values(questionWithGrades), expPoints),
+      publish(
+        submissionId,
+        Object.values(questionWithGrades),
+        expPoints,
+        isPreview,
+      ),
     );
   };
 

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/__test__/PublishButton.test.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/__test__/PublishButton.test.tsx
@@ -1,0 +1,78 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'test-utils';
+
+import { publish } from 'course/assessment/submission/actions';
+import { useCourseContext } from 'course/container/CourseLoader';
+
+import PublishButton from '../PublishButton';
+
+jest.mock('course/assessment/submission/actions', () => ({
+  publish: jest.fn(() => (): Promise<void> => Promise.resolve()),
+}));
+
+jest.mock('course/container/CourseLoader', () => ({
+  useCourseContext: jest.fn(),
+}));
+
+jest.mock('lib/helpers/url-helpers', () => ({
+  ...jest.requireActual('lib/helpers/url-helpers'),
+  getSubmissionId: (): string => '42',
+}));
+
+const mockPublish = publish as jest.Mock;
+const mockUseCourseContext = useCourseContext as jest.Mock;
+
+const buildState = (): object => ({
+  assessments: {
+    submission: {
+      assessment: { delayedGradePublication: false },
+      submission: { graderView: true, workflowState: 'submitted' },
+      submissionFlags: { isSaving: false },
+      grading: { questions: { 1: { grade: 10 } }, exp: 0 },
+    },
+  },
+});
+
+describe('PublishButton', () => {
+  beforeEach(() => {
+    mockPublish.mockClear();
+  });
+
+  it('threads isPreview through to publish() inside a preview course', async () => {
+    mockUseCourseContext.mockReturnValue({ isPreview: true });
+    const user = userEvent.setup();
+
+    render(<PublishButton />, { state: buildState() });
+
+    await user.click(await screen.findByRole('button'));
+
+    expect(mockPublish).toHaveBeenCalledWith('42', [{ grade: 10 }], 0, true);
+  });
+
+  it('passes isPreview=false outside a preview course', async () => {
+    mockUseCourseContext.mockReturnValue({ isPreview: false });
+    const user = userEvent.setup();
+
+    render(<PublishButton />, { state: buildState() });
+
+    await user.click(await screen.findByRole('button'));
+
+    expect(mockPublish).toHaveBeenCalledWith('42', [{ grade: 10 }], 0, false);
+  });
+
+  it('passes isPreview=undefined when rendered outside CourseContainer entirely', async () => {
+    mockUseCourseContext.mockReturnValue(undefined);
+    const user = userEvent.setup();
+
+    render(<PublishButton />, { state: buildState() });
+
+    await user.click(await screen.findByRole('button'));
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      '42',
+      [{ grade: 10 }],
+      0,
+      undefined,
+    );
+  });
+});

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -40,6 +40,7 @@ import {
 import translations from '../../translations';
 
 import BlockedSubmission from './BlockedSubmission';
+import PreviewAutogradingBanner from './PreviewAutogradingBanner';
 import SubmissionEmptyForm from './SubmissionEmptyForm';
 import SubmissionForm from './SubmissionForm';
 import TimeLimitBanner from './TimeLimitBanner';
@@ -174,6 +175,7 @@ class VisibleSubmissionEditIndex extends Component {
     return (
       <Page className="space-y-5">
         {this.renderTimeLimitBanner()}
+        <PreviewAutogradingBanner />
         {this.renderAssessment()}
         {isBlockedInStudentView ? (
           <div className="flex flex-col items-center py-16">

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -26,7 +26,7 @@ import assessmentsTranslations from '../../../translations';
 import {
   enterStudentView,
   exitStudentView,
-  fetchSubmission,
+  loadSubmissionPage,
   purgeSubmissionStore,
 } from '../../actions';
 import ProgressPanel from '../../components/ProgressPanel';
@@ -59,7 +59,7 @@ class VisibleSubmissionEditIndex extends Component {
 
   componentDidMount() {
     const { dispatch, match, setSessionId } = this.props;
-    dispatch(fetchSubmission(match.params.submissionId, setSessionId));
+    dispatch(loadSubmissionPage(match.params.submissionId, setSessionId));
   }
 
   componentWillUnmount() {

--- a/client/app/bundles/course/assessment/submission/reducers/__test__/previewAutograding.test.ts
+++ b/client/app/bundles/course/assessment/submission/reducers/__test__/previewAutograding.test.ts
@@ -1,0 +1,68 @@
+import reducer, {
+  previewAutogradingFailed,
+  previewAutogradingSandboxGone,
+  previewAutogradingSettled,
+  previewAutogradingStarted,
+} from '../previewAutograding';
+
+describe('previewAutograding reducer', () => {
+  it('starts idle with no job', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual({
+      jobUrl: null,
+      status: 'idle',
+    });
+  });
+
+  it('records the job url and starts polling', () => {
+    const state = reducer(
+      undefined,
+      previewAutogradingStarted({ jobUrl: '/jobs/9' }),
+    );
+
+    expect(state).toEqual({ jobUrl: '/jobs/9', status: 'polling' });
+  });
+
+  it('clears itself back to idle when the job settles', () => {
+    const polling = reducer(
+      undefined,
+      previewAutogradingStarted({ jobUrl: '/jobs/9' }),
+    );
+
+    expect(reducer(polling, previewAutogradingSettled())).toEqual({
+      jobUrl: null,
+      status: 'idle',
+    });
+  });
+
+  it('drops the job url but remembers the failure so the banner can persist', () => {
+    const polling = reducer(
+      undefined,
+      previewAutogradingStarted({ jobUrl: '/jobs/9' }),
+    );
+
+    expect(reducer(polling, previewAutogradingFailed())).toEqual({
+      jobUrl: null,
+      status: 'failed',
+    });
+  });
+
+  it('lets a fresh finalise restart polling after a previous failure', () => {
+    const failed = reducer(undefined, previewAutogradingFailed());
+
+    expect(
+      reducer(failed, previewAutogradingStarted({ jobUrl: '/jobs/10' })),
+    ).toEqual({ jobUrl: '/jobs/10', status: 'polling' });
+  });
+
+  it('marks the sandbox gone, dropping the job url', () => {
+    const polling = reducer(
+      undefined,
+      previewAutogradingStarted({ jobUrl: '/jobs/9' }),
+    );
+
+    expect(reducer(polling, previewAutogradingSandboxGone())).toEqual({
+      jobUrl: null,
+      status: 'gone',
+    });
+  });
+});

--- a/client/app/bundles/course/assessment/submission/reducers/index.js
+++ b/client/app/bundles/course/assessment/submission/reducers/index.js
@@ -13,6 +13,7 @@ import gradingResults from './gradingResults';
 import history from './history';
 import liveFeedbackChats from './liveFeedbackChats';
 import posts from './posts';
+import previewAutograding from './previewAutograding';
 import questions from './questions';
 import questionsFlags from './questionsFlags';
 import recorder from './recorder';
@@ -35,6 +36,7 @@ const submissionReducer = combineReducers({
   gradingResults,
   liveFeedbackChats,
   posts,
+  previewAutograding,
   questions,
   questionsFlags,
   submission,

--- a/client/app/bundles/course/assessment/submission/reducers/previewAutograding/index.ts
+++ b/client/app/bundles/course/assessment/submission/reducers/previewAutograding/index.ts
@@ -1,0 +1,50 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { PreviewAutogradingState } from '../../types';
+
+const initialState: PreviewAutogradingState = {
+  jobUrl: null,
+  status: 'idle',
+};
+
+export const previewAutogradingSlice = createSlice({
+  name: 'previewAutograding',
+  initialState,
+  reducers: {
+    previewAutogradingStarted: (
+      state,
+      action: PayloadAction<{ jobUrl: string }>,
+    ) => {
+      state.jobUrl = action.payload.jobUrl;
+      state.status = 'polling';
+    },
+    // The job finished and the submission has been refetched; the banner has nothing left to say.
+    previewAutogradingSettled: (state) => {
+      state.jobUrl = null;
+      state.status = 'idle';
+    },
+    // The job errored or outlived the poll window. The url is dropped (nothing left to poll) but the
+    // status persists, so the banner can keep telling the previewer to refresh.
+    previewAutogradingFailed: (state) => {
+      state.jobUrl = null;
+      state.status = 'failed';
+    },
+    // The sandbox content this attempt lived in was purged mid-session: an admin permanently deleted
+    // an orphaned marketplace listing, which destroys its snapshot assessments and cascades their
+    // submissions. Deliberately distinct from `failed` — there is nothing left to refresh back into,
+    // so the banner must not tell the previewer to refresh.
+    previewAutogradingSandboxGone: (state) => {
+      state.jobUrl = null;
+      state.status = 'gone';
+    },
+  },
+});
+
+export const {
+  previewAutogradingFailed,
+  previewAutogradingSandboxGone,
+  previewAutogradingSettled,
+  previewAutogradingStarted,
+} = previewAutogradingSlice.actions;
+
+export default previewAutogradingSlice.reducer;

--- a/client/app/bundles/course/assessment/submission/selectors/previewAutograding.ts
+++ b/client/app/bundles/course/assessment/submission/selectors/previewAutograding.ts
@@ -1,0 +1,9 @@
+import { AppState } from 'store';
+
+import { PreviewAutogradingState } from '../types';
+
+export const getPreviewAutograding = (
+  state: AppState,
+): PreviewAutogradingState => {
+  return state.assessments.submission.previewAutograding;
+};

--- a/client/app/bundles/course/assessment/submission/translations.ts
+++ b/client/app/bundles/course/assessment/submission/translations.ts
@@ -368,6 +368,26 @@ const translations = defineMessages({
     id: 'course.assessment.submission.updateSuccess',
     defaultMessage: 'Submission updated successfully.',
   },
+  previewPublishSuccess: {
+    id: 'course.assessment.submission.previewPublishSuccess',
+    defaultMessage:
+      'Grade published. In a real course, the student would now be able to see this grade and feedback immediately.',
+  },
+  previewAutogradingInProgress: {
+    id: 'course.assessment.submission.previewAutogradingInProgress',
+    defaultMessage:
+      'Auto-marking is running. The results will appear here in a moment.',
+  },
+  previewAutogradingStalled: {
+    id: 'course.assessment.submission.previewAutogradingStalled',
+    defaultMessage:
+      'Auto-marking did not finish. Refresh this page to check for results.',
+  },
+  previewAutogradingSandboxGone: {
+    id: 'course.assessment.submission.previewAutogradingSandboxGone',
+    defaultMessage:
+      'This preview is no longer available. The assessment it was based on has been removed from the marketplace.',
+  },
   updateIndividualSuccess: {
     id: 'course.assessment.submission.updateIndividualSuccess',
     defaultMessage: 'Submission for {errors} updated successfully',

--- a/client/app/bundles/course/assessment/submission/types.ts
+++ b/client/app/bundles/course/assessment/submission/types.ts
@@ -132,6 +132,11 @@ export interface SubmissionFlagsState {
   isUnsubmitting: boolean;
 }
 
+export interface PreviewAutogradingState {
+  jobUrl: string | null;
+  status: 'idle' | 'polling' | 'failed' | 'gone';
+}
+
 export interface QuestionFlag {
   isAutograding: boolean;
   isResetting: boolean;

--- a/client/app/lib/hooks/router/__test__/redirect.test.ts
+++ b/client/app/lib/hooks/router/__test__/redirect.test.ts
@@ -1,0 +1,52 @@
+import { getNotFoundSourceURL, getNotFoundURL } from '../redirect';
+
+// The not-found page is standalone by design, so reaching it means leaving the page that 404ed.
+// Carrying the address along is what lets that page put it back, so a viewer sent here still sees the
+// URL they asked for rather than `/404` — which is how every other route to that page behaves.
+describe('getNotFoundURL', () => {
+  it('carries the address it was called from', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/courses/8/assessments/33/submissions/818/edit',
+    );
+
+    expect(getNotFoundURL()).toBe(
+      '/404?from=%2Fcourses%2F8%2Fassessments%2F33%2Fsubmissions%2F818%2Fedit',
+    );
+  });
+
+  it('carries the query string too', () => {
+    window.history.replaceState(null, '', '/courses/8/submissions/818?step=2');
+
+    expect(getNotFoundURL()).toBe(
+      '/404?from=%2Fcourses%2F8%2Fsubmissions%2F818%3Fstep%3D2',
+    );
+  });
+});
+
+describe('getNotFoundSourceURL', () => {
+  it('reads back the address a redirect carried', () => {
+    window.history.replaceState(null, '', '/courses/8/submissions/818?step=2');
+
+    expect(getNotFoundSourceURL(`http://localhost${getNotFoundURL()}`)).toBe(
+      '/courses/8/submissions/818?step=2',
+    );
+  });
+
+  it('is null when there is none, as on the route catch-all', () => {
+    expect(
+      getNotFoundSourceURL('http://localhost/courses/8/nonsense'),
+    ).toBeNull();
+  });
+
+  // Handed straight to `history.replaceState`, so a crafted `from` must not be able to rewrite the
+  // address bar to another origin.
+  it('reduces an off-origin address to a path on this one', () => {
+    expect(
+      getNotFoundSourceURL(
+        'http://localhost/404?from=https%3A%2F%2Fevil.test%2Fx',
+      ),
+    ).toBe('/x');
+  });
+});

--- a/client/app/lib/hooks/router/redirect.tsx
+++ b/client/app/lib/hooks/router/redirect.tsx
@@ -51,8 +51,21 @@ export const redirectToSuspended = (): void => {
   window.location.href = url.pathname + url.search;
 };
 
+// Carries the address it was called from, the way `redirectToForbidden` and `redirectToSuspended` do.
+// The not-found page is standalone, so reaching it means leaving the page that 404ed; without the
+// source URL the viewer is shown `/404` instead of the address they actually asked for, which the
+// route catch-all — every other way of reaching this page — never does.
+//
+// Split from the assignment like `getForbiddenURL` so the URL it builds can be asserted on: jsdom
+// forbids stubbing `window.location`, so a test cannot observe the assignment itself.
+export const getNotFoundURL = (): string => {
+  const url = new URL('/404', window.location.origin);
+  url.searchParams.append(FORBIDDEN_SOURCE_URL_SEARCH_PARAM, getCurrentURL());
+  return url.pathname + url.search;
+};
+
 export const redirectToNotFound = (): void => {
-  window.location.href = '/404';
+  window.location.href = getNotFoundURL();
 };
 
 export const getForbiddenSourceURL = (rawURL: string): string | null => {
@@ -63,6 +76,17 @@ export const getForbiddenSourceURL = (rawURL: string): string | null => {
 export const getSuspendedSourceURL = (rawURL: string): string | null => {
   const url = new URL(rawURL);
   return url.searchParams.get(FORBIDDEN_SOURCE_URL_SEARCH_PARAM);
+};
+
+// Parsed defensively, unlike its two siblings: the not-found page hands this straight to
+// `history.replaceState`, and `defensivelyParseURL` reduces whatever arrives to a path on this
+// origin, so a crafted `?from=` cannot rewrite the address bar to somewhere else.
+export const getNotFoundSourceURL = (rawURL: string): string | null => {
+  const sourceURL = new URL(rawURL).searchParams.get(
+    FORBIDDEN_SOURCE_URL_SEARCH_PARAM,
+  );
+
+  return sourceURL && defensivelyParseURL(sourceURL);
 };
 
 /**

--- a/client/app/routers/course/__tests__/assessmentSubmissionRoutes.test.tsx
+++ b/client/app/routers/course/__tests__/assessmentSubmissionRoutes.test.tsx
@@ -1,0 +1,101 @@
+import {
+  matchRoutes,
+  MemoryRouter,
+  RouteObject,
+  useLocation,
+  useRoutes,
+} from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+
+import submissionsRouter from '../assessments/submissions';
+import courseRouter from '../index';
+
+const t = ((descriptor: { defaultMessage?: string }): string =>
+  descriptor.defaultMessage ?? '') as Parameters<typeof courseRouter>[0];
+
+const matchedLeaf = (pathname: string): RouteObject | undefined =>
+  matchRoutes([courseRouter(t)], pathname)?.at(-1)?.route;
+
+const matchedPaths = (pathname: string): (string | undefined)[] | null =>
+  matchRoutes([courseRouter(t)], pathname)?.map(({ route }) => route.path) ??
+  null;
+
+// The real router, with only the redirect's destination stubbed out, so the assertion is about our
+// index route and our relative `to` rather than about a hand-built fixture. Mounting the genuine
+// `edit` leaf would pull in the whole submission page.
+const routerWithStubbedEditPage = (): RouteObject => {
+  const route = submissionsRouter(t);
+  const submission = route.children?.find(
+    (child) => child.path === ':submissionId',
+  );
+  const edit = submission?.children?.find((child) => child.path === 'edit');
+
+  if (!edit) throw new Error('The :submissionId/edit route is missing.');
+
+  delete edit.lazy;
+  edit.element = <div>edit page</div>;
+
+  return route;
+};
+
+// `useRoutes` rather than `createMemoryRouter`: the data router needs the fetch API globals, which
+// jsdom does not define and which nothing in this suite's setup polyfills. It consumes the same route
+// objects, and `Navigate`'s relative resolution — the thing under test — is identical either way.
+const RoutedApp = (): JSX.Element | null =>
+  useRoutes([
+    {
+      path: 'courses/:courseId/assessments/:assessmentId',
+      children: [routerWithStubbedEditPage()],
+    },
+  ]);
+
+const Pathname = (): JSX.Element => (
+  <div data-testid="pathname">{useLocation().pathname}</div>
+);
+
+describe('assessment submission routes', () => {
+  it('matches a submission page', () => {
+    expect(
+      matchedPaths('/courses/7/assessments/43/submissions/8183/edit'),
+    ).toEqual([
+      'courses/:courseId',
+      'assessments',
+      ':assessmentId',
+      'submissions',
+      ':submissionId',
+      'edit',
+    ]);
+  });
+
+  // `/submissions/:id` is not a page of its own — the Rails resource has no `show`, and every
+  // submission link the app builds is an `edit_..._path`. It used to match the `:submissionId` route
+  // itself, which had children but no index: React Router treats a parent with a path as its own
+  // branch, so the URL rendered that route's empty default outlet — the course shell with a blank
+  // content area, for any id, real or invented. An index route both removes the dead end and gives the
+  // bare URL the meaning it should have had.
+  it.each([
+    '/courses/7/assessments/43/submissions/8183',
+    '/courses/7/assessments/43/submissions/8183/',
+    '/courses/7/assessments/43/submissions/818',
+  ])('resolves %s to an index route rather than a dead end', (pathname) => {
+    expect(matchedLeaf(pathname)?.index).toBe(true);
+  });
+
+  // Whether the id exists, and whether this viewer may open it, is the backend's call once we are on
+  // `edit`: an id outside this assessment 404s, someone else's submission 403s, and your own renders.
+  it('redirects a bare submission url to its edit page', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={['/courses/7/assessments/43/submissions/8183']}
+      >
+        <RoutedApp />
+        <Pathname />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('edit page')).toBeInTheDocument();
+    expect(screen.getByTestId('pathname').textContent).toBe(
+      '/courses/7/assessments/43/submissions/8183/edit',
+    );
+  });
+});

--- a/client/app/routers/course/assessments/submissions.tsx
+++ b/client/app/routers/course/assessments/submissions.tsx
@@ -1,4 +1,4 @@
-import { RouteObject } from 'react-router-dom';
+import { Navigate, RouteObject } from 'react-router-dom';
 import { WithRequired } from 'types';
 
 import { Translated } from 'lib/hooks/useTranslation';
@@ -25,6 +25,11 @@ const submissionsRouter: Translated<RouteObject> = (_) => ({
     {
       path: ':submissionId',
       children: [
+        // Load-bearing: React Router makes a parent that has a path a matchable branch of its own, so
+        // without a child here `/submissions/:id` rendered this route's empty default outlet. `edit` is
+        // also the bare URL's right meaning — the Rails resource has no `show`, and every submission
+        // link the app builds is an `edit_course_assessment_submission_path`.
+        { index: true, element: <Navigate replace to="edit" /> },
         {
           path: 'edit',
           lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => {

--- a/client/app/types/home.ts
+++ b/client/app/types/home.ts
@@ -25,4 +25,8 @@ export interface HomeLayoutData {
   timeZone: string | null;
   courses?: HomeLayoutCourseData[];
   user?: HomeLayoutUserData;
+  // Whether the marketplace sandbox's read-only lock applies to THIS viewer. The courseless
+  // counterpart to `CourseLayoutData.isPreviewRestricted`, for shells that cannot read it off a
+  // course. False for a system administrator, who curates the preview container from inside it.
+  isPreviewRestricted?: boolean;
 }

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -15,3 +15,12 @@ user_email_database_cleanup_job:
   cron: '0 0 1 * *'
   class: 'UserEmailDatabaseCleanupJob'
   queue: 'default'
+
+# Reap aged marketplace preview submissions every Sunday at 21:20 UTC, 5:20 AM SGT Monday. The TTL
+# is enforced in the job, not the cron, so this interval sets only how long past the TTL a submission
+# may linger — not how long it is kept. Previewers do not wait on it to start over; the preview
+# banner's "Reset submission" button clears an attempt on demand.
+preview_submission_reaping_job:
+  cron: '20 21 * * 0'
+  class: 'Course::Assessment::Marketplace::PreviewSubmissionReapingJob'
+  queue: 'default'

--- a/spec/controllers/course/assessment/submission/submissions_preview_autograding_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_preview_autograding_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+# The marketplace preview sandbox needs the finalise response to carry the auto-grading job it just
+# enqueued, so the preview page can poll it and show the marks without a manual refresh. The job is
+# created by an `after_commit` hook that fires during the finalising `save` — i.e. before the
+# controller renders — so it is available to the view; these examples pin that down, and pin down
+# that the key leaks nowhere else.
+RSpec.describe Course::Assessment::Submission::SubmissionsController, type: :controller do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    with_active_job_queue_adapter(:test) do
+      render_views
+
+      let(:previewer) { create(:user) }
+      let(:assessment) { create(:assessment, :published, :with_mcq_question, course: course) }
+      let!(:course_user) { create(:course_manager, course: course, user: previewer) }
+      let!(:submission) do
+        create(:submission, :attempting, assessment: assessment, course: course, creator: previewer)
+      end
+
+      before { controller_sign_in(controller, previewer) }
+
+      def finalise!
+        patch :update, params: {
+          course_id: course, assessment_id: assessment, id: submission,
+          submission: { finalise: true }, format: :json
+        }
+      end
+
+      context 'when the course is a marketplace preview sandbox' do
+        let(:course) { create(:course, preview: true) }
+
+        it 'exposes the url of the auto-grading job this request enqueued' do
+          finalise!
+
+          expect(response).to have_http_status(:ok)
+
+          job_url = response.parsed_body['submission']['autoGradingJobUrl']
+          expect(job_url).to match(/\A\/jobs\/[0-9a-f-]{36}\z/)
+          expect(TrackableJob::Job.find(job_url.split('/').last)).to be_present
+        end
+
+        it 'does not expose the key on a plain edit, which enqueues nothing' do
+          get :edit, params: { course_id: course, assessment_id: assessment, id: submission, format: :json }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['submission']).not_to have_key('autoGradingJobUrl')
+        end
+      end
+
+      context 'when the course is an ordinary course' do
+        let(:course) { create(:course) }
+
+        it 'does not expose the key, even though a job was still enqueued' do
+          finalise!
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['submission']).not_to have_key('autoGradingJobUrl')
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/course/assessment/marketplace/preview_submission_reaping_job_spec.rb
+++ b/spec/jobs/course/assessment/marketplace/preview_submission_reaping_job_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Marketplace::PreviewSubmissionReapingJob, type: :job do
+  # Own instance: at most one `preview: true` course may exist per instance, and the job runs
+  # `without_tenant`, so it reaps this course's submissions wherever the course lives.
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:ttl) { described_class::PREVIEW_SUBMISSION_TTL }
+
+    subject { described_class.perform_now }
+
+    # `update_column` bypasses `updated_at`'s own touch, unlike `update!`/`touch`.
+    def age!(submission, ago:)
+      submission.update_column(:updated_at, ago)
+    end
+
+    context 'a preview submission older than the TTL' do
+      let!(:preview_course) { create(:course, preview: true) }
+      let!(:preview_assessment) { create(:assessment, :with_mcq_question, course: preview_course) }
+      let!(:previewer) { create(:user) }
+      let!(:aged_submission) do
+        submission = create(:submission, :attempting, assessment: preview_assessment,
+                                                      course: preview_course, creator: previewer)
+        age!(submission, ago: (ttl + 1.hour).ago)
+        submission
+      end
+
+      it 'reaps the aged preview submission' do
+        expect { subject }.
+          to change { Course::Assessment::Submission.exists?(aged_submission.id) }.from(true).to(false)
+      end
+
+      it 'cascades: the reaped submission\'s answers are destroyed too' do
+        expect { subject }.
+          to change { Course::Assessment::Answer.where(submission_id: aged_submission.id).exists? }.
+          from(true).to(false)
+      end
+
+      it 'leaves the preview course, the assessment, and the enrolment alone' do
+        subject
+
+        expect(Course.exists?(preview_course.id)).to be(true)
+        expect(Course::Assessment.exists?(preview_assessment.id)).to be(true)
+        expect(preview_course.course_users.exists?(user_id: previewer.id)).to be(true)
+      end
+    end
+
+    context 'a preview submission within the TTL grace period' do
+      let!(:preview_course) { create(:course, preview: true) }
+      let!(:preview_assessment) { create(:assessment, :with_mcq_question, course: preview_course) }
+      let!(:previewer) { create(:user) }
+      let!(:fresh_submission) do
+        create(:submission, :attempting, assessment: preview_assessment,
+                                         course: preview_course, creator: previewer)
+      end
+
+      it 'spares the submission' do
+        expect { subject }.
+          not_to(change { Course::Assessment::Submission.exists?(fresh_submission.id) })
+      end
+    end
+
+    # The highest-value example: proves the job scopes to `preview: true` courses rather than
+    # reaping any old submission it finds.
+    context 'a NON-preview submission of the same age' do
+      let!(:normal_course) { create(:course) }
+      let!(:normal_assessment) { create(:assessment, :with_mcq_question, course: normal_course) }
+      let!(:normal_user) { create(:user) }
+      let!(:aged_normal_submission) do
+        submission = create(:submission, :attempting, assessment: normal_assessment,
+                                                      course: normal_course, creator: normal_user)
+        age!(submission, ago: (ttl + 1.hour).ago)
+        submission
+      end
+
+      it 'spares the non-preview submission' do
+        expect { subject }.
+          not_to(change { Course::Assessment::Submission.exists?(aged_normal_submission.id) })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Second of two PRs split out of #8527, stacked on pr8a. pr8a landed a working hands-on preview; this adds what the flow needs to survive real use over time.

A previewer has no grader colleague to refresh the page for them, so finalising a preview submission now hands back the auto-marking job it just enqueued and a preview-only banner polls it, refreshing the marks in place. The publish toast is reworded for the sandbox, where "students can now see their grades" is false. A submission that no longer exists renders a usable not-found page instead of an error, which is also how the preview banner learns its sandbox was purged mid-poll. Finally, preview attempts age out on a TTL so the sandbox does not accumulate dead rows.

## Design decisions

- The finalise response hands back the auto-marking job it just enqueued instead of exposing a new endpoint, because the job object already exists in-process by the time the controller renders. The poller lives in the banner's own effect rather than the submission page's, since that page is a class component and the shared fire-and-forget poll helper orphans pollers across navigation. Platform-wide auto-refresh is a follow-up.
- Relaunching resumes an existing attempt rather than resetting it, and attempts are cleared by a TTL keyed on last activity. One submission per (assessment, previewer) is already enforced by a unique index, and keying the reaper on `updated_at` means an in-progress rehearsal is never reaped out from under someone and async auto-marking has time to land. The reaper only ever removes submissions: the container course, the snapshot copies and the enrolments are deliberately persistent and reused.
- The reaper runs weekly, not hourly, which makes the 24-hour TTL a floor rather than a ceiling - an aged attempt can linger up to a week past it. That slack is affordable precisely because "Reset submission" exists: a previewer never waits on the reaper to start over, so the only thing the interval controls is how promptly dead rows leave the sandbox. It does mean the per-run deletion cap now bounds a week's reaping rather than an hour's, so the cron is what to raise first if preview volume ever outgrows it.
- The 404 is a separate thunk rather than folded into `fetchSubmission`, because the preview banner refetches through `fetchSubmission` and reads the very same 404 as a purged sandbox. One shared handler cannot serve both readings, so `fetchSubmission` gained an optional error callback and the routing case got its own path.

## Regression prevention

Backend covers: the auto-marking job url appearing only in a preview course and only on the request that finalised; and the reaper's TTL, batch cap, and leaving the container course, the snapshot copies and the enrolments intact.

Frontend covers: the auto-marking banner's poll-to-settle path, its timeout ceiling, the purged-sandbox case reading as gone rather than "refresh", and teardown on unmount; the preview-specific publish toast; and a missing submission routing to the not-found page.

Manually verified: finalise refreshing marks in place without a manual refresh; the preview publish toast; a mid-poll listing purge reading as no longer available; and the reaper removing only aged submissions.

Nothing changes for existing courses: the banner, toast wording and reaper are all gated on the sandbox course's `preview` flag. The submission publish and refetch actions gained optional trailing arguments that are inert when omitted.
