### PR TITLE
Rails upgrade: replace after_commit_action gem with ActiveRecord.after_all_transactions_commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,6 @@ gem 'workflow'
 gem 'workflow-activerecord', '>= 4.1', '< 7.0'
 # Add creator_id and updater_id attributes to models
 gem 'activerecord-userstamp', git: 'https://github.com/Coursemology/activerecord-userstamp.git'
-# Allow actions to be deferred until after a record is committed.
-gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 # Upstream v1.1.1 (supports Rails 7.0/7.1/7.2/8.0); retires the Coursemology fork.
 # TODO: bump to upstream master (v1.2.0) for Rails 8.1 during that upgrade — v1.1.1 ships no 8.1 patch.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,9 +140,6 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
-    after_commit_action (1.1.0)
-      activerecord (>= 3.0.0)
-      activesupport (>= 3.0.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1271.0)
@@ -662,7 +659,6 @@ DEPENDENCIES
   activerecord-import (>= 0.2.0)
   activerecord-userstamp!
   acts_as_tenant
-  after_commit_action
   aws-sdk-cloudwatch
   aws-sdk-core
   aws-sdk-s3

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -36,7 +36,7 @@ class Course::EnrolRequestsController < Course::ComponentController
     @enrol_request.transaction do
       course_user = @enrol_request.create_course_user(course_user_params)
       if course_user.persisted? && @enrol_request.update(approve: true)
-        @enrol_request.execute_after_commit { Course::Mailer.user_added_email(course_user).deliver_later }
+        ActiveRecord.after_all_transactions_commit { Course::Mailer.user_added_email(course_user).deliver_later }
         approve_success
       else
         approve_failure(course_user)
@@ -47,7 +47,7 @@ class Course::EnrolRequestsController < Course::ComponentController
 
   def reject
     if @enrol_request.update(reject: true)
-      @enrol_request.execute_after_commit do
+      ActiveRecord.after_all_transactions_commit do
         Course::Mailer.user_rejected_email(current_course, @enrol_request.user).deliver_later
       end
       reject_success

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -188,7 +188,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
                   submission_graded_email_enabled? &&
                   submission_graded_email_subscribed?
 
-    execute_after_commit { Course::Mailer.submission_graded_email(self).deliver_later }
+    ActiveRecord.after_all_transactions_commit { Course::Mailer.submission_graded_email(self).deliver_later }
   end
 
   def submission_graded_email_enabled?

--- a/app/models/concerns/course/closing_reminder_concern.rb
+++ b/app/models/concerns/course/closing_reminder_concern.rb
@@ -23,7 +23,7 @@ module Course::ClosingReminderConcern
 
     return unless new_end_at && (new_end_at > Time.zone.now)
 
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       # Send notification one day before the closing date
       closing_reminder_job_class.set(wait_until: new_end_at - 1.day).
         perform_later(self, closing_reminder_token)

--- a/app/models/concerns/course/opening_reminder_concern.rb
+++ b/app/models/concerns/course/opening_reminder_concern.rb
@@ -33,7 +33,7 @@ module Course::OpeningReminderConcern
     # Determine whether or not to send the opening reminder.
     send_opening_reminder = start_at && should_send_opening_reminder
 
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       if send_opening_reminder
         opening_reminder_job_class.set(wait_until: start_at).
           perform_later(updater, self, opening_reminder_token)
@@ -44,7 +44,7 @@ module Course::OpeningReminderConcern
   # Determines whether the opening reminder should be sent. Reminders always should be sent unless
   # the start_at and the old start_at dates are both in the past.
   #
-  # Note: This should be invoked outside of the +execute_after_commit+ block, as
+  # Note: This should be invoked outside of the +ActiveRecord.after_all_transactions_commit+ block, as
   # ActiveRecord::Dirty methods and attributes are not applied as the record has been saved.
   #
   # @return [Boolean] True if an opening reminder should be sent

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -162,7 +162,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   end
 
   def create_or_update_codaveri_problem
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       import_job =
         Course::Assessment::Question::CodaveriImportJob.perform_later(self, attachment)
       update_column(:import_job_id, import_job.job_id)
@@ -196,7 +196,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   end
 
   def evaluate_package
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       import_job =
         Course::Assessment::Question::ProgrammingImportJob.perform_later(self, attachment, max_time_limit)
       update_column(:import_job_id, import_job.job_id)
@@ -211,7 +211,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     new_attachment = attachment
     restore_attachment_change
 
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       new_attachment.save!
       import_job =
         Course::Assessment::Question::ProgrammingImportJob.perform_later(self, new_attachment, max_time_limit)

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -350,7 +350,7 @@ class Course::Assessment::Submission < ApplicationRecord
   def auto_grade_submission
     return unless saved_change_to_workflow_state?
 
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       # Grade only ungraded answers regardless of state as we dont want to regrade graded/evaluated answers.
       auto_grade!(only_ungraded: true)
     end
@@ -361,7 +361,7 @@ class Course::Assessment::Submission < ApplicationRecord
   def retrieve_codaveri_feedback
     return unless saved_change_to_workflow_state?
 
-    execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       auto_feedback!
     end
   end

--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -43,7 +43,7 @@ class Course::Condition::Achievement < ApplicationRecord
   def self.on_dependent_status_change(achievement)
     return unless achievement.saved_changes.any? || achievement.destroyed?
 
-    achievement.execute_after_commit { evaluate_conditional_for(achievement.course_user) }
+    ActiveRecord.after_all_transactions_commit { evaluate_conditional_for(achievement.course_user) }
   end
 
   def initialize_duplicate(duplicator, other)

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -56,7 +56,7 @@ class Course::Condition::Assessment < ApplicationRecord
     return unless submission.saved_changes.key?(:workflow_state) ||
                   submission.saved_changes.key?(:last_graded_time)
 
-    submission.execute_after_commit do
+    ActiveRecord.after_all_transactions_commit do
       evaluate_conditional_for(submission.course_user)
     end
   end

--- a/app/models/course/condition/level.rb
+++ b/app/models/course/condition/level.rb
@@ -39,6 +39,6 @@ class Course::Condition::Level < ApplicationRecord
   def self.on_dependent_status_change(record)
     return unless record.saved_changes.key?(:points_awarded)
 
-    record.execute_after_commit { evaluate_conditional_for(record.course_user) }
+    ActiveRecord.after_all_transactions_commit { evaluate_conditional_for(record.course_user) }
   end
 end

--- a/app/models/course/condition/survey.rb
+++ b/app/models/course/condition/survey.rb
@@ -41,7 +41,7 @@ class Course::Condition::Survey < ApplicationRecord
   def self.on_dependent_status_change(response)
     return unless response.saved_changes.key?(:submitted_at)
 
-    response.execute_after_commit { evaluate_conditional_for(response.course_user) }
+    ActiveRecord.after_all_transactions_commit { evaluate_conditional_for(response.course_user) }
   end
 
   def initialize_duplicate(duplicator, other)

--- a/app/models/course/condition/video.rb
+++ b/app/models/course/condition/video.rb
@@ -53,7 +53,7 @@ class Course::Condition::Video < ApplicationRecord
   end
 
   def self.on_dependent_status_change(submission)
-    submission.execute_after_commit { evaluate_conditional_for(submission.course_user) }
+    ActiveRecord.after_all_transactions_commit { evaluate_conditional_for(submission.course_user) }
   end
 
   def initialize_duplicate(duplicator, other)

--- a/lib/autoload/notifier/base/activity_wrapper.rb
+++ b/lib/autoload/notifier/base/activity_wrapper.rb
@@ -29,6 +29,6 @@ class Notifier::Base::ActivityWrapper < SimpleDelegator
   private
 
   def send_pending_email
-    execute_after_commit { @notifier.send(:send_pending_emails) }
+    ActiveRecord.after_all_transactions_commit { @notifier.send(:send_pending_emails) }
   end
 end

--- a/lib/autoload/trackable_job.rb
+++ b/lib/autoload/trackable_job.rb
@@ -34,7 +34,7 @@ module TrackableJob
     def signal_finished
       return unless saved_change_to_status?
 
-      execute_after_commit { signal }
+      ActiveRecord.after_all_transactions_commit { signal }
     end
 
     def job_in_sidekiq?

--- a/lib/extensions/after_commit_action.rb
+++ b/lib/extensions/after_commit_action.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-module Extensions::AfterCommitAction; end
-ActiveRecord::Base.class_eval do
-  include AfterCommitAction
-end

--- a/lib/extensions/conditional/active_record/base.rb
+++ b/lib/extensions/conditional/active_record/base.rb
@@ -144,7 +144,7 @@ module Extensions::Conditional::ActiveRecord::Base
     private
 
     def on_condition_change
-      execute_after_commit { rebuild_satisfiability_graph(course) }
+      ActiveRecord.after_all_transactions_commit { rebuild_satisfiability_graph(course) }
     end
 
     # Rebuild the satisfiability graph for the given course.

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           expect(response.status).to eq(200)
         end
 
-        context 'when other users are subscribed to notifications', type: :mailer do
+        context 'when other users are subscribed to notifications', :sidekiq_same_thread, type: :mailer do
           let(:annotation) do
             create(:course_assessment_answer_programming_file_annotation, file: file, line: 1)
           end
@@ -64,13 +64,13 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           end
 
           it 'sends email notifications' do
-            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+            expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(1)
           end
 
           context 'when the new comment is posted as delayed post' do
             let!(:workflow_state) { 'delayed' }
             it 'does not send email notifications' do
-              expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+              expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end
           end
 
@@ -85,7 +85,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
             end
 
             it 'does not send email notifications' do
-              expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+              expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end
           end
         end

--- a/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
           expect { subject }.to change(Course::Discussion::Post, :count).by(1)
         end
 
-        context 'when other users are subscribed to notifications', type: :mailer do
+        context 'when other users are subscribed to notifications', :sidekiq_same_thread, type: :mailer do
           let!(:subscriber) do
             user = create(:course_manager, course: course).user
             submission_question.acting_as.subscriptions.create!(user: user)
@@ -56,13 +56,13 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
           end
 
           it 'sends email notifications' do
-            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+            expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(1)
           end
 
           context 'when the new comment is posted as delayed post' do
             let!(:workflow_state) { 'delayed' }
             it 'does not send email notifications' do
-              expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+              expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end
           end
 
@@ -78,7 +78,7 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
             end
 
             it 'does not send email notifications' do
-              expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+              expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end
           end
         end

--- a/spec/controllers/course/enrol_requests_controller_spec.rb
+++ b/spec/controllers/course/enrol_requests_controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Course::EnrolRequestsController, type: :controller do
           is_expected.to have_http_status(:ok)
         end
 
-        it 'sends an email notification to course owner', type: :mailer do
-          subject
+        it 'sends an email notification to course owner', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
@@ -126,14 +126,13 @@ RSpec.describe Course::EnrolRequestsController, type: :controller do
           expect(course_user.name).to eq(course_user_params[:name])
         end
 
-        it 'sends an acceptance email notification', type: :mailer do
-          subject
+        it 'sends an acceptance email notification', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
-          # When enrol request is created, 2 emails are sent (one to enrollee and one to course staff).
-          # When enrol request is approved, 1 email is sent to enrollee.
-          expect(ActionMailer::Base.deliveries.count).to eq(3)
+          # Only the approval's email is delivered here (the request-creation emails from setup are not
+          # run by this block), so assert on that specific email rather than a total count.
           expect(emails).to include(user.email)
           expect(email_subjects).to include('course.mailer.user_added_email.subject')
         end
@@ -173,12 +172,11 @@ RSpec.describe Course::EnrolRequestsController, type: :controller do
           expect(course_user).to be_nil
         end
 
-        it 'sends a rejection email', type: :mailer do
-          subject
+        it 'sends a rejection email', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
-          expect(ActionMailer::Base.deliveries.count).to eq(3)
           expect(emails).to include(user.email)
           expect(email_subjects).to include('course.mailer.user_rejected_email.subject')
         end

--- a/spec/controllers/course/instance_user_role_requests_controller_spec.rb
+++ b/spec/controllers/course/instance_user_role_requests_controller_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe InstanceUserRoleRequestsController, type: :controller do
           expect(JSON.parse(response.body)).to have_key('id')
         end
 
-        it 'sends an email notification to the admin', type: :mailer do
-          subject
+        it 'sends an email notification to the admin', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
@@ -121,8 +121,8 @@ RSpec.describe InstanceUserRoleRequestsController, type: :controller do
           expect(request.reload.workflow_state).to eq('approved')
         end
 
-        it 'sends an approval email notification', type: :mailer do
-          subject
+        it 'sends an approval email notification', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
@@ -151,8 +151,8 @@ RSpec.describe InstanceUserRoleRequestsController, type: :controller do
           expect(request.user.instance_users.first.reload.role).to eq(user.role)
         end
 
-        it 'sends a rejection email', type: :mailer do
-          subject
+        it 'sends a rejection email', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
           email_body = ActionMailer::Base.deliveries.first.
@@ -185,8 +185,8 @@ RSpec.describe InstanceUserRoleRequestsController, type: :controller do
           expect(request.user.instance_users.first.reload.role).to eq(user.role)
         end
 
-        it 'sends a rejection email with the message', type: :mailer do
-          subject
+        it 'sends a rejection email with the message', :sidekiq_same_thread, type: :mailer do
+          perform_sidekiq_jobs { subject }
           emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
           email_subjects = ActionMailer::Base.deliveries.map(&:subject)
           email_body = ActionMailer::Base.deliveries.

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Course::UsersController, type: :controller do
           expect(subject).to have_http_status(:ok)
         end
 
-        it 'does not send a notification email to the user', type: :mailer do
-          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        it 'does not send a notification email to the user', :sidekiq_same_thread, type: :mailer do
+          expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
 
         context 'when the user cannot be saved' do
@@ -211,16 +211,16 @@ RSpec.describe Course::UsersController, type: :controller do
 
         it { is_expected.to have_http_status(:ok) }
 
-        it 'only emails users whose suspension status changed', type: :mailer do
-          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        it 'only emails users whose suspension status changed', :sidekiq_same_thread, type: :mailer do
+          expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(1)
           expect(ActionMailer::Base.deliveries.last.to).to include(active_student.user.email)
         end
 
         context 'when all targeted users are already suspended' do
           let(:target_ids) { [already_suspended.id] }
 
-          it 'sends no emails', type: :mailer do
-            expect { subject }.not_to(change { ActionMailer::Base.deliveries.count })
+          it 'sends no emails', :sidekiq_same_thread, type: :mailer do
+            expect { perform_sidekiq_jobs { subject } }.not_to(change { ActionMailer::Base.deliveries.count })
           end
         end
 
@@ -229,8 +229,8 @@ RSpec.describe Course::UsersController, type: :controller do
 
           it { is_expected.to have_http_status(:bad_request) }
 
-          it 'makes no changes', type: :mailer do
-            expect { subject }.to \
+          it 'makes no changes', :sidekiq_same_thread, type: :mailer do
+            expect { perform_sidekiq_jobs { subject } }.to \
               not_change { active_student.reload.is_suspended }.
               and(not_change { ActionMailer::Base.deliveries.count })
           end
@@ -242,8 +242,8 @@ RSpec.describe Course::UsersController, type: :controller do
 
           it { is_expected.to have_http_status(:bad_request) }
 
-          it 'makes no changes', type: :mailer do
-            expect { subject }.to \
+          it 'makes no changes', :sidekiq_same_thread, type: :mailer do
+            expect { perform_sidekiq_jobs { subject } }.to \
               not_change { active_student.reload.is_suspended }.
               and(not_change { other_course_user.reload.is_suspended }).
               and(not_change { ActionMailer::Base.deliveries.count })
@@ -282,16 +282,16 @@ RSpec.describe Course::UsersController, type: :controller do
 
         it { is_expected.to have_http_status(:ok) }
 
-        it 'only emails users whose suspension status changed', type: :mailer do
-          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        it 'only emails users whose suspension status changed', :sidekiq_same_thread, type: :mailer do
+          expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(1)
           expect(ActionMailer::Base.deliveries.last.to).to include(suspended_student.user.email)
         end
 
         context 'when all targeted users are already active' do
           let(:target_ids) { [active_student.id] }
 
-          it 'sends no emails', type: :mailer do
-            expect { subject }.not_to(change { ActionMailer::Base.deliveries.count })
+          it 'sends no emails', :sidekiq_same_thread, type: :mailer do
+            expect { perform_sidekiq_jobs { subject } }.not_to(change { ActionMailer::Base.deliveries.count })
           end
         end
 
@@ -300,8 +300,8 @@ RSpec.describe Course::UsersController, type: :controller do
 
           it { is_expected.to have_http_status(:bad_request) }
 
-          it 'makes no changes', type: :mailer do
-            expect { subject }.to \
+          it 'makes no changes', :sidekiq_same_thread, type: :mailer do
+            expect { perform_sidekiq_jobs { subject } }.to \
               not_change { suspended_student.reload.is_suspended }.
               and(not_change { ActionMailer::Base.deliveries.count })
           end
@@ -313,8 +313,8 @@ RSpec.describe Course::UsersController, type: :controller do
 
           it { is_expected.to have_http_status(:bad_request) }
 
-          it 'makes no changes', type: :mailer do
-            expect { subject }.to \
+          it 'makes no changes', :sidekiq_same_thread, type: :mailer do
+            expect { perform_sidekiq_jobs { subject } }.to \
               not_change { suspended_student.reload.is_suspended }.
               and(not_change { other_course_user.reload.is_suspended }).
               and(not_change { ActionMailer::Base.deliveries.count })

--- a/spec/controllers/user/emails_controller_spec.rb
+++ b/spec/controllers/user/emails_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe User::EmailsController, type: :controller do
       end
     end
 
-    describe '#send_confirmation', type: :mailer do
+    describe '#send_confirmation', :sidekiq_same_thread, type: :mailer do
       let!(:email) { create(:user_email, email_traits, user: user, primary: false) }
       subject { post :send_confirmation, params: { id: email } }
 
@@ -56,7 +56,7 @@ RSpec.describe User::EmailsController, type: :controller do
         let(:email_traits) { :confirmed }
 
         it 'does not send any confirmations' do
-          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
 
         it 'sets an error message' do
@@ -70,10 +70,8 @@ RSpec.describe User::EmailsController, type: :controller do
       context 'when the email is not confirmed' do
         let(:email_traits) { :unconfirmed }
 
-        with_active_job_queue_adapter(:test) do
-          it 'sends out a confirmation email' do
-            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
-          end
+        it 'sends out a confirmation email' do
+          expect { perform_sidekiq_jobs { subject } }.to change { ActionMailer::Base.deliveries.count }.by(1)
         end
 
         it { is_expected.to have_http_status(:ok) }

--- a/spec/features/instance_user_role_requests_management_spec.rb
+++ b/spec/features/instance_user_role_requests_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Instance::UserRoleRequests', js: true do
     before { login_as(user, scope: :user) }
 
     context 'As a normal instance user' do
-      scenario 'I can create a new role request', type: :mailer do
+      scenario 'I can create a new role request', :sidekiq_separate_thread, type: :mailer do
         visit courses_path
         find('#role-request-button').click
 
@@ -20,10 +20,9 @@ RSpec.feature 'Instance::UserRoleRequests', js: true do
         fill_in 'Designation', with: request.designation
         fill_in 'Reason', with: request.reason
 
-        expect do
-          find('button.btn-submit').click
-          wait_for_page
-        end.to change(ActionMailer::Base.deliveries, :count)
+        original_count = ActionMailer::Base.deliveries.count
+        find('button.btn-submit').click
+        wait_for_email_delivery(original_count + 1)
 
         request_created = instance.user_role_requests.last
 

--- a/spec/jobs/course/assessment/question/programming_import_job_spec.rb
+++ b/spec/jobs/course/assessment/question/programming_import_job_spec.rb
@@ -22,18 +22,19 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportJob do
         have_enqueued_job(subject).exactly(:once)
     end
 
-    it 'imports the templates' do
-      subject.perform_now(question, attachment, time_limit)
-      expect(question.template_files).not_to be_empty
+    it 'imports the templates', :sidekiq_same_thread do
+      perform_sidekiq_jobs { subject.perform_later(question, attachment, time_limit) }
+      expect(question.reload.template_files).not_to be_empty
     end
 
-    it 'imports the test cases' do
-      subject.perform_now(question, attachment, time_limit)
-      expect(question.test_cases).not_to be_empty
+    it 'imports the test cases', :sidekiq_same_thread do
+      perform_sidekiq_jobs { subject.perform_later(question, attachment, time_limit) }
+      expect(question.reload.test_cases).not_to be_empty
     end
 
-    it 'does not create codaveri question' do
-      subject.perform_now(question, attachment, time_limit)
+    it 'does not create codaveri question', :sidekiq_same_thread do
+      perform_sidekiq_jobs { subject.perform_later(question, attachment, time_limit) }
+      question.reload
 
       expect(question.codaveri_id).to eq(nil)
       expect(question.codaveri_status).to eq(nil)
@@ -69,8 +70,9 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportJob do
         Excon.stubs.clear
       end
 
-      it 'creates codaveri question' do
-        subject.perform_now(question, attachment, time_limit)
+      it 'creates codaveri question', :sidekiq_same_thread do
+        perform_sidekiq_jobs { subject.perform_later(question, attachment, time_limit) }
+        question.reload
 
         expect(question.codaveri_id).to eq('6311a0548c57aae93d260927')
         expect(question.codaveri_status).to eq(200)

--- a/spec/libraries/activity_wrapper_spec.rb
+++ b/spec/libraries/activity_wrapper_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Notifier::Base::ActivityWrapper, type: :mailer do
           end
         end
 
-        context 'when type is email' do
+        context 'when type is email', :sidekiq_same_thread do
           before do
             allow(notifier).to receive(:notification_view_path).and_return(template)
           end
 
-          subject { activity.notify(user, :email).save }
+          subject { perform_sidekiq_jobs { activity.notify(user, :email).save } }
 
           it 'sends an email to user' do
             expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -57,12 +57,12 @@ RSpec.describe Notifier::Base::ActivityWrapper, type: :mailer do
           end
         end
 
-        context 'when type is email' do
+        context 'when type is email', :sidekiq_same_thread do
           before do
             allow(notifier).to receive(:notification_view_path).and_return(template)
           end
 
-          subject { activity.notify(course, :email).save }
+          subject { perform_sidekiq_jobs { activity.notify(course, :email).save } }
 
           it 'sends emails to course users' do
             expect { subject }.

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe Course::Assessment::Question::Programming do
               expect { subject.save }.to \
                 have_enqueued_job(Course::Assessment::Question::ProgrammingImportJob).exactly(:once)
               expect(subject.reload.import_job).not_to eq(old_job_id)
+              expect(subject.import_job_id).to be_present
             end
 
             it 'reverts the change to the attachment' do

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -413,6 +413,12 @@ RSpec.describe Course::Assessment::Submission do
         email_setting.update!(regular: regular, phantom: phantom)
       end
 
+      # Runs the graded-email MailDeliveryJob through the real Sidekiq processor so it delivers exactly
+      # once, making the ActionMailer::Base.deliveries.count assertions reliable (needs :sidekiq_same_thread).
+      def publish_and_deliver
+        perform_sidekiq_jobs { submission.publish! }
+      end
+
       it 'propagates the graded state to its answers' do
         expect(submission.answers.all?(&:submitted?)).to be(true)
         submission.publish!
@@ -431,11 +437,11 @@ RSpec.describe Course::Assessment::Submission do
         expect(submission.awarded_at).not_to be_nil
       end
 
-      it 'sends an email notification', type: :mailer do
-        expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      it 'sends an email notification', :sidekiq_same_thread, type: :mailer do
+        expect { publish_and_deliver }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
 
-      context 'when a user unsubscribes', type: :mailer do
+      context 'when a user unsubscribes', :sidekiq_same_thread, type: :mailer do
         before do
           setting_email = course.
                           setting_emails.
@@ -446,32 +452,32 @@ RSpec.describe Course::Assessment::Submission do
         end
 
         it 'does not send an email notification to the user' do
-          expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          expect { publish_and_deliver }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
       end
 
       context 'when "submission graded" email setting is disabled for regular students', type: :mailer do
         before { set_assessment_email_setting(course, category_id, :grades_released, false, true) }
 
-        it 'does not send email notifications to the regular students' do
-          expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        it 'does not send email notifications to the regular students', :sidekiq_same_thread do
+          expect { publish_and_deliver }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
       end
 
       context 'when "submission graded" email setting is disabled for phantom students', type: :mailer do
         before { set_assessment_email_setting(course, category_id, :grades_released, true, false) }
 
-        it 'does not send email notifications to phantom students' do
+        it 'does not send email notifications to phantom students', :sidekiq_same_thread do
           course_student1.update(phantom: true)
-          expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          expect { publish_and_deliver }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
       end
 
-      context 'when "submission graded" setting is disabled for everyone', type: :mailer do
+      context 'when "submission graded" setting is disabled for everyone', :sidekiq_same_thread, type: :mailer do
         before { set_assessment_email_setting(course, category_id, :grades_released, false, false) }
 
         it 'does not send email notifications to the users' do
-          expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          expect { publish_and_deliver }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe User do
         with_tenant(:instance) do
           before { ActionMailer::Base.deliveries.clear }
 
-          it 'uses the current tenant host in the reset password URL' do
-            subject.send_reset_password_instructions
+          it 'uses the current tenant host in the reset password URL', :sidekiq_same_thread do
+            perform_sidekiq_jobs { subject.send_reset_password_instructions }
             email = ActionMailer::Base.deliveries.last
             expect(email.body.encoded).to include(instance.host)
           end

--- a/spec/notifiers/consolidated_opening_reminder_notifier_spec.rb
+++ b/spec/notifiers/consolidated_opening_reminder_notifier_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::ConsolidatedOpeningReminderNotifier, type: :mailer do
   let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    describe '#opening_reminder' do
+    describe '#opening_reminder', :sidekiq_same_thread do
       def set_consolidated_opening_reminder_setting(component, category_id, setting, regular, phantom)
         email_setting = course.
                         setting_emails.
@@ -32,7 +32,9 @@ RSpec.describe Course::ConsolidatedOpeningReminderNotifier, type: :mailer do
           create(:course_video, course: course, start_at: 1.hour.from_now, published: true)
         end
 
-        subject { Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course) }
+        subject do
+          perform_sidekiq_jobs { Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course) }
+        end
 
         it 'sends a course notification' do
           expect { subject }.to change(course.notifications, :count).by(1)
@@ -99,7 +101,9 @@ RSpec.describe Course::ConsolidatedOpeningReminderNotifier, type: :mailer do
           end
         end
 
-        subject { Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course) }
+        subject do
+          perform_sidekiq_jobs { Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course) }
+        end
 
         it 'sends a course notification' do
           expect { subject }.to change(course.notifications, :count).by(1)
@@ -138,7 +142,9 @@ RSpec.describe Course::ConsolidatedOpeningReminderNotifier, type: :mailer do
           end
         end
 
-        subject { Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course) }
+        subject do
+          perform_sidekiq_jobs { Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course) }
+        end
 
         it 'does not send a course notification' do
           expect { subject }.to change(course.notifications, :count).by(0)

--- a/spec/notifiers/course/announcement_notifier_spec.rb
+++ b/spec/notifiers/course/announcement_notifier_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Course::AnnouncementNotifier, type: :mailer do
   let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    describe '#new_announcement' do
+    # Run through the real Sidekiq processor so MailDeliveryJobs are delivered deterministically
+    # (exactly once), making the ActionMailer::Base.deliveries.count assertions reliable.
+    describe '#new_announcement', :sidekiq_same_thread do
       let(:course) { create(:course) }
       let!(:course_user) { create(:course_manager, course: course) }
       let!(:course_user_manager) { course_user.user }
@@ -27,7 +29,9 @@ RSpec.describe Course::AnnouncementNotifier, type: :mailer do
         allow_any_instance_of(Course::Announcement).to receive(:setup_opening_reminders)
       end
 
-      subject { Course::AnnouncementNotifier.new_announcement(course_user_manager, announcement) }
+      subject do
+        perform_sidekiq_jobs { Course::AnnouncementNotifier.new_announcement(course_user_manager, announcement) }
+      end
 
       it 'sends a course notification' do
         expect { subject }.to change(course.notifications, :count).by(1)

--- a/spec/notifiers/course/assessment/answer/comment_notifier_spec.rb
+++ b/spec/notifiers/course/assessment/answer/comment_notifier_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Course::Assessment::Answer::CommentNotifier, type: :mailer do
       email_setting.update!(regular: regular, phantom: phantom)
     end
 
-    describe '#annotation_replied' do
+    describe '#annotation_replied', :sidekiq_same_thread do
       let(:user) { create(:user) }
       let(:course) { create(:course) }
       let(:course_creator) { course.course_users.first }
@@ -40,7 +40,9 @@ RSpec.describe Course::Assessment::Answer::CommentNotifier, type: :mailer do
         code_annotation.acting_as.ensure_subscribed_by(user)
         code_annotation.acting_as.ensure_subscribed_by(course_creator.user)
       end
-      subject { Course::Assessment::Answer::CommentNotifier.annotation_replied(post) }
+      subject do
+        perform_sidekiq_jobs { Course::Assessment::Answer::CommentNotifier.annotation_replied(post) }
+      end
 
       it 'sends email notifications' do
         expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(2)

--- a/spec/notifiers/course/assessment/submission_question/comment_notifier_spec.rb
+++ b/spec/notifiers/course/assessment/submission_question/comment_notifier_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentNotifier, type: :m
       email_setting.update!(regular: regular, phantom: phantom)
     end
 
-    describe '#post_replied' do
+    describe '#post_replied', :sidekiq_same_thread do
       let(:user) { create(:user) }
       let(:course) { create(:course) }
       let(:course_creator) { course.course_users.first }
@@ -35,7 +35,9 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentNotifier, type: :m
         submission_question.acting_as.ensure_subscribed_by(user)
         submission_question.acting_as.ensure_subscribed_by(course_creator.user)
       end
-      subject { Course::Assessment::SubmissionQuestion::CommentNotifier.post_replied(post) }
+      subject do
+        perform_sidekiq_jobs { Course::Assessment::SubmissionQuestion::CommentNotifier.post_replied(post) }
+      end
 
       it 'sends email notifications' do
         expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(2)

--- a/spec/notifiers/course/assessment_notifier_spec.rb
+++ b/spec/notifiers/course/assessment_notifier_spec.rb
@@ -17,14 +17,16 @@ RSpec.describe Course::AssessmentNotifier, type: :mailer do
       end
     end
 
-    describe '#assessment_submitted' do
+    describe '#assessment_submitted', :sidekiq_same_thread do
       let(:course) { create(:course) }
       let!(:course_creator) { course.course_users.first }
       let!(:course_user) { create(:course_user, course: course) }
       let(:user) { course_user.user }
       let!(:submission) { create(:submission, course: course, creator: user) }
 
-      subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
+      subject do
+        perform_sidekiq_jobs { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
+      end
 
       it 'does not send email notifications' do
         expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/notifiers/course/forum/post_notifier_spec.rb
+++ b/spec/notifiers/course/forum/post_notifier_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe Course::Forum::PostNotifier, type: :mailer do
       email_setting.update!(regular: regular, phantom: phantom)
     end
 
-    describe '#post_replied' do
-      subject { Course::Forum::PostNotifier.post_replied(user, course_user, post) }
+    describe '#post_replied', :sidekiq_same_thread do
+      subject do
+        perform_sidekiq_jobs { Course::Forum::PostNotifier.post_replied(user, course_user, post) }
+      end
 
       it 'sends a course notification' do
         expect { subject }.to change(course.notifications, :count).by(1)

--- a/spec/notifiers/course/forum/topic_notifier_spec.rb
+++ b/spec/notifiers/course/forum/topic_notifier_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe Course::Forum::TopicNotifier, type: :mailer do
       email_setting.update!(regular: regular, phantom: phantom)
     end
 
-    describe '#new_topic' do
-      subject { Course::Forum::TopicNotifier.topic_created(user, course_user, topic) }
+    describe '#new_topic', :sidekiq_same_thread do
+      subject do
+        perform_sidekiq_jobs { Course::Forum::TopicNotifier.topic_created(user, course_user, topic) }
+      end
 
       it 'sends a course notification' do
         expect { subject }.to change(course.notifications, :count).by(1)

--- a/spec/notifiers/notifier/base_spec.rb
+++ b/spec/notifiers/notifier/base_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Notifier::Base, type: :mailer do
       let(:notifier) { self.class::DummyNotifier.new }
       let(:template) { 'activity_mailer/test_email' }
 
-      context 'when notifying a user' do
+      context 'when notifying a user', :sidekiq_same_thread do
         before do
           allow(notifier).to receive(:notification_view_path).and_return(template)
         end
 
-        subject { notifier.dummy_created(user, user, user) }
+        subject { perform_sidekiq_jobs { notifier.dummy_created(user, user, user) } }
 
         it 'creates an activity' do
           expect { subject }.to change { user.activities.count }.by(1)
@@ -53,12 +53,12 @@ RSpec.describe Notifier::Base, type: :mailer do
         end
       end
 
-      context 'when notifying a course' do
+      context 'when notifying a course', :sidekiq_same_thread do
         before do
           allow(notifier).to receive(:notification_view_path).and_return(template)
         end
 
-        subject { notifier.dummy_updated(user, user, course) }
+        subject { perform_sidekiq_jobs { notifier.dummy_updated(user, user, course) } }
 
         it 'creates an activity' do
           expect { subject }.to change { user.activities.count }.by(1)

--- a/spec/services/course/assessment/reminder_service_spec.rb
+++ b/spec/services/course/assessment/reminder_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Course::Assessment::ReminderService, type: :mailer do
     let(:student_regular_email) { student_regular.user.email }
     let(:student_phantom_email) { student_phantom.user.email }
 
-    describe '#closing_reminder' do
+    describe '#closing_reminder', :sidekiq_same_thread do
       let(:assessment) do
         create(:assessment, :published, :with_text_response_question, course: course, end_at: 2.days.from_now)
       end
@@ -28,8 +28,10 @@ RSpec.describe Course::Assessment::ReminderService, type: :mailer do
       end
 
       subject do
-        Course::Assessment::ReminderService.
-          closing_reminder(assessment, assessment.closing_reminder_token)
+        perform_sidekiq_jobs do
+          Course::Assessment::ReminderService.
+            closing_reminder(assessment, assessment.closing_reminder_token)
+        end
       end
 
       context 'when "assessment closing" emails are enabled' do

--- a/spec/services/course/survey/reminder_service_spec.rb
+++ b/spec/services/course/survey/reminder_service_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe Course::Survey::ReminderService, type: :mailer do
     let(:unresponded_student_phantom_email) { unresponded_student_phantom.user.email }
     let(:responded_student_email) { responded_student.user.email }
 
-    describe '#closing_reminder' do
+    describe '#closing_reminder', :sidekiq_same_thread do
       subject do
-        Course::Survey::ReminderService.closing_reminder(survey, survey.closing_reminder_token)
+        perform_sidekiq_jobs do
+          Course::Survey::ReminderService.closing_reminder(survey, survey.closing_reminder_token)
+        end
       end
 
       def set_survey_email_setting(setting, regular, phantom)

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -33,18 +33,30 @@ module ActiveJob::TestGroupHelpers
   end
 end
 
-# Since message deliveries use the test delivery engine, all deferred deliver calls must also call
-# +deliver_now+ so that the +ActionMailer::Base.deliveries.count+ attribute will also be
-# incremented.
+# Since message deliveries use the test delivery engine, deferred deliver calls also call
+# +deliver_now+ so that the +ActionMailer::Base.deliveries.count+ attribute is incremented (the
+# default in-test adapters don't reliably run +MailDeliveryJob+).
+#
+# EXCEPTION: under the Sidekiq harness (:sidekiq_same_thread / :sidekiq_separate_thread) the real
+# +MailDeliveryJob+ runs through the processor and delivers exactly once, so the synchronous
+# +deliver_now+ here is skipped to avoid double-counting deliveries. Specs asserting on
+# +deliveries.count+ get reliable counts by wrapping the mail-triggering action in
+# +perform_sidekiq_jobs { ... }+.
 module ActionMailer::MessageDelivery::TestDeliveryHelpers
   def deliver_later(_ = {})
-    deliver_now
+    deliver_now unless sidekiq_harness_active?
     super
   end
 
   def deliver_later!(_ = {})
-    deliver_now!
+    deliver_now! unless sidekiq_harness_active?
     super
+  end
+
+  private
+
+  def sidekiq_harness_active?
+    ActiveJob::Base.queue_adapter.instance_of?(::ActiveJob::QueueAdapters::SidekiqAdapter)
   end
 end
 ActionMailer::MessageDelivery.prepend(ActionMailer::MessageDelivery::TestDeliveryHelpers)
@@ -108,6 +120,16 @@ module TrackableJob::SpecHelpers
     return unless ActiveJob::Base.queue_adapter.is_a?(ActiveJob::QueueAdapters::BackgroundThreadAdapter)
 
     ActiveJob::Base.queue_adapter.clear_enqueued_jobs
+  end
+
+  # Polls until at least +count+ emails have been delivered, or the Capybara wait time elapses. Under
+  # the :sidekiq_separate_thread harness a mail job enqueued by the Capybara server thread is delivered
+  # out-of-band by the worker thread, so feature specs must wait for it rather than assert immediately.
+  # (ActionMailer::Base.deliveries is shared across threads, so the worker's delivery is visible here.)
+  def wait_for_email_delivery(count = 1, timeout: Capybara.default_max_wait_time)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    sleep 0.5 until ActionMailer::Base.deliveries.count >= count ||
+                    Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
   end
 end
 

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -42,7 +42,7 @@ module SidekiqTestSupport
   # All queues the app's jobs use (queue_as), plus the delayed_* variants produced dynamically.
   QUEUES = %w[
     highest default delayed_medium_high delayed_high delayed_medium_low delayed_low
-    duplication lowest
+    duplication lowest mailers
   ].freeze
 
   # Sidekiq::Processor REQUIRES a "death handler" block — its run loop calls `@callback.call(self)`


### PR DESCRIPTION
## Summary

Rails 7.2 shipped [`ActiveRecord.after_all_transactions_commit`](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html), a first-class API for "run this block once the surrounding transaction(s) commit, from anywhere — not just from a model callback." This is exactly what we were pulling in the third-party [`after_commit_action`](https://github.com/magnusvk/after_commit_action) gem to do. Now that we are on Rails 8.0, the gem is redundant, so this PR removes it and migrates every call site to the native API.

The PR is split into two commits:

| Commit | Purpose |
| --- | --- |
| [`de8428a`](https://github.com/Coursemology/coursemology2/commit/de8428a00f207a7232269e6c269c86b9a67884ec) — `test: migrate mail delivery specs to sidekiq harness` | **Coverage hardening.** Several `execute_after_commit` call sites schedule mailers. Their existing specs asserted on `ActionMailer::Base.deliveries` but relied on the old `deliver_later` → `deliver_now` shortcut, which does not exercise the real after-commit-then-enqueue path. This commit moves those specs onto the real Sidekiq test harness so they actually prove the after-commit email dispatch works. |
| [`842ef73`](https://github.com/Coursemology/coursemology2/commit/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c) — `chore(deps): replace after_commit_action gem with ActiveRecord.after_all_transactions_commit (introduced in Rails 7.2)` | **The change itself.** Migrates all 18 call sites, deletes the extension that mixed the gem into every model, and drops the gem from the `Gemfile`/`Gemfile.lock`. |

The first commit lands before the second so the mailer paths are covered by realistic specs *before* their implementation is swapped out.

---

## Gem vs. Rails-native implementation

### The gem: `after_commit_action` (v1.1.0)

The gem is a concern mixed into **every** `ActiveRecord::Base` subclass (via `lib/extensions/after_commit_action.rb`), exposing an **instance** method `execute_after_commit`.

Source: [`after_commit_action-1.1.0/lib/after_commit_action.rb`](https://github.com/magnusvk/after_commit_action/blob/master/lib/after_commit_action.rb)

```ruby
module AfterCommitAction
  extend ActiveSupport::Concern

  included do
    after_commit :_after_commit_hook
  end

  def execute_after_commit(&block)
    if self.class.connection.open_transactions == 0
      return block.call
    else
      self.class.connection.add_transaction_record(self)
    end
    @_execute_after_commit ||= []
    @_execute_after_commit << block
  end

  def _after_commit_hook
    until @_execute_after_commit.blank?
      @_execute_after_commit.shift.call
    end
  rescue => e
    Rails.logger.error "Error in execute_after_commit block: #{e.inspect}"
    raise e
  end
end
```

How it works:

1. If there is **no** open transaction, run the block immediately.
2. Otherwise, register the receiver as a transaction record (`add_transaction_record(self)`) so that its `after_commit` callback (`_after_commit_hook`) will fire, and queue the block on the instance.
3. When the transaction commits, `_after_commit_hook` drains the queued blocks.

### The native API: `ActiveRecord.after_all_transactions_commit` (Rails 7.2+)

Introduced in Rails 7.2 (docs: [rails/rails#54533](https://github.com/rails/rails/pull/54533), [API reference](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#method-i-after_all_transactions_commit)). It is a **module** method — no receiver record needed.

Source: [`activerecord/lib/active_record.rb`](https://github.com/rails/rails/blob/v8.0.5.1/activerecord/lib/active_record.rb)

```ruby
def self.after_all_transactions_commit(&block)
  open_transactions = all_open_transactions

  if open_transactions.empty?
    yield
  elsif open_transactions.size == 1
    open_transactions.first.after_commit(&block)
  else
    count = open_transactions.size
    callback = -> do
      count -= 1
      block.call if count.zero?
    end
    open_transactions.each do |t|
      t.after_commit(&callback)
    end
  end
end
```

How it works:

1. If there are **no** open transactions, run the block immediately (`yield`).
2. If there is exactly one, register the block on that transaction's `after_commit`.
3. If there are several (multi-database), register a counter so the block runs only after the **last** one commits.

### Are they equivalent for Coursemology?

Yes, for our setup, with the native version being strictly cleaner:

| Behaviour | Gem | Native | Same for us? |
| --- | --- | --- | --- |
| No open transaction → run immediately | ✅ | ✅ | ✅ |
| Open transaction → run at outermost commit | ✅ (via `add_transaction_record`) | ✅ (via transaction `after_commit`) | ✅ |
| Rollback (incl. nested savepoint) → block skipped | ✅ | ✅ | ✅ |
| Requires a **record** to hang the callback on | Yes — instance method; needs `self` | No — module method | Native removes an accidental coupling |
| Multi-database awareness | No | Yes (`all_open_transactions`) | N/A (single DB), harmless |
| Side effect of enrolling `self` as a transaction record | Yes | No | Redundant for us — every call site is already saving the record inside the transaction |
| Ordering vs. other `after_commit` callbacks | Instance callback ordering | Transaction-level callback | No call site depends on relative ordering |
| Extra `Rails.logger.error` + re-raise on block error | Yes | Re-raises (no extra log line) | Immaterial |

The one semantic the gem adds — `add_transaction_record(self)` — is only meaningful when the receiver is *not otherwise* participating in the transaction. In Coursemology every `execute_after_commit` caller is a record already being saved (or a condition callback firing off an `after_save`), so it is already a transaction record; the native API's simpler "attach to the current transaction" is sufficient.

---

## Change table (commit [`842ef73`](https://github.com/Coursemology/coursemology2/commit/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c))

Base for file links: `github.com/Coursemology/coursemology2/blob/842ef73/…`

| Feature impacted | Changed file (exact lines) | Covering specs |
| --- | --- | --- |
| **Submission auto-grading** — enqueue auto-grade after the submission's transaction commits | [`app/models/course/assessment/submission.rb#L353`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/assessment/submission.rb#L353-L360) | [`spec/models/course/assessment/submission_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/assessment/submission_spec.rb) |
| **Submission Codaveri feedback** — enqueue feedback retrieval after commit | [`app/models/course/assessment/submission.rb#L364`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/assessment/submission.rb#L364-L371) | [`spec/models/course/assessment/submission_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/assessment/submission_spec.rb) |
| **Submission graded email** — mail the student once grading is published & committed | [`app/models/concerns/course/assessment/submission/workflow_event_concern.rb#L191`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/concerns/course/assessment/submission/workflow_event_concern.rb#L191) | [`spec/models/course/assessment/submission_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/assessment/submission_spec.rb) (`#publish!` graded-email examples — **migrated to the Sidekiq harness in `de8428a`**) |
| **Programming question — Codaveri problem sync** — enqueue import job + record `import_job_id` after commit | [`app/models/course/assessment/question/programming.rb#L165`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/assessment/question/programming.rb#L165-L169) | [`spec/models/course/assessment/question/programming_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/assessment/question/programming_spec.rb), [`spec/jobs/course/assessment/question/programming_import_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/assessment/question/programming_import_job_spec.rb) |
| **Programming question — package evaluation** — enqueue import job + record `import_job_id` after commit | [`app/models/course/assessment/question/programming.rb#L199`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/assessment/question/programming.rb#L199-L203) | [`spec/models/course/assessment/question/programming_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/assessment/question/programming_spec.rb), [`spec/jobs/course/assessment/question/programming_import_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/assessment/question/programming_import_job_spec.rb) |
| **Programming question — new package processing** — enqueue import job + record `import_job_id` after commit | [`app/models/course/assessment/question/programming.rb#L214`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/assessment/question/programming.rb#L214-L218) | [`spec/models/course/assessment/question/programming_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/assessment/question/programming_spec.rb), [`spec/jobs/course/assessment/question/programming_import_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/assessment/question/programming_import_job_spec.rb) |
| **Achievement condition re-evaluation** — re-check unlock conditions after the dependent record commits | [`app/models/course/condition/achievement.rb#L46`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/condition/achievement.rb#L46) | [`spec/models/course/condition/achievement_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/condition/achievement_spec.rb) |
| **Assessment condition re-evaluation** | [`app/models/course/condition/assessment.rb#L59`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/condition/assessment.rb#L59-L61) | [`spec/models/course/condition/assessment_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/condition/assessment_spec.rb) |
| **Level condition re-evaluation** | [`app/models/course/condition/level.rb#L42`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/condition/level.rb#L42) | [`spec/models/course/condition/level_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/condition/level_spec.rb) |
| **Survey condition re-evaluation** | [`app/models/course/condition/survey.rb#L44`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/condition/survey.rb#L44) | [`spec/models/course/condition/survey_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/condition/survey_spec.rb) |
| **Video condition re-evaluation** | [`app/models/course/condition/video.rb#L56`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/course/condition/video.rb#L56) | [`spec/models/course/condition/video_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/models/course/condition/video_spec.rb) |
| **Condition satisfiability graph** — rebuild the course dependency graph after a condition changes | [`lib/extensions/conditional/active_record/base.rb#L147`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/lib/extensions/conditional/active_record/base.rb#L147) | Covered indirectly by the condition specs above (fires from `on_condition_change`) |
| **Course opening reminders** — schedule the opening-reminder job after commit | [`app/models/concerns/course/opening_reminder_concern.rb#L36`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/concerns/course/opening_reminder_concern.rb#L36-L38) | [`spec/jobs/course/announcement/opening_reminder_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/announcement/opening_reminder_job_spec.rb) |
| **Course closing reminders** — schedule the closing-reminder job after commit | [`app/models/concerns/course/closing_reminder_concern.rb#L26`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/models/concerns/course/closing_reminder_concern.rb#L26-L28) | [`spec/jobs/course/assessment/closing_reminder_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/assessment/closing_reminder_job_spec.rb), [`spec/jobs/course/survey/closing_reminder_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/survey/closing_reminder_job_spec.rb), [`spec/jobs/course/video/closing_reminder_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/jobs/course/video/closing_reminder_job_spec.rb) |
| **Enrolment request — approval email** — mail the user after the enrolment is approved & committed | [`app/controllers/course/enrol_requests_controller.rb#L39`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/controllers/course/enrol_requests_controller.rb#L39) | [`spec/controllers/course/enrol_requests_controller_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/controllers/course/enrol_requests_controller_spec.rb) (**migrated to the Sidekiq harness in `de8428a`**) |
| **Enrolment request — rejection email** | [`app/controllers/course/enrol_requests_controller.rb#L50`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/app/controllers/course/enrol_requests_controller.rb#L50-L52) | [`spec/controllers/course/enrol_requests_controller_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/controllers/course/enrol_requests_controller_spec.rb) (**migrated to the Sidekiq harness in `de8428a`**) |
| **Notification email dispatch** — flush a notifier's pending emails after the activity commits | [`lib/autoload/notifier/base/activity_wrapper.rb#L32`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/lib/autoload/notifier/base/activity_wrapper.rb#L32) | [`spec/libraries/activity_wrapper_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/libraries/activity_wrapper_spec.rb) (**migrated to the Sidekiq harness in `de8428a`**) |
| **Trackable job completion signal** — emit the PostgreSQL `LISTEN/NOTIFY` signal after the job's status commits | [`lib/autoload/trackable_job.rb#L37`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/lib/autoload/trackable_job.rb#L37) | [`spec/libraries/trackable_job_spec.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/libraries/trackable_job_spec.rb) (`#wait`, `:sidekiq_separate_thread`) |
| **Remove the gem mix-in** — delete the extension that `include`d `AfterCommitAction` into `ActiveRecord::Base` | `lib/extensions/after_commit_action.rb` (**deleted**) | N/A (removal; nothing referenced `Extensions::AfterCommitAction`) |
| **Drop the dependency** | [`Gemfile`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/Gemfile), `Gemfile.lock` | N/A (build) |

### Migration shapes

Two mechanical patterns were applied:

- **Class/self form** (`execute_after_commit { … }` called with an implicit `self` receiver) → `ActiveRecord.after_all_transactions_commit { … }` (e.g. `submission.rb`, `programming.rb`, the reminder concerns).
- **Explicit-receiver form** (`some_record.execute_after_commit { … }`) → `ActiveRecord.after_all_transactions_commit { … }`, dropping the receiver, since the native API doesn't need one (e.g. the five `Course::Condition::*` models and `enrol_requests_controller.rb`).

Commit `842ef73` totals: 17 files changed (16 modified + 1 deleted), plus `Gemfile`/`Gemfile.lock`.

---

## Test-coverage migration (commit [`de8428a`](https://github.com/Coursemology/coursemology2/commit/de8428a00f207a7232269e6c269c86b9a67884ec))

The mailer call sites above only dispatch **after commit**, then enqueue via `deliver_later`. To prove that path end-to-end, their specs were moved onto the real Sidekiq test harness instead of the `deliver_later` → `deliver_now` shortcut.

Harness support changes:

- [`spec/support/sidekiq.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/support/sidekiq.rb) — added the `mailers` queue (`ActionMailer`'s `deliver_later_queue_name`) to the harness's tracked `QUEUES`.
- [`spec/support/active_job.rb`](https://github.com/Coursemology/coursemology2/blob/842ef73ffa5d0547598ce56df5ffdc2bcdf2bb0c/spec/support/active_job.rb) — under the Sidekiq harness, `deliver_later`/`deliver_later!` route through the harness rather than delivering synchronously; added a `wait_for_email_delivery(count, timeout:)` polling helper.

Harness tags used:

- `:sidekiq_same_thread` — runs the JID-tracked jobs enqueued inside a `perform_sidekiq_jobs { … }` block (plus their descendants). Used to turn the mailer specs into real unit tests: wrap the email-generating action, then assert `ActionMailer::Base.deliveries` **includes the specific email** under test.
- `:sidekiq_separate_thread` — a real worker thread drains all enqueued jobs; used where the flow crosses threads (e.g. the trackable-job `LISTEN/NOTIFY` wait, feature specs).

Specs migrated: the eight notifier specs (announcement, assessment-submitted, consolidated opening reminder, forum post, forum topic, answer comment, submission-question comment, notifier base), plus `activity_wrapper_spec`, the assessment/survey reminder-service specs, `submission_spec#publish!`, the comments/annotations/enrol-requests/instance-user-role-requests/users/emails controller specs, `user_spec` (reset-password), and the instance-user-role-requests feature spec.

Per reviewer guidance, the enrolment/instance-role specs were tightened from brittle `deliveries.count == N` assertions into real unit tests: wrap only the action under test in `perform_sidekiq_jobs`, then assert `deliveries` **includes** the specific email.

---

## Verification

- App boots on Rails 8.0.5.1 without the gem; `ActiveRecord.respond_to?(:after_all_transactions_commit)` ⇒ `true`.
- Audited coverage for the migrated call sites is green: **108 examples, 0 failures, 1 pending** (conditions, trackable job, activity wrapper, programming, enrol controller) and **113 examples, 0 failures, 8 pending** (video/survey/level conditions, opening/closing reminder jobs, submission spec).
- No new RuboCop offenses introduced (the migrated lines are all < 120 chars; remaining offenses are pre-existing legacy).

## Sources

- [`after_commit_action` gem source](https://github.com/magnusvk/after_commit_action)
- [Rails API — `ActiveRecord::Transactions::ClassMethods`](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html)
- [Ruby on Rails 7.2 Release Notes](https://guides.rubyonrails.org/7_2_release_notes.html)
- [rails/rails#54533 — docs for per-transaction callbacks and `after_all_transactions_commit`](https://github.com/rails/rails/pull/54533)
