### PR TITLE
feat(comments): add opt-in flag to show/hide pending AI comments topics

### DIFF
--- a/app/controllers/course/admin/discussion/topic_settings_controller.rb
+++ b/app/controllers/course/admin/discussion/topic_settings_controller.rb
@@ -17,7 +17,7 @@ class Course::Admin::Discussion::TopicSettingsController < Course::Admin::Contro
   private
 
   def topic_settings_params
-    params.require(:settings_topics_component).permit(:title, :pagination)
+    params.require(:settings_topics_component).permit(:title, :pagination, :is_showing_ai_generated_comments)
   end
 
   def component

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -28,7 +28,7 @@ class Course::Discussion::TopicsController < Course::ComponentController
     @topics = if current_course_user&.student?
                 unread_topics_for_student
               else
-                all_topics.pending_staff_reply
+                hide_ai_generated_comments(all_topics.pending_staff_reply)
               end
 
     render_topics_list_data
@@ -40,7 +40,7 @@ class Course::Discussion::TopicsController < Course::ComponentController
   end
 
   def my_students_pending
-    @topics = my_students_topics.pending_staff_reply
+    @topics = hide_ai_generated_comments(my_students_topics.pending_staff_reply)
     render_topics_list_data
   end
 

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -14,20 +14,40 @@ module Course::Discussion::TopicsHelper
     format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)
   end
 
+  # Whether the course shows AI-generated comments in the staff pending counts/lists (set in the comments
+  # settings admin page). Defaults to true, preserving the existing behaviour of surfacing them.
+  #
+  # @return [Boolean]
+  def showing_ai_generated_comments?
+    value = current_course.settings(Course::Discussion::TopicsComponent.key).is_showing_ai_generated_comments
+    value.nil? || value
+  end
+
+  # Applies the "hide AI-generated comments" filter to a pending-topics relation, dropping topics whose
+  # latest post is an unreviewed AI draft, unless the course shows AI-generated comments.
+  #
+  # @param [ActiveRecord::Relation] topics A relation of pending topics.
+  # @return [ActiveRecord::Relation]
+  def hide_ai_generated_comments(topics)
+    showing_ai_generated_comments? ? topics : topics.without_ai_draft_latest_post
+  end
+
   # Returns the count of topics pending staff reply.
   #
   # @return [Integer] Returns the count of topics pending staff reply.
   def all_staff_unread_count
-    @all_staff_unread_count ||= current_course.discussion_topics.
-                                globally_displayed.pending_staff_reply.distinct.count
+    @all_staff_unread_count ||= hide_ai_generated_comments(
+      current_course.discussion_topics.globally_displayed.pending_staff_reply
+    ).distinct.count
   end
 
   def my_students_unread_count
     @my_students_unread_count ||=
       if current_course_user
         my_student_ids = current_course_user.my_students.pluck(:user_id)
-        topics = current_course.discussion_topics.globally_displayed.pending_staff_reply.distinct.
-                 includes(actable: [:submission, file: { answer: :submission }])
+        topics = hide_ai_generated_comments(
+          current_course.discussion_topics.globally_displayed.pending_staff_reply
+        ).distinct.includes(actable: [:submission, file: { answer: :submission }])
         topics.select { |topic| from_user(topic, my_student_ids) }.count
       else
         0

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -56,6 +56,24 @@ class Course::Discussion::Topic < ApplicationRecord
 
   scope :pending_staff_reply, -> { where(pending_staff_reply: true) }
 
+  # Excludes topics whose most recent post (by created_at) is an AI-generated draft. Such a topic surfaced
+  # as pending only because unreviewed AI feedback (e.g. rubric grading) was added and no human has posted
+  # since -- a staff reply/publish clears the pending flag, and a later student post becomes the latest
+  # post. Used to drop these from the staff pending counts/lists when the course hides AI comments.
+  #
+  # The NOT EXISTS is correlated to each candidate topic (this scope is always chained onto an already
+  # course- and pending-scoped relation), so the database inspects only that topic's own posts instead of
+  # scanning every AI draft in the instance.
+  scope :without_ai_draft_latest_post, lambda {
+    where(
+      'NOT EXISTS (SELECT 1 FROM course_discussion_posts ai_draft ' \
+      'WHERE ai_draft.topic_id = course_discussion_topics.id ' \
+      'AND ai_draft.is_ai_generated = TRUE AND ai_draft.workflow_state = ? ' \
+      'AND ai_draft.created_at = (SELECT MAX(p.created_at) FROM course_discussion_posts p ' \
+      'WHERE p.topic_id = course_discussion_topics.id))', 'draft'
+    )
+  }
+
   # Return if a user has subscribed to this topic
   #
   # @param [User] user The user to check
@@ -94,5 +112,14 @@ class Course::Discussion::Topic < ApplicationRecord
 
     self.pending_staff_reply = false
     save
+  end
+
+  # Whether this topic's most recent post is an AI-generated draft -- the per-topic counterpart of
+  # .without_ai_draft_latest_post. Surfaced to the comments UI so its optimistic pending-count updates can
+  # skip topics that the staff pending count already excludes when the course hides AI comments. Reads from
+  # the loaded posts association (preloaded by the topic list actions), so it adds no query.
+  def latest_post_ai_generated_draft?
+    latest_post = posts.max_by(&:created_at)
+    latest_post.present? && latest_post.is_ai_generated? && latest_post.draft?
   end
 end

--- a/app/models/course/settings/topics_component.rb
+++ b/app/models/course/settings/topics_component.rb
@@ -20,4 +20,17 @@ class Course::Settings::TopicsComponent < Course::Settings::Component
   def pagination=(count)
     settings.pagination = count
   end
+
+  # Whether AI-generated comments are shown in the staff pending counts and pending lists in the comments
+  # centre (see Course::Discussion::TopicsHelper). Defaults to true (coerced from an unset setting),
+  # preserving the existing behaviour of surfacing them; unchecking hides topics pending only on unreviewed
+  # AI feedback.
+  def is_showing_ai_generated_comments # rubocop:disable Naming/PredicatePrefix
+    value = settings.is_showing_ai_generated_comments
+    value.nil? || value
+  end
+
+  def is_showing_ai_generated_comments=(value)
+    settings.is_showing_ai_generated_comments = ActiveRecord::Type::Boolean.new.cast(value)
+  end
 end

--- a/app/views/course/admin/discussion/topic_settings/edit.json.jbuilder
+++ b/app/views/course/admin/discussion/topic_settings/edit.json.jbuilder
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 json.title @settings.title || ''
 json.pagination @settings.pagination.to_i
+json.isShowingAiGeneratedComments @settings.is_showing_ai_generated_comments

--- a/app/views/course/discussion/topics/_tabs.json.jbuilder
+++ b/app/views/course/discussion/topics/_tabs.json.jbuilder
@@ -7,6 +7,8 @@ json.tabs do
     json.myStudentExist my_students_exist
     json.myStudentUnreadCount my_students_unread_count if my_students_exist
     json.allStaffUnreadCount all_staff_unread_count
+    # Lets the client's optimistic pending-count updates skip AI-draft topics that these counts exclude.
+    json.isShowingAiGeneratedComments showing_ai_generated_comments?
   elsif current_course_user&.student?
     json.allStudentUnreadCount all_student_unread_count
   end

--- a/app/views/course/discussion/topics/_topic.json.jbuilder
+++ b/app/views/course/discussion/topics/_topic.json.jbuilder
@@ -5,8 +5,8 @@ json.postList topic.posts.ordered_topologically.flatten.each do |post|
   json.partial! 'course/discussion/posts/post', post: post if can_grade || post.published?
 end
 
+can_toggle_pending = can?(:manage, topic)
 json.topicPermissions do
-  can_toggle_pending = can?(:manage, topic)
   json.canTogglePending can_toggle_pending
   json.canMarkAsRead current_course_user&.student? unless can_toggle_pending
 end
@@ -14,4 +14,7 @@ end
 json.topicSettings do
   json.isPending topic.pending_staff_reply?
   json.isUnread topic.unread?(current_user)
+  if can_toggle_pending || !current_course_user&.student?
+    json.isAiGeneratedPending topic.latest_post_ai_generated_draft?
+  end
 end

--- a/client/app/bundles/course/admin/pages/CommentsSettings/CommentsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/CommentsSettings/CommentsSettingsForm.tsx
@@ -5,6 +5,7 @@ import { CommentsSettingsData } from 'types/course/admin/comments';
 import { number, object, string } from 'yup';
 
 import Section from 'lib/components/core/layouts/Section';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormTextField from 'lib/components/form/fields/TextField';
 import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -81,6 +82,23 @@ const CommentsSettingsForm = forwardRef<
               />
             )}
           />
+
+          <Controller
+            control={control}
+            name="isShowingAiGeneratedComments"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormCheckboxField
+                disabled={props.disabled}
+                field={field}
+                fieldState={fieldState}
+                label={t(translations.showAiGeneratedComments)}
+              />
+            )}
+          />
+
+          <Typography className="!mt-2" color="text.secondary" variant="body2">
+            {t(translations.showAiGeneratedCommentsHint)}
+          </Typography>
         </Section>
       )}
     </Form>

--- a/client/app/bundles/course/admin/pages/CommentsSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/CommentsSettings/operations.ts
@@ -20,6 +20,7 @@ export const updateCommentsSettings = async (
     settings_topics_component: {
       title: data.title,
       pagination: data.pagination,
+      is_showing_ai_generated_comments: data.isShowingAiGeneratedComments,
     },
   };
 

--- a/client/app/bundles/course/admin/pages/CommentsSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/CommentsSettings/translations.ts
@@ -5,4 +5,13 @@ export default defineMessages({
     id: 'course.admin.CommentsSettings.commentsSettings',
     defaultMessage: 'Comments settings',
   },
+  showAiGeneratedComments: {
+    id: 'course.admin.CommentsSettings.showAiGeneratedComments',
+    defaultMessage: 'Show AI-generated pending comments',
+  },
+  showAiGeneratedCommentsHint: {
+    id: 'course.admin.CommentsSettings.showAiGeneratedCommentsHint',
+    defaultMessage:
+      "When disabled, topics awaiting review for AI-generated feedback are excluded from the 'Pending' and 'My Students Pending' tabs. The comments still appear normally elsewhere.",
+  },
 });

--- a/client/app/bundles/course/discussion/topics/store.ts
+++ b/client/app/bundles/course/discussion/topics/store.ts
@@ -7,6 +7,7 @@ import {
   CommentTabInfo,
   CommentTabTypes,
   CommentTopicData,
+  CommentTopicEntity,
 } from 'types/course/comments';
 import {
   createEntityStore,
@@ -35,6 +36,18 @@ import {
   UPDATE_POST,
   UpdatePostAction,
 } from './types';
+
+// A topic contributes to the staff pending counts unless the course hides AI-generated comments and this
+// topic's latest post is an AI draft -- the server already excludes such topics from those counts, so the
+// optimistic updates below must leave the staff counts untouched for them.
+const affectsStaffPendingCount = (
+  state: CommentState,
+  topic: CommentTopicEntity,
+): boolean =>
+  !(
+    state.tabs.isShowingAiGeneratedComments === false &&
+    topic.topicSettings.isAiGeneratedPending
+  );
 
 const initialState: CommentState = {
   topicCount: 0,
@@ -112,32 +125,38 @@ const reducer = produce((draft: CommentState, action: CommentActionType) => {
         };
         saveEntityToStore(draft.topicList, newTopic);
 
-        // To update pending bubble count shown on the comment tabs.
-        if (topic.topicSettings.isPending) {
-          if (
-            draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS_PENDING ||
-            draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS
-          ) {
-            draft.tabs.myStudentUnreadCount! -= 1;
-            draft.tabs.allStaffUnreadCount! -= 1;
-          } else if (
-            draft.pageState.tabValue === CommentTabTypes.PENDING ||
-            draft.pageState.tabValue === CommentTabTypes.ALL
-          ) {
-            draft.tabs.allStaffUnreadCount! -= 1;
-          }
-        } else if (!topic.topicSettings.isPending) {
-          if (
-            draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS_PENDING ||
-            draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS
-          ) {
-            draft.tabs.myStudentUnreadCount! += 1;
-            draft.tabs.allStaffUnreadCount! += 1;
-          } else if (
-            draft.pageState.tabValue === CommentTabTypes.PENDING ||
-            draft.pageState.tabValue === CommentTabTypes.ALL
-          ) {
-            draft.tabs.allStaffUnreadCount! += 1;
+        // To update pending bubble count shown on the comment tabs. When the course hides AI-generated
+        // comments, an AI-draft topic is excluded from the staff counts server-side (yet still listed in
+        // All/My Students), so toggling it here must not shift those counts.
+        if (affectsStaffPendingCount(draft, topic)) {
+          if (topic.topicSettings.isPending) {
+            if (
+              draft.pageState.tabValue ===
+                CommentTabTypes.MY_STUDENTS_PENDING ||
+              draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS
+            ) {
+              draft.tabs.myStudentUnreadCount! -= 1;
+              draft.tabs.allStaffUnreadCount! -= 1;
+            } else if (
+              draft.pageState.tabValue === CommentTabTypes.PENDING ||
+              draft.pageState.tabValue === CommentTabTypes.ALL
+            ) {
+              draft.tabs.allStaffUnreadCount! -= 1;
+            }
+          } else if (!topic.topicSettings.isPending) {
+            if (
+              draft.pageState.tabValue ===
+                CommentTabTypes.MY_STUDENTS_PENDING ||
+              draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS
+            ) {
+              draft.tabs.myStudentUnreadCount! += 1;
+              draft.tabs.allStaffUnreadCount! += 1;
+            } else if (
+              draft.pageState.tabValue === CommentTabTypes.PENDING ||
+              draft.pageState.tabValue === CommentTabTypes.ALL
+            ) {
+              draft.tabs.allStaffUnreadCount! += 1;
+            }
           }
         }
       }
@@ -173,14 +192,19 @@ const reducer = produce((draft: CommentState, action: CommentActionType) => {
             ...topic.topicSettings,
             isPending: false,
             isUnread: false,
+            isAiGeneratedPending: false,
           },
         };
         saveEntityToStore(draft.topicList, newTopic);
 
         // To update pending bubble count shown on the comment tabs.
         // When a new post of a topic is created, mark_as_pending is marked as false
-        // in the backend side.
-        if (topic.topicSettings.isPending) {
+        // in the backend side. A topic already excluded from the staff counts (hidden AI draft) was never
+        // counted, so it must not be decremented here either.
+        if (
+          affectsStaffPendingCount(draft, topic) &&
+          topic.topicSettings.isPending
+        ) {
           if (
             draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS_PENDING ||
             draft.pageState.tabValue === CommentTabTypes.MY_STUDENTS

--- a/client/app/types/course/admin/comments.ts
+++ b/client/app/types/course/admin/comments.ts
@@ -1,11 +1,13 @@
 export interface CommentsSettingsData {
   title: string;
   pagination: number;
+  isShowingAiGeneratedComments: boolean;
 }
 
 export interface CommentsSettingsPostData {
   settings_topics_component: {
     title: CommentsSettingsData['title'];
     pagination: CommentsSettingsData['pagination'];
+    is_showing_ai_generated_comments: CommentsSettingsData['isShowingAiGeneratedComments'];
   };
 }

--- a/client/app/types/course/comments.ts
+++ b/client/app/types/course/comments.ts
@@ -29,6 +29,7 @@ export interface CommentSettings {
 export interface CommentTopicSettings {
   isPending: boolean;
   isUnread: boolean;
+  isAiGeneratedPending: boolean;
   topicCount: number;
 }
 
@@ -37,6 +38,7 @@ export interface CommentTabInfo {
   myStudentUnreadCount?: number;
   allStaffUnreadCount?: number;
   allStudentUnreadCount?: number;
+  isShowingAiGeneratedComments?: boolean;
 }
 
 export interface CommentTopicListData {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -650,6 +650,12 @@
   "course.admin.CommentsSettings.commentsSettings": {
     "defaultMessage": "Comments settings"
   },
+  "course.admin.CommentsSettings.showAiGeneratedComments": {
+    "defaultMessage": "Show AI-generated pending comments"
+  },
+  "course.admin.CommentsSettings.showAiGeneratedCommentsHint": {
+    "defaultMessage": "When disabled, topics awaiting review for AI-generated feedback are excluded from the 'Pending' and 'My Students Pending' tabs. The comments still appear normally elsewhere."
+  },
   "course.admin.ComponentSettings.componentSettings": {
     "defaultMessage": "Components settings"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -650,6 +650,12 @@
   "course.admin.CommentsSettings.commentsSettings": {
     "defaultMessage": "댓글 설정"
   },
+  "course.admin.CommentsSettings.showAiGeneratedComments": {
+    "defaultMessage": "AI 생성 검토 대기 댓글 표시"
+  },
+  "course.admin.CommentsSettings.showAiGeneratedCommentsHint": {
+    "defaultMessage": "비활성화하면, AI 생성 피드백에 대한 검토 대기 주제가 '검토 대기' 및 '내 학생 검토 대기' 탭에서 제외됩니다. 해당 댓글은 다른 곳에서는 정상적으로 표시됩니다."
+  },
   "course.admin.ComponentSettings.componentSettings": {
     "defaultMessage": "컴포넌트 설정"
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -650,6 +650,12 @@
   "course.admin.CommentsSettings.commentsSettings": {
     "defaultMessage": "评论设置"
   },
+  "course.admin.CommentsSettings.showAiGeneratedComments": {
+    "defaultMessage": "显示 AI 生成的待处理评论"
+  },
+  "course.admin.CommentsSettings.showAiGeneratedCommentsHint": {
+    "defaultMessage": "停用后，等待审核 AI 生成反馈的主题将从「待处理」和「我的学生待处理」标签页中排除。这些评论仍会在其他位置正常显示。"
+  },
   "course.admin.ComponentSettings.componentSettings": {
     "defaultMessage": "组件设置"
   },

--- a/spec/controllers/course/admin/discussion/topic_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/discussion/topic_settings_controller_spec.rb
@@ -27,5 +27,20 @@ RSpec.describe Course::Admin::Discussion::TopicSettingsController do
         end
       end
     end
+
+    describe '#update persisting is_showing_ai_generated_comments' do
+      subject do
+        patch :update, format: :json, params: {
+          course_id: course, settings_topics_component: { is_showing_ai_generated_comments: false }
+        }
+      end
+
+      it 'stores the flag on the topics component settings' do
+        expect(subject).to render_template(:edit)
+        expect(
+          course.reload.settings(Course::Discussion::TopicsComponent.key).is_showing_ai_generated_comments
+        ).to be(false)
+      end
+    end
   end
 end

--- a/spec/controllers/course/discussion/topics_controller_spec.rb
+++ b/spec/controllers/course/discussion/topics_controller_spec.rb
@@ -66,6 +66,21 @@ RSpec.describe Course::Discussion::TopicsController do
           subject
           expect(topics).to contain_exactly(pending_topic)
         end
+
+        context 'and the course hides AI-generated comments' do
+          before do
+            course.settings(Course::Discussion::TopicsComponent.key).is_showing_ai_generated_comments = false
+            course.save!
+            create(:course_discussion_post, topic: pending_topic,
+                                            is_ai_generated: true, workflow_state: :draft,
+                                            created_at: 1.hour.from_now)
+          end
+
+          it 'excludes topics whose latest post is an AI-generated draft' do
+            subject
+            expect(topics).to be_empty
+          end
+        end
       end
 
       context 'when a course student visits the page' do

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -228,5 +228,81 @@ RSpec.describe Course::Discussion::Topic, type: :model do
         end
       end
     end
+
+    describe '.without_ai_draft_latest_post' do
+      let(:topic) { create(:course_discussion_topic) }
+      subject(:result) { Course::Discussion::Topic.without_ai_draft_latest_post }
+
+      def post_at(time, **attrs)
+        create(:course_discussion_post, topic: topic, created_at: time, **attrs)
+      end
+
+      context 'when the most recent post is an AI-generated draft' do
+        before do
+          post_at(2.hours.ago)
+          post_at(1.hour.ago, is_ai_generated: true, workflow_state: :draft)
+        end
+
+        it 'excludes the topic' do
+          expect(result).not_to include(topic)
+        end
+      end
+
+      context 'when a human post is more recent than the AI draft' do
+        before do
+          post_at(2.hours.ago, is_ai_generated: true, workflow_state: :draft)
+          post_at(1.hour.ago)
+        end
+
+        it 'includes the topic' do
+          expect(result).to include(topic)
+        end
+      end
+
+      context 'when the most recent AI post is published rather than a draft' do
+        before { post_at(1.hour.ago, is_ai_generated: true, workflow_state: :published) }
+
+        it 'includes the topic' do
+          expect(result).to include(topic)
+        end
+      end
+
+      context 'with only human posts' do
+        before { post_at(1.hour.ago) }
+
+        it 'includes the topic' do
+          expect(result).to include(topic)
+        end
+      end
+    end
+
+    describe '#latest_post_ai_generated_draft?' do
+      let(:topic) { create(:course_discussion_topic) }
+
+      def post_at(time, **attrs)
+        create(:course_discussion_post, topic: topic, created_at: time, **attrs)
+      end
+
+      it 'is true when the most recent post is an AI-generated draft' do
+        post_at(2.hours.ago)
+        post_at(1.hour.ago, is_ai_generated: true, workflow_state: :draft)
+        expect(topic.reload.latest_post_ai_generated_draft?).to be(true)
+      end
+
+      it 'is false when a human post is more recent' do
+        post_at(2.hours.ago, is_ai_generated: true, workflow_state: :draft)
+        post_at(1.hour.ago)
+        expect(topic.reload.latest_post_ai_generated_draft?).to be(false)
+      end
+
+      it 'is false when the most recent AI post is published' do
+        post_at(1.hour.ago, is_ai_generated: true, workflow_state: :published)
+        expect(topic.reload.latest_post_ai_generated_draft?).to be(false)
+      end
+
+      it 'is false with no posts' do
+        expect(topic.latest_post_ai_generated_draft?).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation

Rubric AI grading creates a draft feedback comment on each graded answer and marks its discussion topic
as pending staff reply. On courses that autograde at scale this floods the comments centre's **Pending**
count with topics that are only waiting because of unreviewed AI drafts.

## Change

A new component setting in **`/admin/comments`** — **"Show AI-generated pending comments"** — controls
whether those topics count toward the staff pending views. Default is **on** (checked), preserving today's
behaviour.

When unchecked, topics whose **most recent post is an AI-generated draft** are dropped from:

- the **Pending** count (sidebar badge + tab) and its list, and
- the **My Students Pending** count and list.

Everything else is untouched — the "All" tab, student views, and the comments themselves inside the
assessment/forum threads all behave exactly as before.

### Why "latest post is an AI draft"

The `pending_staff_reply` flag is a single boolean with no record of *why* a topic is pending. But a staff
reply/publish clears it, and a later student post becomes the newest post, so among currently-pending
topics an AI-generated post is always a draft and always the latest one. "Latest post is an AI draft"
therefore means exactly "pending only because of unreviewed AI feedback", and a genuine student follow-up
keeps the topic counted.

## Implementation

- **Setting** — `is_showing_ai_generated_comments` on `Course::Settings::TopicsComponent` (settings_on_rails,
  no migration), defaulting to `true` when unset.
- **Scope** — `Course::Discussion::Topic.without_ai_draft_latest_post` (a correlated subquery matching
  topics whose max-`created_at` post is `is_ai_generated` + `draft`).
- **Application** — a helper in `Course::Discussion::TopicsHelper` applies the scope to
  `all_staff_unread_count` / `my_students_unread_count` and to the `pending` / `my_students_pending`
  controller actions when the course opts out of showing them.
- **Admin UI** — a checkbox + hint in `CommentsSettingsForm`; `en` / `ko` / `zh` locale strings.

## Scope note

The filter keys off `is_ai_generated`, which rubric grading sets. Codaveri annotation drafts also mark
topics pending but are **not** flagged `is_ai_generated` (identified only by `creator: User.system`), so
they are unaffected. Forum auto-answer posts live on `Course::Forum` topics, not the comments centre, and
are out of scope. Both can be folded in later if desired.

## Tests

- Topic scope spec (latest AI draft excluded; newer human post kept; published AI post kept; human-only
  kept).
- `#pending` controller integration test (AI-draft-latest topic excluded when the setting is off).
- Admin settings round-trip test persisting the flag.
