### PR TITLE
fix(users): unblock sign up when the invitation carries an external ID

### DIFF
--- a/app/models/concerns/course/unique_external_id_concern.rb
+++ b/app/models/concerns/course/unique_external_id_concern.rb
@@ -7,6 +7,12 @@ module Course::UniqueExternalIdConcern
   extend ActiveSupport::Concern
 
   included do
+    # The invitation this record is being created from, if any. A record inheriting its external ID
+    # from the invitation that created it is not a conflict, so that invitation is excluded from the
+    # uniqueness check. Callers that set this must confirm or destroy the invitation in the same
+    # transaction, otherwise the two records are left sharing an external ID.
+    attr_accessor :source_invitation
+
     before_validation :normalize_external_id
 
     validate :validate_unique_external_id_within_course, if: -> { new_record? || external_id_changed? }
@@ -35,6 +41,7 @@ module Course::UniqueExternalIdConcern
   def external_id_taken_by_invitation?
     query = Course::UserInvitation.unconfirmed.where(course_id: course_id, external_id: external_id)
     query = query.where.not(id: id) if is_a?(Course::UserInvitation)
+    query = query.where.not(id: source_invitation.id) if source_invitation&.persisted?
     query.exists?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,6 +166,7 @@ class User < ApplicationRecord
                        timeline_algorithm: invitation.timeline_algorithm ||
                           invitation.course&.default_timeline_algorithm,
                        external_id: invitation.external_id.presence,
+                       source_invitation: invitation,
                        creator: self,
                        updater: self)
   end

--- a/spec/controllers/user/registration_controller_spec.rb
+++ b/spec/controllers/user/registration_controller_spec.rb
@@ -154,6 +154,51 @@ RSpec.describe User::RegistrationsController, type: :controller do
           end
         end
       end
+
+      context 'when signing up through a course invitation' do
+        requires_login
+
+        let(:course) { create(:course) }
+        let(:email) { generate(:email) }
+        let!(:invitation) do
+          create(:course_user_invitation, course: course, email: email, external_id: external_id)
+        end
+
+        before { allow(controller).to receive(:verify_recaptcha).and_return(true) }
+
+        subject do
+          post :create, params: {
+            invitation: invitation.invitation_key,
+            user: { name: 'New Student', email: email,
+                    password: 'lolololol', password_confirmation: 'lolololol' }
+          }
+        end
+
+        shared_examples 'a successful enrolment' do
+          it 'creates the user, enrols them once and confirms the invitation' do
+            expect { subject }.to change(User, :count).by(1).and change(CourseUser, :count).by(1)
+
+            new_user = User.order(:created_at).last
+            course_user = CourseUser.find_by(course: course, user: new_user)
+            expect(course_user).to be_present
+            expect(course_user.external_id).to eq(external_id)
+            expect(invitation.reload).to be_confirmed
+            expect(invitation.confirmer).to eq(new_user)
+          end
+        end
+
+        context 'when the invitation has no external_id' do
+          let(:external_id) { nil }
+
+          it_behaves_like 'a successful enrolment'
+        end
+
+        context 'when the invitation has an external_id' do
+          let(:external_id) { 'A0123456X' }
+
+          it_behaves_like 'a successful enrolment'
+        end
+      end
     end
   end
 end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -137,6 +137,36 @@ RSpec.describe CourseUser, type: :model do
           expect(student).to be_valid
         end
       end
+
+      context 'when the course user is created from an invitation' do
+        let!(:invitation) { create(:course_user_invitation, course: course, external_id: 'invited-id') }
+
+        # The invitation is confirmed in the same transaction that saves the course user, so a course
+        # user inheriting its external_id is not a conflict with the invitation it came from.
+        it 'is valid despite the still-unconfirmed invitation holding the same external_id' do
+          student = build(:course_student, course: course, external_id: 'invited-id',
+                                           source_invitation: invitation)
+          expect(student).to be_valid
+        end
+
+        it 'is still invalid when a different pending invitation holds the external_id' do
+          other_invitation = create(:course_user_invitation, course: course, external_id: 'other-id')
+          student = build(:course_student, course: course, external_id: other_invitation.external_id,
+                                           source_invitation: invitation)
+          expect(student).not_to be_valid
+          expect(student.errors[:external_id]).
+            to include(I18n.t('activerecord.errors.models.course_user.attributes.external_id.taken'))
+        end
+
+        it 'is still invalid when an enrolled course user holds the external_id' do
+          existing = create(:course_student, course: course, external_id: 'enrolled-id')
+          student = build(:course_student, course: course, external_id: existing.external_id,
+                                           source_invitation: invitation)
+          expect(student).not_to be_valid
+          expect(student.errors[:external_id]).
+            to include(I18n.t('activerecord.errors.models.course_user.attributes.external_id.taken'))
+        end
+      end
     end
 
     describe '.staff' do


### PR DESCRIPTION
## Bug

Students invited to a course with an external ID could not create an account. Submitting the sign-up form returned a generic error toast and no account was created. Nothing appeared in error reporting, because no exception is ever raised — the save simply returns `false`.

`Course::UniqueExternalIdConcern` rejects an external ID already claimed by an unconfirmed invitation in the same course, and excludes the record under validation from that query **only when the record is itself an invitation**:

```ruby
def external_id_taken_by_invitation?
  query = Course::UserInvitation.unconfirmed.where(course_id: course_id, external_id: external_id)
  query = query.where.not(id: id) if is_a?(Course::UserInvitation)
  query.exists?
end
```

A `CourseUser` created from an invitation inherits that invitation's `external_id`, so it collides with **its own invitation** — unless the invitation has already been confirmed by the time the `CourseUser` is validated. Three paths create a `CourseUser` from an invitation, and they order those two steps differently:

| creation path | invitation confirmed | outcome |
|---|---|---|
| `Course::UserRegistrationService#accept_invitation` | before the `CourseUser` is built | ok |
| `User::Email#accept_all_pending_invitations` | before the `CourseUser` is built | ok |
| `User::RegistrationsController#create` | after `resource.save` returns | **rejected** |

The first two dodge the defect deliberately — `User::Email` even carries a comment naming this exact hazard:

```ruby
# Confirm the invitation before saving the CourseUser so that the
# UniqueExternalIdConcern validation doesn't reject the new CourseUser
# for sharing an external_id with what is now a confirmed invitation.
```

The sign-up path cannot dodge it by reordering. `build_resource` calls `User#build_from_invitation`, which builds the `CourseUser` onto the unsaved `User`; `has_many :course_users` autosave-validates it during `user.valid?`, which precedes **every** `after_save`. The controller's `@invitation.confirm!` runs after `super` returns, and `User::Email`'s hook fires during the save — both too late. Confirming earlier is not available either: `confirm!` sets `confirmer` to a `User` that does not yet have an id.

**What the client sees.** `resource.save` returns `false`, Devise responds `200` with an empty body, and `SignUpPage` falls through its `!result.id` branch to a generic `errorSigningUp` toast. The `422` branch that renders per-field errors is never reached, so the underlying message — `activerecord.attributes.user.course_users is invalid`, an unresolved i18n key on an association the form does not render — would not have helped even if it had been surfaced.

**Trigger conditions.** Both must hold, which is why this presented as affecting a minority rather than everyone:

* **The invitation carries a non-blank `external_id`.** Blank is normalised to `nil` before validation and `nil` returns early, so invitations predating the feature are unaffected.
* **The invitee has no Coursemology account yet.** Invited users who already have one enrol through `UserRegistrationService` or the `User::Email` hook, both safe.

Within those conditions the failure is total, not intermittent.

**Regression window.** Introduced with the concern itself in `4b4647885` (_"feat(users): add optional external_id field to course members and invitations"_, 14 May 2026). The partial unique indexes added in the same commit never caught it — they are per-table, and this is a cross-table check that exists only in application code.

## Remediation

Let a record declare the invitation it is being created from, and exclude that one invitation from the uniqueness query:

```ruby
# Course::UniqueExternalIdConcern
attr_accessor :source_invitation

def external_id_taken_by_invitation?
  query = Course::UserInvitation.unconfirmed.where(course_id: course_id, external_id: external_id)
  query = query.where.not(id: id) if is_a?(Course::UserInvitation)
  query = query.where.not(id: source_invitation.id) if source_invitation&.persisted?
  query.exists?
end
```

`User#build_course_user_from_invitation` — the shared builder behind both the sign-up path and the `User::Email` hook — passes `source_invitation: invitation`.

The exclusion is deliberately narrow. It removes exactly one row from one of the two queries; a different pending invitation or an already-enrolled course user holding the same external ID still fails validation, and `external_id_taken_by_course_user?` is untouched. `source_invitation` is a plain `attr_accessor`, not an ActiveRecord attribute: it has no column, is never persisted or serialised, and appears in no `permit` list, so it cannot be set from a request.

## Scope check

Audited every site that writes `external_id` or creates a `CourseUser` from an invitation.

1. `Course::UserRegistrationService#find_or_create_course_user!` — confirms before building, so it never needed the exclusion. **Left unchanged**; setting `source_invitation` here too would guard against a future reordering of those two lines, at the cost of threading the invitation through `create_course_user_record!`.

2. `User::Email#accept_all_pending_invitations` — confirms before building. Now also receives `source_invitation` via the shared builder, which is redundant but harmless: by then the invitation is confirmed and already outside the `unconfirmed` scope.

3. `Course::UserInvitationService` (parse/process concerns) — tracks collisions itself through an in-memory `@taken_external_ids` set and never creates a `CourseUser` from an invitation record. Untouched.

4. `Course::UsersControllerManagementConcern` — permits `:external_id` on update. Unaffected; those records have no `source_invitation`, so the full check applies.

No DB migration. The partial unique indexes on `course_users` and `course_user_invitations` are unchanged and continue to backstop the per-table cases.

## Tests

Five examples, all of which fail with the fix reverted and pass with it.

`registration_controller_spec.rb` gains sign-up-through-a-course-invitation coverage, parameterised over `external_id` nil and present, asserting the user is created, the `CourseUser` carries the external ID, and the invitation is confirmed by the new user. It asserts `CourseUser.count` changes by exactly **1**, so a future change that lets both the eager build and the `User::Email` hook enrol the same user would be caught rather than silently double-enrolling.

`course_user_spec.rb` pins the narrowness of the exclusion at the model level — valid against its own invitation, still invalid against a different pending invitation, still invalid against an enrolled course user. These live at model level by necessity: the conflicting state cannot be constructed through the controller, because the invitation's own validation prevents any other record from taking its external ID in the first place.

Unrelated: `user_registration_service_spec.rb:42` fails on `master` as well, a background-job deserialisation race in `BackgroundThreadAdapter`. Not introduced here.
