### PR TITLE
Preserve content-bearing tags in `clean_html_text`

### DIFF
--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -85,19 +85,56 @@ module ApplicationFormattersHelper
     format('%<hours>02dH%<minutes>02dM%<seconds>02dS', hours: hours, minutes: minutes, seconds: seconds)
   end
 
+  # Tags that survive +clean_html_text+ instead of being stripped.
+  #
+  # These elements are empty or void: everything they contribute lives in their attributes
+  # (an uploaded image's +src+, an embedded video's +url+), so stripping them discards content
+  # rather than merely dropping formatting. Presentational tags remain stripped, since the text
+  # they wrap is kept.
+  #
+  # See ApplicationHtmlFormattersHelper::SANITIZATION_FILTER_WHITELIST for what may actually
+  # reach the database: <oembed> is what CKEditor's media embed writes, while <iframe> only
+  # appears in rich text saved by older editors.
+  CLEAN_HTML_TEXT_ALLOWED_TAGS = ['img', 'oembed', 'iframe', 'embed', 'audio', 'video', 'source'].freeze
+
+  # Attributes kept on CLEAN_HTML_TEXT_ALLOWED_TAGS. Only those identifying or describing the
+  # embedded resource are retained; sizing and styling attributes are formatting, so they go.
+  CLEAN_HTML_TEXT_ALLOWED_ATTRIBUTES = ['src', 'srcset', 'url', 'alt', 'title'].freeze
+
+  # Tags that end a visual line, and so become a newline in the plain text output. CKEditor emits
+  # bare <br>, but rich text saved by older editors uses <br /> and <br/>.
+  CLEAN_HTML_TEXT_LINE_BREAK_TAGS = /<br\s*\/?>|<\/(?:p|figure)>/i
+
+  # Splits sanitized HTML into tags and the text between them, so that entities are only decoded in
+  # the latter. Matching up to the first '>' is not enough: the HTML5 serializer escapes '&', '"' and
+  # non-breaking spaces in attribute values but leaves '<' and '>' alone, so an image whose alt text
+  # reads 'a > b' would otherwise be cut in half and the attributes after the cut wrongly decoded.
+  # Quoted values are therefore skipped over, which is safe as the serializer always double-quotes
+  # attributes and escapes any '"' within them.
+  CLEAN_HTML_TEXT_TAGS = /(<[^>"]*(?:"[^"]*"[^>"]*)*>)/
+
   # Formats rich text fields for CSV export by stripping HTML tags and decoding HTML entities.
   # Rich text fields are saved as HTML in the database (from WYSIWYG editors), so this helper
   # converts them to plain text suitable for CSV files by removing HTML markup and decoding
   # entities like &nbsp;, &amp;, etc.
   #
+  # Tags in CLEAN_HTML_TEXT_ALLOWED_TAGS are kept verbatim, as stripping them would drop the
+  # content itself and not just its formatting.
+  #
   # @param [String] text The rich text (HTML) to format
-  # @param [Boolean] preserve_newlines Whether to preserve paragraph/line breaks (default: true)
-  # @return [String] Plain text with HTML tags removed and entities decoded
+  # @return [String] Plain text with formatting HTML tags removed and entities decoded
   def clean_html_text(text)
     return '' unless text
 
-    cleaned_text = text.gsub('</p>', "</p>\n").gsub('<br />', "<br />\n")
-    HTMLEntities.new.decode(ActionController::Base.helpers.strip_tags(cleaned_text)).strip
+    cleaned_text = text.gsub(CLEAN_HTML_TEXT_LINE_BREAK_TAGS) { |tag| "#{tag}\n" }
+    sanitized = strip_formatting_html_tags(cleaned_text)
+
+    entities = HTMLEntities.new
+    decoded = sanitized.split(CLEAN_HTML_TEXT_TAGS).map do |part|
+      part.start_with?('<') ? part : entities.decode(part)
+    end.join
+
+    decoded.strip
   end
   alias_method :format_rich_text_for_csv, :clean_html_text
 
@@ -108,5 +145,21 @@ module ApplicationFormattersHelper
   # @return [Boolean] true if the text is blank after stripping HTML
   def clean_html_text_blank?(text)
     clean_html_text(text).blank?
+  end
+
+  private
+
+  # Strips every HTML tag except CLEAN_HTML_TEXT_ALLOWED_TAGS, keeping the text the stripped tags
+  # wrapped. Note that the sanitizer is instantiated per call because it is not thread-safe, and that
+  # +sanitize+ cannot be used here: ApplicationHtmlFormattersHelper overrides it with a pipeline
+  # that ignores the tag and attribute options.
+  #
+  # @param [String] text The rich text (HTML) to strip
+  # @return [String] Sanitized HTML fragment containing only the allowed tags and allow-listed attributes
+  def strip_formatting_html_tags(text)
+    sanitizer = Rails::HTML::Sanitizer.best_supported_vendor.safe_list_sanitizer.new
+    sanitizer.sanitize(text,
+                       tags: CLEAN_HTML_TEXT_ALLOWED_TAGS,
+                       attributes: CLEAN_HTML_TEXT_ALLOWED_ATTRIBUTES)
   end
 end

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -393,6 +393,49 @@ RSpec.describe ApplicationFormattersHelper do
       end
     end
 
+    context 'when text contains tags carrying content in their attributes' do
+      it 'keeps uploaded images' do
+        html = '<p>My answer</p><figure class="image"><img src="/attachments/123" alt="My diagram"></figure>'
+        expect(helper.clean_html_text(html)).to eq("My answer\n<img src=\"/attachments/123\" alt=\"My diagram\">")
+      end
+
+      it 'keeps inline images' do
+        html = '<p>Refer to <img src="/attachments/9" alt="chart"> above</p>'
+        expect(helper.clean_html_text(html)).to eq('Refer to <img src="/attachments/9" alt="chart"> above')
+      end
+
+      it 'keeps embedded videos' do
+        html = '<figure class="media"><oembed url="https://youtu.be/abc123"></oembed></figure>'
+        expect(helper.clean_html_text(html)).to eq('<oembed url="https://youtu.be/abc123"></oembed>')
+      end
+
+      it 'keeps videos embedded by older editors' do
+        html = '<iframe src="https://www.youtube.com/embed/abc123" width="560"></iframe>'
+        expect(helper.clean_html_text(html)).to eq('<iframe src="https://www.youtube.com/embed/abc123"></iframe>')
+      end
+
+      it 'is not blank when the text is only an image' do
+        html = '<figure class="image"><img src="/attachments/123"></figure>'
+        expect(helper.clean_html_text_blank?(html)).to eq(false)
+      end
+
+      it 'drops the presentational attributes of the tags it keeps' do
+        html = '<img src="/attachments/1" alt="Graph" width="200" height="100" style="width:50%" class="image_resized">'
+        expect(helper.clean_html_text(html)).to eq('<img src="/attachments/1" alt="Graph">')
+      end
+
+      it 'drops event handler attributes of the tags it keeps' do
+        html = '<img src="/attachments/1" onerror="alert(1)" onload="alert(2)">'
+        expect(helper.clean_html_text(html)).to eq('<img src="/attachments/1">')
+      end
+
+      it 'strips the surrounding formatting tags' do
+        html = '<figure class="image image_resized"><img src="/attachments/1">' \
+               '<figcaption>A caption</figcaption></figure>'
+        expect(helper.clean_html_text(html)).to eq('<img src="/attachments/1">A caption')
+      end
+    end
+
     context 'when text contains HTML entities' do
       it 'decodes &nbsp; to space' do
         html = '<p>Hello&nbsp;World</p>'
@@ -413,6 +456,28 @@ RSpec.describe ApplicationFormattersHelper do
         html = '<p>&#34;Quote&#34;</p>'
         expect(helper.clean_html_text(html)).to eq('"Quote"')
       end
+
+      it 'decodes angle brackets typed as text' do
+        html = '<p>if a &lt; b &amp;&amp; b &gt; c</p>'
+        expect(helper.clean_html_text(html)).to eq('if a < b && b > c')
+      end
+
+      it 'decodes text that looks like a tag without treating it as one' do
+        html = '<p>use the &lt;img&gt; tag</p>'
+        expect(helper.clean_html_text(html)).to eq('use the <img> tag')
+      end
+
+      it 'does not decode entities inside the attributes of the tags it keeps' do
+        html = '<p>Tom &amp; Jerry</p><img src="/attachments/1?x=1&amp;y=2" alt="Tom &amp; Jerry">'
+        expect(helper.clean_html_text(html)).
+          to eq("Tom & Jerry\n<img src=\"/attachments/1?x=1&amp;y=2\" alt=\"Tom &amp; Jerry\">")
+      end
+
+      it 'does not decode entities in attributes following an angle bracket in an attribute' do
+        html = '<img src="/attachments/1" alt="a &gt; b" title="Tom &amp; Jerry">'
+        expect(helper.clean_html_text(html)).
+          to eq('<img src="/attachments/1" alt="a > b" title="Tom &amp; Jerry">')
+      end
     end
 
     context 'when text contains paragraph and line breaks' do
@@ -426,6 +491,12 @@ RSpec.describe ApplicationFormattersHelper do
         html = '<p>Line 1<br />Line 2</p>'
         result = helper.clean_html_text(html)
         expect(result).to eq("Line 1\nLine 2")
+      end
+
+      it 'preserves unclosed and self-closing line breaks as newlines' do
+        html = '<p>Line 1<br>Line 2<br/>Line 3</p>'
+        result = helper.clean_html_text(html)
+        expect(result).to eq("Line 1\nLine 2\nLine 3")
       end
 
       it 'handles complex HTML with mixed content' do


### PR DESCRIPTION
## Problem

`clean_html_text` (aliased as `format_rich_text_for_csv`) turns stored rich text into plain text for
CSV exports, autogradable question templates, and the `clean_html_text_blank?` checks. It did this
with `strip_tags`, which removes *every* tag.

That is right for formatting — `<p>`, `<strong>`, `<span>` wrap text that survives the strip — but
wrong for elements that carry their content in their attributes. An answer consisting of an uploaded
image exported as an empty CSV cell, and an embedded video's URL disappeared entirely, because
`<img src="/attachments/123">` and `<oembed url="...">` have no text to leave behind.

## Change

`clean_html_text` now keeps an allow-list of tags verbatim and strips the rest:

| Tag | Why |
| --- | --- |
| `img` | Uploaded and inserted images; the `src` is the content |
| `oembed` | What CKEditor's media embed writes; the `url` is the content |
| `iframe` | Video embeds in rich text saved by older editors, still allow-listed on save |
| `embed`, `audio`, `video`, `source` | Not producible by the current editor, but the same class |

Attributes are allow-listed too: `src`, `srcset`, `url`, `alt`, `title`. Sizing and styling
(`width`, `style`, `class`) are formatting and still get dropped, and so do event handlers —
`<img src="/attachments/1" onerror="alert(1)" style="width:50%">` exports as
`<img src="/attachments/1">`. Both lists are named constants, so adjusting them is a one-line change.

Also fixed in the same lines: the newline injection matched only the literal `<br />`, but CKEditor 5
emits bare `<br>`, so soft line breaks in current content were silently collapsing. It is now a regex
covering `<br>`, `<br/>` and `<br />`, plus `</figure>` so an image block does not run into the
paragraph after it.

### Entity decoding is scoped to text

Entity decoding now applies only between tags, not inside them. Decoding the whole string would
rewrite `src="/a?x=1&amp;y=2"` to `src="/a?x=1&y=2"` and leave the tags we deliberately kept holding
unescaped attribute values.

Splitting text from tags has one subtlety worth recording. The HTML5 serializer escapes `&`, `"` and
non-breaking spaces in attribute values, but per spec it leaves `<` and `>` alone — so `alt="a &gt; b"`
comes back out as `alt="a > b"`, with a bare `>` inside the quotes. A naive `/(<[^>]+>)/` split cuts
that tag in half at the wrong `>` and decodes the remainder as if it were text, which corrupts exactly
the attributes the split exists to protect: `title="Tom &amp; Jerry"` becomes `title="Tom & Jerry"`.
The split therefore skips over quoted values, which is safe because the serializer always
double-quotes attributes and escapes any `"` inside them. Both cases are covered by tests.

Text nodes need no such care: the serializer always re-escapes `<` and `>` in text, so literal angle
brackets a student typed arrive as `&lt;`/`&gt;`, are never mistaken for markup by the split, and are
decoded back to `<`/`>` in the output.

## Why `rails-html-sanitizer` instead of `strip_tags`

`strip_tags` is `Rails::HTML::FullSanitizer`, which is all-or-nothing by design: it has no notion of
an allow-list. Keeping `<img>` through it would mean either regex surgery on the HTML before or after
the strip, or a hand-rolled Nokogiri walk. `Rails::HTML::SafeListSanitizer` is the sibling class in
the same gem — `rails-html-sanitizer` is already what backs `strip_tags`, so this adds no dependency
and no new parser, it swaps one sanitizer in the library for another.

Concretely, over a regex approach:

- **Attribute filtering comes for free.** Because the output is no longer guaranteed tag-free,
  whatever we keep has to be scrubbed. A regex that preserves `<img ...>` preserves `onerror=` with
  it; the sanitizer drops every attribute not named in the list, without us enumerating the dangerous
  ones.
- **It parses instead of pattern-matching.** Unclosed tags, `<IMG SRC=…>`, unquoted attributes and
  the other shapes real stored content takes are handled by the same parser that sanitised the
  content on the way into the database, rather than by a pattern we would have to keep in sync.
- **Semantics match what was there before.** Given a `tags:` option, `SafeListSanitizer` scrubs with
  `PermitScrubber`, which removes a disallowed element but splices its children back in — exactly
  `FullSanitizer`'s behaviour for everything outside the allow-list. All 16 pre-existing
  expectations pass unchanged, including the HTML-entity decoding and the `<script>` case.
- **Same parsing rules as the editor.** `Rails::HTML::Sanitizer.best_supported_vendor` resolves to
  the HTML5 vendor, so fragments parse the way browsers and CKEditor produce them.

The sanitizer is instantiated per call because its scrubber holds the per-call tag and attribute
options and is not thread-safe to share. Note that the `sanitize` helper cannot be used here:
`ApplicationHtmlFormattersHelper` overrides it with an HTML::Pipeline that ignores these options.

## Tests

Thirteen examples added in `spec/helpers/application_formatters_helper_spec.rb` covering block and
inline images, `oembed`, legacy `iframe`, presentational- and event-handler-attribute removal, the
`clean_html_text_blank?` case for an image-only body, the `<br>` variants, literal angle brackets in
text, and entities in attributes both before and after a bare `>`.

- `spec/helpers/application_formatters_helper_spec.rb` — 69 examples, 0 failures
- CSV download, survey download, forum post response and text response answer specs — 35 examples,
  0 failures
- RuboCop clean on both changed files

## Not included

A link's URL is real information, but the anchor text survives the strip, so
nothing vanishes. CKEditor sets link text to the URL when one is pasted, so allow-listing it would
render the common case as `<a href="https://x">https://x</a>` in every exported cell.

List items and table cells still run together, because only `</p>`
and `<br>` produce separators. `<li>one</li><li>two</li>` exports as `onetwo` and a 2×2 table as
`abcd`. It is the same class of data loss, but fixing it changes output for every existing CSV
consumer and the separator choice (newline for `</li>` and `</tr>`, space or tab for `</td>`) should
be decided deliberately.