### PR TITLE
fix(submissions): fix unhandled 404s in assessment/submission routes

### DIFF
--- a/client/app/api/ErrorHandling.ts
+++ b/client/app/api/ErrorHandling.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 
 import { AUTH_USER_MANAGER } from 'lib/components/wrappers/AuthProvider';
 import {
@@ -36,4 +36,21 @@ export const redirectIfMatchesErrorIn = (response?: AxiosResponse): void => {
     // Should open a new window and login
     redirectToForbidden();
   if (isComponentNotFoundResponse(response)) redirectToNotFound();
+};
+
+/**
+ * Redirects to the not-found page if `error` is a 404 response, and returns whether it
+ * did, so callers can skip their own error handling.
+ *
+ * The backend 404s when a resource doesn't exist under the parent resource in the URL,
+ * even if it exists under another parent, so this covers both a nonexistent ID and an
+ * ID belonging to someone else's course or assessment.
+ *
+ * This is opt-in rather than part of `redirectIfMatchesErrorIn` because some endpoints
+ * legitimately 404 as part of their normal flow, and expect to handle it themselves.
+ */
+export const redirectToNotFoundIfMissing = (error: unknown): boolean => {
+  const missing = (error as AxiosError)?.response?.status === 404;
+  if (missing) redirectToNotFound();
+  return missing;
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentShow/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentShow/index.tsx
@@ -5,6 +5,7 @@ import {
   isUnauthenticatedAssessmentData,
 } from 'types/course/assessment/assessments';
 
+import { redirectToNotFoundIfMissing } from 'api/ErrorHandling';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import Preload from 'lib/components/wrappers/Preload';
 
@@ -19,8 +20,16 @@ const AssessmentShow = (): JSX.Element => {
   const id = parseInt(params?.assessmentId ?? '', 10) || undefined;
   if (!id) throw new Error(`AssessmentShow was loaded with ID: ${id}.`);
 
-  const fetchAssessmentWithId = (): Promise<FetchAssessmentData> =>
-    fetchAssessment(id);
+  const fetchAssessmentWithId = async (): Promise<FetchAssessmentData> => {
+    try {
+      return await fetchAssessment(id);
+    } catch (error) {
+      // An ID that matches no assessment in this course 404s from the backend. Show the
+      // not-found page rather than `Preload`'s generic fetching error.
+      redirectToNotFoundIfMissing(error);
+      throw error;
+    }
+  };
 
   return (
     <Preload render={<LoadingIndicator />} while={fetchAssessmentWithId}>

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -1,5 +1,6 @@
 import GlobalAPI from 'api';
 import CourseAPI from 'api/course';
+import { redirectToNotFoundIfMissing } from 'api/ErrorHandling';
 import { setNotification } from 'lib/actions';
 import pollJob from 'lib/helpers/jobHelpers';
 
@@ -102,7 +103,12 @@ export function fetchSubmission(id, onGetMonitoringSessionId) {
           }),
         );
       })
-      .catch(() => {
+      .catch((error) => {
+        // An ID that matches no submission in this assessment 404s from the backend. The
+        // page has nothing to render for it, so show the not-found page instead of an
+        // empty attempt page.
+        if (redirectToNotFoundIfMissing(error)) return;
+
         dispatch({ type: actionTypes.FETCH_SUBMISSION_FAILURE });
         dispatch(resetExistingAnswerFlags());
       });

--- a/client/app/bundles/course/assessment/submission/actions/logs.ts
+++ b/client/app/bundles/course/assessment/submission/actions/logs.ts
@@ -1,10 +1,18 @@
 import { LogInfo } from 'types/course/assessment/submission/logs';
 
 import CourseAPI from 'api/course';
+import { redirectToNotFoundIfMissing } from 'api/ErrorHandling';
 
 const fetchLogs = async (): Promise<LogInfo> => {
-  const response = await CourseAPI.assessment.logs.index();
-  return response.data;
+  try {
+    const response = await CourseAPI.assessment.logs.index();
+    return response.data;
+  } catch (error) {
+    // As with the attempt page, an ID that matches no submission in this assessment 404s
+    // from the backend, and there are no logs to show for it.
+    redirectToNotFoundIfMissing(error);
+    throw error;
+  }
 };
 
 export default fetchLogs;

--- a/client/app/routers/course/assessments/submissions.tsx
+++ b/client/app/routers/course/assessments/submissions.tsx
@@ -1,4 +1,4 @@
-import { RouteObject } from 'react-router-dom';
+import { Navigate, RouteObject } from 'react-router-dom';
 import { WithRequired } from 'types';
 
 import { Translated } from 'lib/hooks/useTranslation';
@@ -25,6 +25,12 @@ const submissionsRouter: Translated<RouteObject> = (_) => ({
     {
       path: ':submissionId',
       children: [
+        {
+          // A submission on its own has no page of its own to show, so send it to
+          // the attempt page instead of rendering an empty outlet.
+          index: true,
+          element: <Navigate replace to="edit" />,
+        },
         {
           path: 'edit',
           lazy: async (): Promise<WithRequired<RouteObject, 'Component'>> => {


### PR DESCRIPTION
## Problem

Two dead ends in the submission and assessment routes:

**`/submissions/:id` rendered a blank page.** The `:submissionId` route has children but no element
of its own. React Router still creates a match branch for a parent route, so an exact
`/submissions/5` matched it and rendered a default `<Outlet />` with nothing inside — it never fell
through to the not-found route.

**A submission or assessment ID that doesn't exist showed no 404.** The backend returns 404, but the
frontend swallowed it:

| Page | Fetch | What the user saw |
| --- | --- | --- |
| Attempt (`submissions/:id/edit`) | `fetchSubmission` | Blank page — the catch only flipped `isLoading` off, leaving the page to render against an empty store |
| Assessment (`assessments/:id`) | `fetchAssessment` via `Preload` | Generic red "fetching error" note and toast |
| Access logs (`submissions/:id/logs`) | `fetchLogs` via `Preload` | Same generic error note |

The existing response interceptor only redirects on the 404 whose body says "component not found"
(a disabled course component). A missing record raises `ActiveRecord::RecordNotFound`, whose response
doesn't match, so nothing redirected.

## Change

An index route under `:submissionId` redirects to `edit`, matching the pattern already used for
`marketplace/listings`.

A `redirectToNotFoundIfMissing` helper in `api/ErrorHandling.ts` redirects to the not-found page on a
404 and returns whether it did, so callers can skip their own error handling. It is applied at the
three fetches above.

Note this covers more than a typo'd ID. Resources are loaded through their parent — `through: :course`
in `Course::Assessment::Controller`, `through: :assessment` in
`Course::Assessment::Submission::Controller` — so CanCanCan scopes the find to
`@course.assessments` / `@assessment.submissions`. An assessment that exists in *another* course
raises `RecordNotFound` before authorization ever runs, and so 404s rather than 403s. That is the
right split, and it means the not-found path leaks no existence information across courses.

## Why the helper is opt-in

The obvious alternative is to redirect on every 404 inside `redirectIfMatchesErrorIn`, in the
response interceptor. That would break callers that treat a 404 as a normal outcome — `sendOldSessions`
in the video submission actions uses it to detect a session the backend has already dropped. Keeping
it opt-in also leaves the existing local handling in `RubricPlaygroundPage` coherent.

`Preload`'s own `onErrorDo` was not usable for the two `Preload` pages: it receives
`error.response?.data`, not the status, so the check has to sit at the call site.