### PR TITLE
fix(db): partial fix of deltas between schema.rb and production state

### DIFF
--- a/db/migrate/20211023070257_add_conditional_satisfiability_evaluation_time_to_courses.rb
+++ b/db/migrate/20211023070257_add_conditional_satisfiability_evaluation_time_to_courses.rb
@@ -1,5 +1,11 @@
 class AddConditionalSatisfiabilityEvaluationTimeToCourses < ActiveRecord::Migration[6.0]
   def change
-    add_column :courses, :conditional_satisfiability_evaluation_time, :datetime, default: Time.now
+    # The original line (commented) generated the default based on when the migration was run, which
+    # caused desync between the schema.rb (based on migration run time in local development) and the actual
+    # production schema (based on migration run time in production).
+    # To fix this, we set the default value to a fixed time matching the actual production value.
+    #
+    # add_column :courses, :conditional_satisfiability_evaluation_time, :datetime, default: Time.now
+    add_column :courses, :conditional_satisfiability_evaluation_time, :datetime, default: '2021-11-09 00:08:09.279414'
   end
 end

--- a/db/migrate/20211024140630_add_last_graded_time_to_course_assessment_submissions.rb
+++ b/db/migrate/20211024140630_add_last_graded_time_to_course_assessment_submissions.rb
@@ -1,5 +1,11 @@
 class AddLastGradedTimeToCourseAssessmentSubmissions < ActiveRecord::Migration[6.0]
   def change
-    add_column :course_assessment_submissions, :last_graded_time, :datetime, default: Time.now
+    # The original line (commented) generated the default based on when the migration was run, which
+    # caused desync between the schema.rb (based on migration run time in local development) and the actual
+    # production schema (based on migration run time in production).
+    # To fix this, we set the default value to a fixed time matching the actual production value.
+    #
+    # add_column :course_assessment_submissions, :last_graded_time, :datetime, default: Time.now
+    add_column :course_assessment_submissions, :last_graded_time, :datetime, default: '2021-11-09 00:08:09.318947'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -664,7 +664,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_02_000000) do
     t.datetime "published_at", precision: nil
     t.string "session_id", limit: 255
     t.datetime "submitted_at", precision: nil
-    t.datetime "last_graded_time", precision: nil, default: "2021-10-24 14:11:56"
+    t.datetime "last_graded_time", precision: nil, default: "2021-11-09 00:08:09"
     t.index ["assessment_id", "creator_id"], name: "unique_assessment_id_and_creator_id", unique: true
     t.index ["assessment_id"], name: "fk__course_assessment_submissions_assessment_id"
     t.index ["creator_id"], name: "fk__course_assessment_submissions_creator_id"
@@ -744,7 +744,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_02_000000) do
     t.index ["scholaistic_assessment_id"], name: "idx_on_scholaistic_assessment_id_60ce66b4ce"
   end
 
-  create_table "course_condition_surveys", id: :serial, force: :cascade do |t|
+  create_table "course_condition_surveys", force: :cascade do |t|
     t.bigint "survey_id", null: false
     t.index ["survey_id"], name: "fk__course_condition_surveys_survey_id"
   end
@@ -774,7 +774,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_02_000000) do
 
   create_table "course_discussion_post_codaveri_feedbacks", force: :cascade do |t|
     t.bigint "post_id", null: false
-    t.integer "status"
+    t.integer "status", default: 0
     t.text "codaveri_feedback_id", null: false
     t.text "original_feedback", null: false
     t.integer "rating"
@@ -1737,7 +1737,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_02_000000) do
     t.boolean "enrollable", default: false, null: false
     t.string "time_zone", limit: 255
     t.boolean "show_personalized_timeline_features", default: false, null: false
-    t.datetime "conditional_satisfiability_evaluation_time", precision: nil, default: "2021-10-24 10:31:32"
+    t.datetime "conditional_satisfiability_evaluation_time", precision: nil, default: "2021-11-09 00:08:09"
     t.integer "default_timeline_algorithm", default: 0, null: false
     t.string "koditsu_workspace_id"
     t.uuid "ssid_folder_id"
@@ -2145,8 +2145,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_02_000000) do
   add_foreign_key "course_condition_achievements", "course_achievements", column: "achievement_id", name: "fk_course_condition_achievements_achievement_id"
   add_foreign_key "course_condition_assessments", "course_assessments", column: "assessment_id", name: "fk_course_condition_assessments_assessment_id"
   add_foreign_key "course_condition_scholaistic_assessments", "course_scholaistic_assessments", column: "scholaistic_assessment_id"
-  add_foreign_key "course_condition_surveys", "course_surveys", column: "survey_id", name: "fk_course_condition_surveys_survey_id"
-  add_foreign_key "course_condition_videos", "course_videos", column: "video_id", name: "fk_course_condition_videos_video_id"
+  add_foreign_key "course_condition_surveys", "course_surveys", column: "survey_id"
+  add_foreign_key "course_condition_videos", "course_videos", column: "video_id"
   add_foreign_key "course_conditions", "courses", name: "fk_course_conditions_course_id"
   add_foreign_key "course_conditions", "users", column: "creator_id", name: "fk_course_conditions_creator_id"
   add_foreign_key "course_conditions", "users", column: "updater_id", name: "fk_course_conditions_updater_id"
@@ -2223,8 +2223,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_02_000000) do
   add_foreign_key "course_groups", "course_group_categories", column: "group_category_id"
   add_foreign_key "course_groups", "users", column: "creator_id", name: "fk_course_groups_creator_id"
   add_foreign_key "course_groups", "users", column: "updater_id", name: "fk_course_groups_updater_id"
-  add_foreign_key "course_learning_maps", "courses", name: "fk_course_learning_maps_course_id"
-  add_foreign_key "course_learning_rate_records", "course_users", name: "fk_course_learning_rate_records_course_user_id"
+  add_foreign_key "course_learning_maps", "courses"
+  add_foreign_key "course_learning_rate_records", "course_users"
   add_foreign_key "course_lesson_plan_event_materials", "course_lesson_plan_events", column: "lesson_plan_event_id", name: "fk_course_lesson_plan_event_materials_lesson_plan_event_id"
   add_foreign_key "course_lesson_plan_event_materials", "course_materials", column: "material_id", name: "fk_course_lesson_plan_event_materials_material_id"
   add_foreign_key "course_lesson_plan_items", "courses", name: "fk_course_lesson_plan_items_course_id"


### PR DESCRIPTION
# fix(db): resolve deltas between `db/schema.rb` and production

## Problem

Every migration we merge produces a diff in `db/schema.rb` containing changes unrelated to that migration. The unrelated hunks flip back and forth between PRs depending on who ran `db:migrate`, and they have never broken a deploy — production only ever runs `db:migrate`, and never reads `schema.rb`.

The cause is that `db/schema.rb` did not describe the production database. `db:migrate` regenerates the **entire** file from whatever database the developer happens to have, so:

- a developer whose database came from `db:schema:load` / `db:reset` dumps one variant;
- a developer whose database descends from a production restore dumps another;
- whoever merges last flips every divergent line to their variant.

This PR restores the committed file to production's actual state at every site where the two disagreed and the disagreement was fixable, so the file stops oscillating.

Verified against a local restore of the production backup, and confirmed on production by querying database table information directly.

## Method

Dump the schema from a database restored from the production backup and diff it against the committed file:

```bash
SCHEMA=/tmp/schema_from_db.rb bin/rails db:schema:dump
diff db/schema.rb /tmp/schema_from_db.rb
```

Each resulting hunk was then traced to the commit that introduced it, and classified as either a real production state that `schema.rb` misreported, or an artefact of the environment that produced the dump.

Every **Verification** query below is read-only and was run against production.

## Changes

### 1. `course_discussion_post_codaveri_feedbacks.status` — added `default: 0`

```diff
-    t.integer "status"
+    t.integer "status", default: 0
```

**Investigation.** [`20220819091113_create_new_codaveri_feedbacks_table.rb`](db/migrate/20220819091113_create_new_codaveri_feedbacks_table.rb) declares `t.integer :status, index: true, default: 0`, and production has the default. Introduced by [`7016f9095`](https://github.com/Coursemology/coursemology2/commit/7016f90955e30cf44d0ae815528cc85aac49ff66), where the `schema.rb` written into the commit simply omitted it.

**Resolution.** `schema.rb` now states the default the migration always created. No production change.

**Verification.**

```sql
SELECT table_name, column_name, data_type, is_nullable, column_default
FROM information_schema.columns
WHERE table_schema = 'public'
  AND table_name = 'course_discussion_post_codaveri_feedbacks'
  AND column_name = 'status';
```

Expected: `column_default` is `0`, confirming the committed `default: 0`.

<!-- PASTE PRODUCTION OUTPUT BELOW -->
```
                table_name                 | column_name | data_type | is_nullable | column_default 
-------------------------------------------+-------------+-----------+-------------+----------------
 course_discussion_post_codaveri_feedbacks | status      | integer   | YES         | 0
(1 row)
```

### 2. `course_condition_surveys` — removed `id: :serial`

```diff
-  create_table "course_condition_surveys", id: :serial, force: :cascade do |t|
+  create_table "course_condition_surveys", force: :cascade do |t|
```

**Investigation.** [`20210821030941_create_course_condition_surveys.rb`](db/migrate/20210821030941_create_course_condition_surveys.rb) is an `ActiveRecord::Migration[5.2]` `create_table` with no `id:` option, so it creates a **bigint** primary key. Production has bigint. The table was first dumped correctly, as bigint, by [`4c776e758`](https://github.com/Coursemology/coursemology2/commit/4c776e7585f142c3e8c5da11cea24b6384223872).

The `id: :serial` was introduced by the merge commit [`75b1db675`](https://github.com/Coursemology/coursemology2/commit/75b1db6756956e78dc6a1e268b531908bbc90bf7) ("Merge newest coursemology2 changes"), and git shows it was **hand-typed, not dumped**. In a combined merge diff, `++` marks lines present in neither parent. Exactly two lines carry it:

```
++  create_table "course_condition_surveys", id: :serial, force: :cascade do |t|
+     t.bigint "survey_id", null: false            <- from a parent
+     t.index [...]                                <- from a parent
++  add_foreign_key ... name: "fk_course_condition_surveys_survey_id"
```

That merge pulled in a Rails 6-era dump in which every genuinely-integer legacy table gained an explicit `id: :serial`. The conflicting `course_condition_surveys` block was re-typed by hand, copying `id: :serial` from its neighbours and inventing an FK name to match the surrounding `fk__*` convention. No database has ever been in that state.

**Resolution.** Removed. The table now reads as bigint, consistent with `course_condition_videos` and with production. No production change.

**Verification.**

```sql
SELECT c.column_name,
       c.data_type,
       c.is_nullable,
       c.column_default,
       pg_get_serial_sequence('course_condition_surveys', 'id') AS owned_sequence
FROM information_schema.columns c
WHERE c.table_schema = 'public'
  AND c.table_name   = 'course_condition_surveys'
  AND c.column_name  = 'id';
```

Expected: `data_type` is `bigint`, not `integer`. Had it been `integer`, `id: :serial` would have been correct and should have stayed.

```
 column_name | data_type | is_nullable |                    column_default                    |             owned_sequence             
-------------+-----------+-------------+------------------------------------------------------+----------------------------------------
 id          | bigint    | NO          | nextval('course_condition_surveys_id_seq'::regclass) | public.course_condition_surveys_id_seq
(1 row)
```

### 3. Four `add_foreign_key` lines — removed invented `name:` options

```diff
-  add_foreign_key "course_condition_surveys", "course_surveys", column: "survey_id", name: "fk_course_condition_surveys_survey_id"
-  add_foreign_key "course_condition_videos", "course_videos", column: "video_id", name: "fk_course_condition_videos_video_id"
+  add_foreign_key "course_condition_surveys", "course_surveys", column: "survey_id"
+  add_foreign_key "course_condition_videos", "course_videos", column: "video_id"
-  add_foreign_key "course_learning_maps", "courses", name: "fk_course_learning_maps_course_id"
-  add_foreign_key "course_learning_rate_records", "course_users", name: "fk_course_learning_rate_records_course_user_id"
+  add_foreign_key "course_learning_maps", "courses"
+  add_foreign_key "course_learning_rate_records", "course_users"
```

**Investigation.** Same root cause as #2 — these names were never created by any migration. The migrations name the *index* (`fk__course_condition_surveys_survey_id`, note the double underscore) but leave the FK constraint unnamed, so Rails generates `fk_rails_<hash>`.

The schema dumper omits `name:` precisely when the constraint carries Rails' own generated name, which is why these lines kept reverting.

**Resolution.** `name:` removed from all four. No production change.

**Verification.**

```sql
SELECT con.conrelid::regclass::text  AS child_table,
       a.attname                     AS child_column,
       con.confrelid::regclass::text AS parent_table,
       con.conname                   AS constraint_name,
       pg_get_constraintdef(con.oid) AS definition
FROM pg_constraint con
JOIN pg_attribute a
  ON a.attrelid = con.conrelid AND a.attnum = con.conkey[1]
WHERE con.contype = 'f'
  AND array_length(con.conkey, 1) = 1
  AND con.conrelid::regclass::text IN ('course_condition_surveys',
                                       'course_condition_videos',
                                       'course_learning_maps',
                                       'course_learning_rate_records')
ORDER BY child_table;
```

Expected: all four `constraint_name` values match `fk_rails_%`. Any custom name here would mean the corresponding `name:` should have been kept. The values seen on the production restore were:

| Table | Constraint name |
| --- | --- |
| `course_condition_surveys` | `fk_rails_d699b6eee8` |
| `course_condition_videos` | `fk_rails_3fbea0b16d` |
| `course_learning_maps` | `fk_rails_8ab49608b9` |
| `course_learning_rate_records` | `fk_rails_5f27d82a71` |

```
         child_table          |  child_column  |  parent_table  |   constraint_name   |                        definition                        
------------------------------+----------------+----------------+---------------------+----------------------------------------------------------
 course_condition_surveys     | survey_id      | course_surveys | fk_rails_d699b6eee8 | FOREIGN KEY (survey_id) REFERENCES course_surveys(id)
 course_condition_videos      | video_id       | course_videos  | fk_rails_3fbea0b16d | FOREIGN KEY (video_id) REFERENCES course_videos(id)
 course_learning_maps         | course_id      | courses        | fk_rails_8ab49608b9 | FOREIGN KEY (course_id) REFERENCES courses(id)
 course_learning_rate_records | course_user_id | course_users   | fk_rails_5f27d82a71 | FOREIGN KEY (course_user_id) REFERENCES course_users(id)
(4 rows)
```

### 4. Two `datetime` defaults — corrected to production's values, truncated to the second

```diff
-    t.datetime "last_graded_time", precision: nil, default: "2021-10-24 14:11:56"
+    # truncated to whole seconds due to ActiveRecord limitations
+    # see migrations/20211024140630_... for true value
+    t.datetime "last_graded_time", precision: nil, default: "2021-11-09 00:08:09"
```

(and the same for `courses.conditional_satisfiability_evaluation_time`.)

**Investigation.** Both migrations used `default: Time.now`:

- [`20211023070257_add_conditional_satisfiability_evaluation_time_to_courses.rb`](db/migrate/20211023070257_add_conditional_satisfiability_evaluation_time_to_courses.rb)
- [`20211024140630_add_last_graded_time_to_course_assessment_submissions.rb`](db/migrate/20211024140630_add_last_graded_time_to_course_assessment_submissions.rb)

`Time.now` is evaluated when the migration runs, so the DDL bakes in the wall-clock time of whoever ran it. Production ran both in a single deploy on **2021-11-09 00:08:09**; the committed values were a developer's local run on 2021-10-24. Both landed in [`32cbd9979`](https://github.com/Coursemology/coursemology2/commit/32cbd997955f9be00df6c1a35b4dfd7c5a70f898).

The migrations are now pinned to production's literal values (with microseconds), so a database rebuilt from scratch matches production exactly.

**On the truncation.** `schema.rb` cannot carry the microseconds. Rails renders every datetime default through `type_cast_for_schema` in [`activemodel/lib/active_model/type/helpers/time_value.rb`](https://github.com/rails/rails/blob/v8.0.5.1/activemodel/lib/active_model/type/helpers/time_value.rb), which is hardcoded to `value.to_fs(:db).inspect` — and `:db` is `"%Y-%m-%d %H:%M:%S"`. Traced live against production's value:

```
raw default from PG:  "2021-11-09 00:08:09.279414"
deserialized:         2021-11-09 00:08:09.279414 UTC (usec=279414)
type_cast_for_schema: "2021-11-09 00:08:09"      <- fractional seconds gone
```

There is no option controlling this; it is independent of the column's `precision`. Related upstream discussion of `precision: nil` semantics in PostgreSQL schema dumps: [rails/rails#44571](https://github.com/rails/rails/issues/44571).

**Resolution.** `schema.rb` carries the second-truncated value. This is stable in both directions: production (with microseconds) and a `schema:load` database (without) now dump to the identical line. The residual sub-second difference only affects the *default* for rows that omit the column, and is immaterial.

**Verification.**

```sql
SELECT table_name || '.' || column_name AS column_ref,
       data_type,
       column_default
FROM information_schema.columns
WHERE table_schema = 'public'
  AND (table_name, column_name) IN
      (('course_assessment_submissions', 'last_graded_time'),
       ('courses',                       'conditional_satisfiability_evaluation_time'))
ORDER BY 1;
```

Expected: the defaults read `'2021-11-09 00:08:09.318947'` and `'2021-11-09 00:08:09.279414'` respectively — i.e. the committed second-truncated literals are correct up to the sub-second part that `schema.rb` cannot express, and the old `2021-10-24` values were wrong outright.

```
                     column_ref                     |          data_type          |                      column_default                       
----------------------------------------------------+-----------------------------+-----------------------------------------------------------
 course_assessment_submissions.last_graded_time     | timestamp without time zone | '2021-11-09 00:08:09.318947'::timestamp without time zone
 courses.conditional_satisfiability_evaluation_time | timestamp without time zone | '2021-11-09 00:08:09.279414'::timestamp without time zone
(2 rows)
```

## Deliberately not changed

### `index_course_rubric_playground_evaluation_on_answer_rubric`

A local dump showed a different predicate from the committed one, but this is **not** production drift — it is an artefact of restoring a backup.

`evaluation_type IN (...)` in [`20260610232505_migrate_rubric_based_responses_to_v2.rb`](db/migrate/20260610232505_migrate_rubric_based_responses_to_v2.rb) is stored by PostgreSQL in a form that is not stable across `pg_dump`/restore. Tested on a scratch database:

| Index created from | PostgreSQL stores it as |
| --- | --- |
| `IN ('playground', 'playground_hidden')` (the migration) | **form A** — `ANY ((ARRAY[...])::text[])` |
| form A's own deparsed text (what `pg_dump` emits) | **form B** — `ANY (ARRAY[(...)::text, ...])` |
| form B's text | form B (stable) |

So restoring a production backup silently rewrites A into B. Production was queried directly and reports **form A**, which matches the committed `schema.rb`, so the line was left untouched.

**Verification.**

```sql
SELECT c.relname                          AS index_name,
       pg_get_expr(i.indpred, i.indrelid) AS predicate,
       CASE WHEN pg_get_expr(i.indpred, i.indrelid) LIKE '%])::text[]%'
            THEN 'form A - matches committed schema.rb'
            ELSE 'form B - post-restore normalisation, do NOT commit'
       END                                AS form
FROM pg_index i
JOIN pg_class c ON c.oid = i.indexrelid
WHERE c.relname = 'index_course_rubric_playground_evaluation_on_answer_rubric';
```

Expected: `form A`. A locally restored database reports form B — that is why this hunk must be checked against production and not against a restore.

```
                         index_name                         |                                                         predicate                                                          |                 form                 
------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+--------------------------------------
 index_course_rubric_playground_evaluation_on_answer_rubric | ((evaluation_type)::text = ANY ((ARRAY['playground'::character varying, 'playground_hidden'::character varying])::text[])) | form A - matches committed schema.rb
(1 row)
```

### Rails 8 dumper output

`ActiveRecord::Schema[7.2]` → `[8.0]` and `enable_extension "plpgsql"` → `"pg_catalog.plpgsql"` are genuine Rails-version dumper changes, not drift. They belong to the Rails 8 upgrade, and will be committed as part of the first migration post-Rails-upgrade.

## Follow-ups

Two sites remain out of sync and cannot be fixed by editing `schema.rb` alone — each needs either a migration or a change of schema format:

- `course_assessment_answer_programming_test_results.id` — the id sequence still carries its pre-2017-rename, PostgreSQL-truncated name, so the dumper cannot use the `serial` shorthand.
- `polyglot_languages.weight` — a nullable column with a `nextval` default, which the Ruby schema format cannot represent (`serial` implies `NOT NULL`).

Both are written up in full, with options and ready-to-run migrations, in a separate comment on this PR.

Until those land, `db:migrate` will still produce two unrelated hunks — down from the previous ten.
