### PR TITLE
Rails 8.1 readiness: wrap perform_later jobs in explicit after_commit blocks

### DIFF
--- a/app/controllers/concerns/course/users_controller_management_concern.rb
+++ b/app/controllers/concerns/course/users_controller_management_concern.rb
@@ -90,7 +90,9 @@ module Course::UsersControllerManagementConcern
 
       to_notify = to_suspend.reject(&:is_suspended?)
       to_suspend.update_all(is_suspended: true)
-      to_notify.each { |cu| Course::Mailer.user_suspended_email(cu).deliver_later }
+      ActiveRecord.after_all_transactions_commit do
+        to_notify.each { |cu| Course::Mailer.user_suspended_email(cu).deliver_later }
+      end
 
       head :ok
     end
@@ -107,7 +109,9 @@ module Course::UsersControllerManagementConcern
 
       to_notify = to_unsuspend.select(&:is_suspended?)
       to_unsuspend.update_all(is_suspended: false)
-      to_notify.each { |cu| Course::Mailer.user_unsuspended_email(cu).deliver_later }
+      ActiveRecord.after_all_transactions_commit do
+        to_notify.each { |cu| Course::Mailer.user_unsuspended_email(cu).deliver_later }
+      end
 
       head :ok
     end


### PR DESCRIPTION
This is the last **application-code** PR before the Rails 8.0 → 8.1 version bump. It lands on Rails
8.0.5.1 so the bump itself stays a pure dependency change.

The code diff is deliberately tiny — **two call sites** — but the PR carries the full audit of the four
remaining Rails 8.1 application-code items previously flagged by Claude during the migration process. Every one of them turned
out to be a **verified no-op**, and the sections below record *how* that was established so a reviewer
does not have to take it on faith, and so we do not re-litigate it during the bump.

| Rails 8.1 item | Verdict | Code change |
| --- | --- | --- |
| `config.active_job.enqueue_after_transaction_commit` **removed** | No-op — auto-deferral was never on | none |
| `to_time` always preserves timezone | No-op — already on 8.1 behaviour via `load_defaults 8.0` | none |
| Order-dependent finders without `order` **deprecated** | Structurally unreachable — every model has a PK | none |
| `insert_all`/`upsert_all` with unpersisted association records **deprecated** | Unreachable — all call sites are class-level | none |

Two corrections to the checklist's earlier assumptions came out of this and are folded into the docs:
the `enqueue_after_transaction_commit` value does **not** come from `load_defaults`, and the
order-dependent-finder deprecation is **far** narrower than "watch the deprecation-log volume across ~82
`.first`/`.last` sites".

---

## The change

Two `deliver_later` calls inside explicit transactions were not wrapped in
`ActiveRecord.after_all_transactions_commit`, unlike the 18 sites [migrated in the PR that introduced it.](https://github.com/Coursemology/coursemology2/pull/8543). They were the only
un-wrapped in-transaction enqueues left in the app.

`app/controllers/concerns/course/users_controller_management_concern.rb`

```diff
       to_notify = to_suspend.reject(&:is_suspended?)
       to_suspend.update_all(is_suspended: true)
-      to_notify.each { |cu| Course::Mailer.user_suspended_email(cu).deliver_later }
+      ActiveRecord.after_all_transactions_commit do
+        to_notify.each { |cu| Course::Mailer.user_suspended_email(cu).deliver_later }
+      end
```

…and the mirrored change in `#unsuspend` for `user_unsuspended_email`.

**Why this is correct, not just consistent.** Auto-deferral is off (see item 1), so today these enqueue
*immediately, mid-transaction* — mail can be sent for a transaction that later rolls back. The blast
radius is currently small (only `head :ok` follows the enqueue), which is why this reads as a
consistency fix rather than an outage. It is still a real ordering bug, and wrapping it removes the
last place where our deferral behaviour depends on the ActiveJob default rather than on explicit code.

`to_notify` is already a materialised `Array` at that point — `reject`/`select` force the relation to
load *before* `update_all` — so the closure captures loaded records, not a lazy relation that would
re-query post-commit and come back empty.

---

## Item 1 — `enqueue_after_transaction_commit` config removal

**The Rails change.** Rails 7.2 introduced `config.active_job.enqueue_after_transaction_commit`; 8.0
deprecated it; **8.1 removes it** along with the `:always` / `:never` / `:default` values.

**Why it cannot affect us.** The railtie only overrides the attribute when the config key is explicitly
present:

> `activejob-8.0.5.1/lib/active_job/railtie.rb:33`
> ```ruby
> if app.config.active_job.key?(:enqueue_after_transaction_commit)
> ```

We never set it, and — contrary to the checklist's earlier note — **`load_defaults` never sets it
either** (zero hits for the key across `railties-8.0.5.1/lib`). The effective value therefore comes from
the class attribute default:

> `activejob-8.0.5.1/lib/active_job/enqueuing.rb:53`
> ```ruby
> class_attribute :enqueue_after_transaction_commit, instance_accessor: false,
>                 instance_predicate: false, default: false
> ```

…which Rails 8.1 **keeps**. Runtime confirmation under `-e test`:

```
base_value=false          config_key_set=false
module_included=true      overriding_subclasses=[]     # after eager_load!, across all 43 job classes
```

Auto-deferral has been **off the entire time**, production included, so nothing can have been relying on
it. Removing the config changes nothing.

**Adjacent finding — the Sidekiq adapter is a red herring.** The Sidekiq gem's adapter declares
`enqueue_after_transaction_commit? => true`
(`sidekiq-7.3.10/lib/active_job/queue_adapters/sidekiq_adapter.rb:17`), and it *is* the adapter that
wins at runtime (`source_location` resolves to the gem, not to activejob). That looked like a way for
deferral to switch on silently when we move to the gem-provided adapter for 8.1 — but activejob 8.0 has
**zero call sites** for that method; the 7.2-era `:default` handshake was removed when `:default` was
collapsed to `false`. The declaration is dead code. The adapter switch is safe.

**⚠️ Forward risk (8.2, not 8.1).** Rails 8.2 flips the default to `true`. At that point every
`perform_later` / `deliver_later` inside a transaction becomes implicitly deferred, and
`TrackableJob#wait` — which enqueues and then waits within a single transaction — would deadlock. The
cheap insurance when we get there is `ActiveJob::Base.enqueue_after_transaction_commit = false` in an
initializer; direct assignment on the class survives the config removal.

---

## Item 2 — `to_time` timezone change

**The Rails change.** 8.1 makes `to_time` always preserve the receiver's timezone and deprecates
`config.active_support.to_time_preserves_timezone`.

**Why it cannot affect us — we are already on the 8.1 behaviour.** `load_defaults 8.0` sets the value to
`:zone`:

> `railties-8.0.5.1/lib/rails/application/configuration.rb:341`
> ```ruby
> active_support.to_time_preserves_timezone = :zone
> ```

Confirmed at runtime (`to_time_preserves_timezone = :zone`). Production has been running the 8.1
semantics since the 8.0 hop. 8.1 only deprecates the *setting*, which we never set — so there is nothing
to opt into and nothing to remove.

**Call-site audit.** Exactly **two** `to_time` usages exist in `app/` + `lib/` (none in `spec/` or
`db/`), both in `course/assessment/submission/statistics_download_service.rb` (`:98`, `:142`), and both
are `.to_time.to_i` durations.

**Why they are safe regardless of the setting.** `to_time` never changes the instant — all three
branches call `getlocal`, which re-renders the same epoch rather than shifting it:

> `activesupport-8.0.5.1/lib/active_support/time_with_zone.rb:493`
> ```ruby
> def to_time
>   if preserve_timezone == :zone   then @to_time_with_timezone        ||= getlocal(time_zone)
>   elsif preserve_timezone         then @to_time_with_instance_offset ||= getlocal(utc_offset)
>   else                                 @to_time_with_system_offset   ||= getlocal
>   end
> end
> ```

Measured under all three settings with `TZ=UTC`, which forces the legacy branch to *render* differently:

```
TZ=UTC  :zone    to_time=2026-08-24 09:00:00 +0800   to_i=1787533200
TZ=UTC  :offset  to_time=2026-08-24 09:00:00 +0800   to_i=1787533200
TZ=UTC  false    to_time=2026-08-24 01:00:00 +0000   to_i=1787533200
```

Different rendering, identical epoch. These would be safe even if they were absolute values rather than
differences.

The CSV's absolute time columns (`csv_created_at`, `csv_submitted_date_time`, `csv_graded_at`) never
touch `to_time` at all — they go through `format_datetime` →
`in_time_zone(user_zone).to_formatted_s` (`app/helpers/application_formatters_helper.rb:69`). Separate
path, also unaffected.

**Related confirmation — our timestamp model is uniformly UTC.** Checked while auditing this item, since
it is the premise the whole analysis rests on:

- `config.time_zone` is unset → `"UTC"`; `ActiveRecord.default_timezone` → `:utc`;
  `time_zone_aware_attributes` → `true`; PG session `TimeZone` → `UTC`.
- All **243** datetime columns are `timestamp without time zone` — no `timestamptz` anywhere.
- AR converts to UTC on write regardless of `Time.zone`. Round-trip probe:

  | `Time.zone` at write | `Time.zone.parse("09:00")` | value stored in the column |
  | --- | --- | --- |
  | Singapore | `09:00 +08` | `2026-08-24 01:00:00` |
  | UTC | `09:00 UTC` | `2026-08-24 09:00:00` |
  | America/New_York | `09:00 EDT` | `2026-08-24 13:00:00` |

- Real data agrees: newest `users.created_at` = `2026-08-23 15:51:33` against DB `now()` of
  `16:22 UTC` (Singapore would have been `00:22` the next day).
- The per-request `Time.use_zone(current_user.time_zone)` in
  `app/controllers/concerns/application_user_time_zone_concern.rb:13` (defaulting to `Singapore`)
  affects **parsing and rendering only**, never storage.

**UTC in the database, UTC+8 only at the presentation boundary.**

---

## Item 3 — Order-dependent finders without `order`

**The Rails change.** [rails/rails#54608](https://github.com/rails/rails/pull/54608) deprecates
order-dependent finders when no ordering can be inferred, adds
`ActiveRecord.raise_on_missing_required_finder_order_columns` (default `false`), and introduces
`ActiveRecord::MissingRequiredOrderError` — which replaces the deprecation in **8.2**.

**✏️ The checklist's earlier framing was wrong**, and this is the correction most worth carrying
forward. The item read *"~82 `.first`/`.last` in models/controllers … watch the deprecation-log
volume"*, implying a broad, noisy deprecation. The actual guard:

> `activerecord-8.1.3/lib/active_record/relation/finder_methods.rb:641`
> ```ruby
> def ordered_relation
>   if order_values.empty?
>     if !_order_columns.empty?
>       return order(_order_columns.map { |column| table[column].asc })
>     end
>     # …deprecate / raise here…
> ```
> ```ruby
> def _order_columns
>   columns = Array(model.implicit_order_column)
>   return columns.compact if columns.length.positive? && columns.last.nil?
>   columns += Array(model.query_constraints_list || model.primary_key)
>   columns.uniq.compact
> end
> ```

It fires only when the relation has no `order` **and** the model has no `implicit_order_column`, no
`query_constraints`, **and no primary key**. A PK'd model gets its implicit `order(:id)` and never warns,
however many finders are called on it. **The count of `.first`/`.last` call sites is irrelevant** — the
only question is whether any model lacks a primary key.

Note also that it affects **`#first` as well as `#last`** (both route through `ordered_relation` — lines
608/627 via `find_nth` → `find_nth_with_limit`, and line 205 respectively). Several write-ups claim
`#first` is exempt; the 8.1.3 source says otherwise.

**Audit.**

- *Static:* `db/schema.rb` contains no `id: false` and no `primary_key:` overrides; `app/` + `lib/`
  contain no `self.primary_key`, `implicit_order_column`, or `query_constraints`.
- *Runtime:* all **207** concrete, table-backed AR models have non-empty order columns. That includes
  the two lazily-created HABTM join models (`Course::QuestionAssessment::HABTM_Skills`,
  `Course::Assessment::Skill::HABTM_QuestionAssessments`) — their join table
  `course_assessment_skills_question_assessments` unusually *does* carry an `id` primary key
  (`db/schema.rb:631` has no `id: false`), verified against the live database — and the
  `active_record-acts_as` MTI models.
- *Empirical:* the exact 8.1.3 `ordered_relation` / `_order_columns` was backported onto 8.0 as a
  logging probe and swept across **4,978 examples** (models, services, libraries, controllers, jobs,
  mailers, notifiers, helpers, uploaders, components) — **zero hits**.

**Not adopting `raise_on_missing_required_finder_order_columns`.** It was considered as a permanent
guard, but our standard practice for new tables/models already includes a primary key, so the flag would
protect against something that should not arise. Noted here so the decision is on the record rather than
an oversight.

---

## Item 4 — `insert_all` / `upsert_all` with unpersisted association records

**The Rails change.** [rails/rails#53920](https://github.com/rails/rails/pull/53920) deprecates
`insert / insert_all / insert! / insert_all! / upsert / upsert_all` **on association proxies** when the
association holds unpersisted records; it becomes an error in **8.2** (groundwork for
[rails/rails#45943](https://github.com/rails/rails/issues/45943)).

> `activerecord-8.1.3/lib/active_record/associations/collection_proxy.rb:1128`
> ```ruby
> %w(insert insert_all insert! insert_all! upsert upsert_all).each do |method|
>   def #{method}(...)
>     if @association&.target&.any? { |r| r.new_record? }
>       ActiveRecord.deprecator.warn(...)   # note: no reset
>       scope.#{method}(...)
>     else
>       scope.#{method}(...).tap { reset }
>     end
>   end
> end
> ```

In 8.0 those same six methods are a plain `delegate(..., to: :scope)` with no check
(`activerecord-8.0.5.1/.../collection_proxy.rb:1134`).

**Two conditions are both required**: the receiver must be a **`CollectionProxy`**
(`record.things.insert_all`), *and* the association's already-loaded target must contain a
`new_record?`. A model class or relation receiver is never affected.

**⚠️ Worth knowing for future code: the 8.2 failure mode is silent, not an error.** 8.1's deprecated
branch deliberately skips the `.tap { reset }`, so built-but-unsaved records survive the call today.
8.2 removes the branch, `reset` always runs, and those records are discarded with no warning.

**Audit — all 12 call sites are class-level** `Model.insert_all(array_of_hashes)`, which routes through
`Relation#insert_all`; `CollectionProxy` is never involved. Zero association-scoped calls.

| Area | Sites |
| --- | --- |
| Rubric selections | `Course::Rubric::AnswerEvaluation[::Selection]`, `Course::Rubric::MockAnswerEvaluation[::Selection]`, `Course::Assessment::Question::RubricBasedResponseCategory` |
| Live feedback | `LiveFeedback::MessageFile` (×2), `LiveFeedback::MessageOption`, `LiveFeedback::File` |
| Other | `Course::Assessment::Answer.upsert_all`, `InstanceUser.insert_all`, `Course::Monitoring::Heartbeat.insert_all` |

**Two lookalikes checked and cleared:**

1. `.upsert` / `.upsert!` in `course/video/session.rb:27`, `course/video/submission.rb:49`,
   `jobs/video_statistic_update_job.rb:19` are the **`active_record_upsert` gem's instance methods**
   (`record.upsert!`), not ActiveRecord's class/relation `upsert` — and `upsert!` is not even among the
   six deprecated methods. `events.build(event_params).upsert!` is the closest shape to the risky
   pattern (`events` *is* an association, and `build` does place an unpersisted record in its target),
   but `.upsert!` is invoked on the record `build` returns, not on the proxy.
2. `Course::Gradebook::ExternalContribution.upsert` (`:31`) is a **custom private class method** doing
   `find_or_initialize_by(...).save!`. It shadows ActiveRecord's own `Model.upsert`. Unrelated to 8.1,
   but a naming hazard worth being aware of.

**Empirical:** a probe replicating the 8.1 check swept **3,283 examples** (models, services, libraries)
plus the specs covering the controller/concern call sites — **zero hits**, not even a benign
association-scoped call.

---

## Method note — how the "verified no-op" claims were established

For items 3 and 4 the argument "this deprecation is structurally unreachable" is reasoning, not
evidence. To make it evidence, the **exact 8.1.3 implementation was backported onto our 8.0** as a
`prepend`ed logging module (`ordered_relation` / the six `CollectionProxy` methods), then run under the
suite. Rather than raising, each probe appended `model + caller` to a log so a whole sweep could be
inspected in one pass.

Each probe was **mutation-tested before being trusted**:

- *Order finders:* a deliberately PK-less table was created; the probe logged both `.first` and `.last`
  on it, and stayed silent for `User.first` / `User.last` / `User.order(:name).first`.
- *Insert:* a class-level `insert_all` was not logged; an association-scoped call was logged as
  `ASSOCIATION-CALL`; the same call after `association.build(...)` was logged as `WOULD-DEPRECATE`.

The same technique was applied to item 1: forcing
`ActiveJob::Base.enqueue_after_transaction_commit = true` (the Rails 8.2 default) made the
in-transaction enqueue assertion fail as expected (`expected: 1, got: 0`), confirming the check was
capable of detecting the change it claims to rule out.

All probe files were removed; none are part of this PR.

---

## Verification

- `spec/controllers/course/users_controller_spec.rb` — **47 examples, 0 failures** (covers `#suspend`
  and `#unsuspend`, including the "only emails users whose suspension status changed" and "makes no
  changes" cases, on the real Sidekiq harness).
- `spec/jobs` — **140 examples, 0 failures**.
- Audit sweeps — **3,283 examples** (models/services/libraries) and **1,695 examples**
  (controllers/jobs/mailers/notifiers/helpers/uploaders/components), 0 probe hits.
- RuboCop clean on the changed file.

One flaky failure was observed during the sweeps and is **pre-existing and unrelated**:
`programming_codaveri_auto_grading_service_spec.rb:141` attempts a real outbound API call and fails with
`connect(2) would block`; it fails identically without any probe applied and passed on a later run.

**Not covered:** the feature/Selenium suite was not run for these audits. The findings are structural
(no PK-less model exists; no association-scoped `insert_all` exists), so spec coverage is corroboration
rather than the load-bearing evidence.

---

## Not in this PR

- **A guard spec for `enqueue_after_transaction_commit`.** One was written and mutation-verified during
  the investigation (config unset, global value `false`, no per-class opt-in, immediate in-transaction
  enqueue, explicit `after_all_transactions_commit` still deferring). It is held back deliberately: its
  value is pinning behaviour against the **8.2** default flip, which is not what this PR is about. Worth
  revisiting when the 8.2 hop is on the table.
- **The version bump itself**, `bin/rails app:update`, and `config.load_defaults 8.1`.
- **Ruby 3.3.5 → 3.4.x**, and the `calculated_attributes` Phase C ref bump to `aha-app` master (v1.2.0).
- **Post-bump runtime verification** of `edge`, `acts_as_tenant`, Devise, Keycloak et al.

With this PR merged, every §6 application-code item is closed and the 8.1 hop reduces to a dependency
bump plus the framework-defaults review.

---

## Sources

- [Rails 8.1 release notes](https://guides.rubyonrails.org/8_1_release_notes.html) · [Upgrading Ruby on Rails](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html)
- [rails/rails#54608 — deprecate order-dependent finder methods without `order`](https://github.com/rails/rails/pull/54608)
- [rails/rails#53920 — deprecate `insert_all` with unpersisted associations](https://github.com/rails/rails/pull/53920) · [rails/rails#45943 — the underlying issue](https://github.com/rails/rails/issues/45943)
- [`ActiveRecord.after_all_transactions_commit`](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html)
- [`ActiveRecord::Associations::CollectionProxy`](https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html)
- [Rails 8.2 makes `enqueue_after_transaction_commit` the default](https://prateekcodes.com/rails-82-enqueue-after-transaction-commit-default/) · [the original 7.2 feature](https://prateekcodes.com/rails-72-enqueue-after-transaction-commit/)
- Repo docs: [`rails_8_migration.md`](rails_8_migration.md) · [`rails_81_migration_gem_checklist.md`](rails_81_migration_gem_checklist.md) · [`pr_after_commit_action_migration.md`](pr_after_commit_action_migration.md)
