### PR TITLE
feat(sidekiq): migrate admin console to use app authentication

### DIFF
--- a/app/constraints/sidekiq_admin_constraint.rb
+++ b/app/constraints/sidekiq_admin_constraint.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+# Gates the mounted Sidekiq Web dashboard on the same credentials as the rest of the app.
+#
+# Sidekiq::Web is a Rack app mounted in the router, so it never reaches ApplicationController and
+# cannot use ApplicationUserConcern. Including ApplicationAuthenticationConcern keeps token
+# handling in exactly one place; the two shims below stand in for the ActionController methods it
+# expects, both of which a routing constraint can answer trivially.
+class SidekiqAdminConstraint
+  include ApplicationAuthenticationConcern
+
+  # The router calls +matches?+ on whatever object it is handed, so the class itself is the
+  # constraint and every request gets a fresh instance. That is load-bearing: the concern
+  # memoises the decoded token per instance, and a single shared instance would hand the first
+  # admin's identity to everyone who came after them.
+  def self.matches?(request)
+    new(request).admin?
+  end
+
+  def initialize(request)
+    @request = request
+  end
+
+  def admin?
+    user = current_user_from_token
+    user.present? && user.administrator?
+  end
+
+  # True when the request carries no usable credential at all. Lets the router bounce visitors to
+  # the sign in page while still 404ing signed-in non-admins, who have nothing to gain from being
+  # told the dashboard is there.
+  def signed_out?
+    current_user_from_token.blank?
+  end
+
+  private
+
+  attr_reader :request
+
+  # Stands in for ActionController::Cookies#cookies, which is this and nothing more.
+  def cookies
+    request.cookie_jar
+  end
+
+  # Stands in for ActionController::Metal#performed?. A constraint cannot render, so no response
+  # has ever been performed by the time the concern checks.
+  def performed?
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,35 @@ Rails.application.routes.draw do
 
   get 'csrf_token' => 'csrf_token#csrf_token'
 
+  # Sidekiq's own dashboard, gated on the same access token as the rest of the app rather than on
+  # separate HTTP Basic credentials. Guarded because the sidekiq gems are in the :production (and
+  # :test) bundle groups only, so the constant is absent in development.
+  if defined?(Sidekiq)
+    require 'sidekiq/web'
+    require 'sidekiq/cron/web' if defined?(Sidekiq::Cron)
+
+    constraints SidekiqAdminConstraint do
+      mount Sidekiq::Web, at: '/sidekiq'
+    end
+
+    # Signed-out visitors are sent to sign in, and `next` brings them back here once they are
+    # through Keycloak. Signed-in non-admins match neither route and fall through to the usual
+    # 404, so the dashboard is not advertised to people who cannot open it.
+    #
+    # 303, so that whatever method was sent, the browser is told unambiguously to GET the sign in
+    # page. It also keeps the response uncacheable, unlike the 301 `redirect` defaults to, which a
+    # browser would hold on to and keep replaying after the visitor had signed in.
+    sign_in_redirect = redirect(status: 303) do |_params, request|
+      "/users/sign_in?next=#{CGI.escape(request.fullpath)}"
+    end
+
+    constraints ->(request) { SidekiqAdminConstraint.new(request).signed_out? } do
+      # Every method, not just GET: the dashboard's own buttons (retry, kill, delete) are POSTs, so
+      # a session that lapses while it is open should send its owner to sign in rather than 404.
+      match '/sidekiq(/*rest)', to: sign_in_redirect, via: :all
+    end
+  end
+
   resources :announcements, only: [:index] do
     post 'mark_as_read'
   end

--- a/spec/requests/sidekiq_web_spec.rb
+++ b/spec/requests/sidekiq_web_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+# Sidekiq::Web is mounted in the router rather than reached through a controller, so its access
+# control lives in SidekiqAdminConstraint and can only be exercised through a real request.
+RSpec.describe 'Sidekiq Web dashboard' do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:administrator) { create(:administrator) }
+    let(:normal_user) { create(:user) }
+
+    let(:tokens) do
+      {
+        'admin-token' => administrator.email,
+        'user-token' => normal_user.email
+      }
+    end
+
+    # The dashboard itself is Sidekiq's, and rendering it wants a live Redis. What is under test is
+    # who the router lets reach it, so stand in for the mounted app: being called at all is the
+    # assertion, and a Redis hiccup can never look like an authorisation bug.
+    before do
+      allow(Sidekiq::Web).to receive(:call).and_return([200, { 'content-type' => 'text/plain' }, ['dashboard']])
+    end
+
+    # Access tokens are minted by Keycloak, so decoding is stubbed the way controller specs already
+    # sidestep it. Everything else runs for real: header parsing, the encrypted cookie, the user
+    # lookup by email, and the role check.
+    before do
+      allow(Authentication::AuthenticationService).to receive(:validate_token) do |access_token, _method|
+        email = tokens[access_token]
+        if email
+          Authentication::VerificationService::Response.new({ email: email, session_state: 'a-session' }, nil)
+        else
+          error = Authentication::VerificationService::Error.new('Invalid token', :unauthorized)
+          Authentication::VerificationService::Response.new(nil, error)
+        end
+      end
+    end
+
+    # The dashboard's retry, kill and delete buttons are POSTs, so every rule below has to hold for
+    # more than GET.
+    WRITE_METHODS = [:post, :put, :patch, :delete].freeze
+
+    describe '/sidekiq' do
+      context 'when the user is a system administrator' do
+        it 'serves the dashboard to a bearer token' do
+          get '/sidekiq', headers: bearer('admin-token')
+
+          expect(response).to have_http_status(:ok)
+          expect(Sidekiq::Web).to have_received(:call)
+        end
+
+        it 'serves the dashboard to the encrypted access token cookie' do
+          get '/sidekiq', headers: access_token_cookie('admin-token')
+
+          expect(response).to have_http_status(:ok)
+          expect(Sidekiq::Web).to have_received(:call)
+        end
+
+        it 'serves nested dashboard paths' do
+          get '/sidekiq/queues/default', headers: bearer('admin-token')
+
+          expect(response).to have_http_status(:ok)
+          expect(Sidekiq::Web).to have_received(:call)
+        end
+
+        WRITE_METHODS.each do |method|
+          it "serves #{method.to_s.upcase} requests" do
+            public_send(method, '/sidekiq/retries', headers: bearer('admin-token'))
+
+            expect(response).to have_http_status(:ok)
+            expect(Sidekiq::Web).to have_received(:call)
+          end
+        end
+      end
+
+      # Neither route matches, so the router raises ActionController::RoutingError and the exception
+      # middleware turns it into a 404 - the same answer as any path the app does not serve, which
+      # is the point: the dashboard is not advertised to people who cannot open it.
+      context 'when the user is signed in but not an administrator' do
+        it 'does not route to the dashboard' do
+          get '/sidekiq', headers: bearer('user-token')
+
+          expect(response).to have_http_status(:not_found)
+          expect(Sidekiq::Web).to_not have_received(:call)
+        end
+
+        it 'does not route to nested dashboard paths' do
+          get '/sidekiq/queues/default', headers: bearer('user-token')
+
+          expect(response).to have_http_status(:not_found)
+          expect(Sidekiq::Web).to_not have_received(:call)
+        end
+
+        it 'does not route to the dashboard when authenticated by cookie' do
+          get '/sidekiq', headers: access_token_cookie('user-token')
+
+          expect(response).to have_http_status(:not_found)
+          expect(Sidekiq::Web).to_not have_received(:call)
+        end
+
+        WRITE_METHODS.each do |method|
+          it "does not route #{method.to_s.upcase} requests to the dashboard" do
+            public_send(method, '/sidekiq/retries', headers: bearer('user-token'))
+
+            expect(response).to have_http_status(:not_found)
+            expect(Sidekiq::Web).to_not have_received(:call)
+          end
+        end
+      end
+
+      context 'when the user is not signed in' do
+        it 'redirects to the sign in page, returning here afterwards' do
+          get '/sidekiq'
+
+          # See Other, so the browser fetches the sign in page with GET and does not cache its way
+          # past the dashboard once signed in.
+          expect(response).to have_http_status(:see_other)
+          expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq')
+          expect(Sidekiq::Web).to_not have_received(:call)
+        end
+
+        # A session that lapses while the dashboard is open should send its owner to sign in, not
+        # 404 them the moment they press one of its buttons.
+        WRITE_METHODS.each do |method|
+          it "redirects #{method.to_s.upcase} requests to the sign in page" do
+            public_send(method, '/sidekiq/retries')
+
+            expect(response).to have_http_status(:see_other)
+            expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq%2Fretries')
+            expect(Sidekiq::Web).to_not have_received(:call)
+          end
+        end
+
+        it 'preserves the requested path and query in the next URL' do
+          get '/sidekiq/retries?count=25'
+
+          expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq%2Fretries%3Fcount%3D25')
+          expect(Sidekiq::Web).to_not have_received(:call)
+        end
+
+        it 'redirects when the token is not one the auth server recognises' do
+          get '/sidekiq', headers: bearer('forged-token')
+
+          expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq')
+          expect(Sidekiq::Web).to_not have_received(:call)
+        end
+      end
+
+      # SidekiqAdminConstraint includes ApplicationAuthenticationConcern, which memoises the decoded
+      # token per instance. Were the router to hold one shared constraint object, the first admin
+      # through would be remembered and everyone after them would inherit that identity.
+      it 'does not carry one request\'s identity into the next' do
+        get '/sidekiq', headers: bearer('admin-token')
+        expect(response).to have_http_status(:ok)
+
+        get '/sidekiq', headers: bearer('user-token')
+        expect(response).to have_http_status(:not_found)
+
+        get '/sidekiq'
+        expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq')
+      end
+    end
+
+    def bearer(token)
+      { 'Authorization' => "Bearer #{token}" }
+    end
+
+    # Mirrors ApplicationUserConcern#add_token_to_cookie: a browser's copy of the access token is an
+    # encrypted, httponly cookie, so build one exactly as the app writes it. The ciphertext has to
+    # be escaped the way Rails escapes it on the way out, otherwise any '+' it happens to contain
+    # is read back as a space and decryption fails for roughly half of all generated tokens.
+    def access_token_cookie(token)
+      env = Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'test.host').merge(Rails.application.env_config)
+      jar = ActionDispatch::Cookies::CookieJar.build(ActionDispatch::Request.new(env), {})
+      jar.encrypted[:access_token] = token
+
+      { 'HTTP_COOKIE' => "access_token=#{Rack::Utils.escape(jar[:access_token])}" }
+    end
+  end
+end


### PR DESCRIPTION
The Sidekiq Web dashboard at `/sidekiq` sat behind HTTP Basic auth with its own
`SIDEKIQ_ADMIN_USERNAME` / `SIDEKIQ_ADMIN_PASSWORD` credentials — a second, shared secret living
entirely outside the app's authentication. This moves it under the same umbrella as everything
else: the Keycloak access token, and the `User#administrator?` role.

It also moves the mount itself into `config/routes.rb`. Until now the dashboard was not in this
repo at all — it was injected at image build time by a `patch` against `routes.rb` in the
deployment repo, which had to be re-fuzzed whenever this file changed.

## How it works

`SidekiqAdminConstraint` is a routing constraint that resolves the request to a `User` and checks
the role. `Sidekiq::Web` is a Rack app mounted in the router, so it never reaches
`ApplicationController` and cannot use `ApplicationUserConcern` — but it can include
`ApplicationAuthenticationConcern` directly, keeping token handling in exactly one place. The
concern expects two things from a controller, and a constraint answers both trivially:

| Concern expects | Constraint supplies |
| --- | --- |
| `cookies` | `request.cookie_jar` |
| `performed?` | `false` — a constraint cannot render |

`request.headers` needs no shim; `ActionDispatch::Request` already responds to it. So the
`Authorization: Bearer` header, the encrypted `access_token` cookie, the email lookup and the error
semantics are all the app's existing code, unchanged.

Admin is `User#administrator?` — the same condition behind `can :manage, :all` in `Ability`.
Checking the role directly rather than building an `Ability` keeps the constraint free of the
tenant, which is not yet resolved when routing constraints run.

### Resulting behaviour

| Who | `/sidekiq` |
| --- | --- |
| System administrator | The dashboard |
| Signed in, not an administrator | 404, same as any unserved path |
| Signed out | 303 to `/users/sign_in?next=%2Fsidekiq` |

All three hold for every HTTP method, not just GET. The dashboard's own retry, kill and delete
buttons are POSTs, so a session that lapses while it is open sends its owner to sign in rather than
404ing them the moment they press one.

The `next` parameter is the app's existing convention — `AuthenticationRedirection` reads it via
`useNextURL` and passes it as the OIDC `redirect_uri` — so an admin who opens a bookmarked
`/sidekiq` is sent through Keycloak and lands back on the dashboard.

The admin popup menu already links to `/sidekiq`; that link now just works, with no second password
to hand around.

## Notes for review

- **`if defined?(Sidekiq)` is load-bearing.** The sidekiq gems are in the `:production` (and
  `:test`) bundle groups only, so an unconditional `require 'sidekiq/web'` at the top of
  `routes.rb` would break `rails s` in development. A consequence worth knowing: the dashboard is
  now mounted in the **test** environment too, where it previously was not, since the old patch only
  ran during the production image build.

- **The class itself is the constraint, not an instance.** The router calls `matches?` on whatever
  object it is given, so `constraints SidekiqAdminConstraint` works and constructs a fresh instance
  per request. This is deliberate: `ApplicationAuthenticationConcern` memoises the decoded token in
  instance variables, so a single shared constraint object would remember the first admin through
  and hand their identity to everyone after them. There is a spec pinning this.

- **The sign-in redirect is a 303, not the 301 that `redirect` defaults to.** Two reasons: a
  permanent redirect would be cached by the browser, so the admin would keep landing on the sign-in
  page even after signing in; and since the guard covers every method, See Other is the status that
  unambiguously tells the browser to fetch the sign-in page with GET whatever it originally sent.

## Tests

`spec/requests/sidekiq_web_spec.rb` — 22 examples driving real requests through the router:

- admin reaches the dashboard via bearer token, via the encrypted `access_token` cookie, and on
  nested paths (`/sidekiq/queues/default`)
- signed-in non-admin gets a 404 through both credential types and on nested paths
- signed-out visitor is redirected, with the path and query string preserved in `next`
- each of those three outcomes is asserted for POST, PUT, PATCH and DELETE as well as GET
- an unrecognised token is treated as signed out rather than as an error
- one request's identity does not carry into the next (the memoisation case above)

Keycloak token *decoding* is stubbed, the way `controller_sign_in` already sidesteps it for
controller specs. Everything else runs for real: header parsing, cookie decryption, the user lookup
by email, and the role check. `Sidekiq::Web.call` is stubbed so that the dashboard's own need for a
live Redis can never look like an authorisation failure.

Two details in the spec that are easy to get wrong, both commented in place:

- The encrypted cookie value must be escaped the way Rails escapes it on the way out. Skipping that
  lets Rack read any `+` in the ciphertext back as a space; measured over 200 generated tokens,
  about half contain a `+`, so the spec would fail intermittently.
- A blocked request is asserted as a **404 response**, not a raised `ActionController::RoutingError`.
  On Rails 8.1 `ExceptionWrapper.show?` only special-cases `:none` and `:rescuable`; this repo's
  `config.action_dispatch.show_exceptions = false` falls through to the default and renders. (That
  line's comment — "Raise exceptions instead of rendering exception templates" — has been inaccurate
  since the Rails 7.1 upgrade. Left alone here; changing it would affect the whole suite.)

## Deployment

**This must ship together with the corresponding deployment-repo change.** That repo currently
applies `patches/config/sidekiq_dash.patch` to this file during the image build. Once `routes.rb`
carries the mount, the patch no longer applies, `patch` exits non-zero, and `set -e` fails the
build. The matching change removes the patch, the `COPY patches` line, and the now-unused
`SIDEKIQ_ADMIN_USERNAME` / `SIDEKIQ_ADMIN_PASSWORD` from the app and worker compose files.

Those two variables can also be dropped from the Elastic Beanstalk environment configuration once
this is out.

No change is needed at the nginx layer: `/sidekiq` already proxies through to the app.
