### PR TITLE
feat(sidekiq): opening /sidekiq when not logged in redirects to keycloak

### DIFF
--- a/app/constraints/sidekiq_admin_constraint.rb
+++ b/app/constraints/sidekiq_admin_constraint.rb
@@ -25,13 +25,6 @@ class SidekiqAdminConstraint
     user.present? && user.administrator?
   end
 
-  # True when the request carries no usable credential at all. Lets the router bounce visitors to
-  # the sign in page while still 404ing signed-in non-admins, who have nothing to gain from being
-  # told the dashboard is there.
-  def signed_out?
-    current_user_from_token.blank?
-  end
-
   private
 
   attr_reader :request

--- a/app/controllers/system/admin/sidekiq_sessions_controller.rb
+++ b/app/controllers/system/admin/sidekiq_sessions_controller.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+# Signs a visitor in to the Sidekiq dashboard, which SidekiqAdminConstraint has just turned away.
+#
+# The dashboard is mounted in the router and served by Rails, so an ordinary page visit carries no
+# Authorization header - only the encrypted access_token cookie, which is written as a side effect
+# of the client app's authenticated requests and holds a Keycloak access token that expires in
+# minutes. A direct visit or a bookmark therefore routinely arrives with no usable credential even
+# though the visitor is signed in to the app.
+#
+# Redirecting such a visitor to the client app's sign in page cannot fix that: they come back to a
+# server-rendered page that still has no way to mint the cookie, and Keycloak's live SSO session
+# makes the return trip instant, so it loops. Instead this runs the authorization code flow here,
+# where the callback lands on Rails and the cookie can be written before the dashboard is served.
+#
+# PKCE, not a client secret: the frontend Keycloak client is public. The redirect URI needs no
+# Keycloak change, since KeycloakAdminService already registers "#{instance.redirect_uri}/*".
+class System::Admin::SidekiqSessionsController < ApplicationController
+  SESSION_KEY = :sidekiq_authorization
+  DASHBOARD_PATH = '/sidekiq'
+
+  # Where the flow returns to. Must be one fixed, registered URI, so the path the visitor actually
+  # asked for is carried in the session rather than in the redirect URI.
+  def show
+    return head :not_found unless request.get?
+
+    return complete_authorization if params[:code].present?
+
+    # Reaching here with a credential the app accepts means the constraint refused on the role, not
+    # on the credential. Sending them round Keycloak would only return them to the same answer.
+    return head :not_found if current_user.present?
+
+    # An error handed back by Keycloak (a cancelled login, a rejected consent) must not restart the
+    # flow, or the visitor bounces between here and the auth server.
+    return head :not_found if params[:error].present?
+
+    start_authorization
+  end
+
+  protected
+
+  # Nothing here can require a signed-in user: the whole point is to obtain one.
+  def publicly_accessible?
+    true
+  end
+
+  private
+
+  def start_authorization
+    verifier = SecureRandom.urlsafe_base64(64, false)
+    state = SecureRandom.urlsafe_base64(32, false)
+
+    session[SESSION_KEY] = { 'verifier' => verifier, 'state' => state, 'return_to' => return_path }
+
+    redirect_to authorization_url(state, code_challenge(verifier)), allow_other_host: true
+  end
+
+  def complete_authorization
+    authorization = session.delete(SESSION_KEY)
+    return head :not_found if authorization.blank?
+    return head :not_found unless valid_state?(params[:state], authorization['state'])
+
+    access_token = exchange_code(params[:code], authorization['verifier'])
+    return head :not_found if access_token.blank?
+
+    user = user_from(access_token)
+    return head :not_found unless user&.administrator?
+
+    # Mirrors ApplicationUserConcern#add_token_to_cookie, which is what the constraint reads.
+    cookies.encrypted[:access_token] = { value: access_token, httponly: true, expires: 1.hour.from_now }
+
+    redirect_to authorization['return_to'].presence || DASHBOARD_PATH
+  end
+
+  def user_from(access_token)
+    response = Authentication::AuthenticationService.validate_token(access_token, :local)
+    return nil if response.error
+
+    email = response.decoded_token[:email]
+    return nil if email.blank?
+
+    User.joins(:emails).where('user_emails.email = ?', email).first
+  end
+
+  def exchange_code(code, verifier)
+    response = Net::HTTP.post_form(URI.parse(token_endpoint),
+                                   grant_type: 'authorization_code',
+                                   code: code,
+                                   redirect_uri: redirect_uri,
+                                   client_id: client_id,
+                                   code_verifier: verifier)
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)['access_token']
+  rescue StandardError => e
+    Rails.logger.warn("Sidekiq dashboard token exchange failed: #{e.class}")
+    nil
+  end
+
+  def authorization_url(state, challenge)
+    query = {
+      client_id: client_id,
+      redirect_uri: redirect_uri,
+      response_type: 'code',
+      # Exactly what the client app asks for. oidc-client-ts defaults to "openid" and AuthProvider's
+      # oidcConfig sets no scope, so requesting the same keeps both flows' tokens identical in shape:
+      # same audience, same claims, same validation. Asking for more risks an invalid_scope refusal
+      # from Keycloak, or an `aud` that JwtVerificationService would then reject.
+      scope: 'openid',
+      state: state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256'
+    }
+
+    "#{authorization_endpoint}?#{query.to_query}"
+  end
+
+  def code_challenge(verifier)
+    Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
+  end
+
+  def valid_state?(received, expected)
+    received.present? && expected.present? &&
+      ActiveSupport::SecurityUtils.secure_compare(received.to_s, expected.to_s)
+  end
+
+  # Only ever a path under the dashboard, so a crafted `return_to` cannot turn this into an open
+  # redirect or a way to reach some other part of the app with a freshly minted cookie.
+  def return_path
+    return DASHBOARD_PATH unless request.path == DASHBOARD_PATH || request.path.start_with?("#{DASHBOARD_PATH}/")
+
+    request.fullpath
+  end
+
+  def redirect_uri
+    "#{request.base_url}#{DASHBOARD_PATH}"
+  end
+
+  def client_id
+    Rails.application.credentials.dig(:keycloak, :frontend, :client_id)
+  end
+
+  # chomp: the configured auth server URL may or may not carry a trailing slash (it does in the
+  # test credentials), and "//realms/..." is not the same path to every proxy in front of Keycloak.
+  def realm_url
+    "#{Keycloak.auth_server_url.to_s.chomp('/')}/realms/#{Keycloak.realm}/protocol/openid-connect"
+  end
+
+  def authorization_endpoint
+    "#{realm_url}/auth"
+  end
+
+  def token_endpoint
+    "#{realm_url}/token"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,22 +91,10 @@ Rails.application.routes.draw do
       mount Sidekiq::Web, at: '/sidekiq'
     end
 
-    # Signed-out visitors are sent to sign in, and `next` brings them back here once they are
-    # through Keycloak. Signed-in non-admins match neither route and fall through to the usual
-    # 404, so the dashboard is not advertised to people who cannot open it.
-    #
-    # 303, so that whatever method was sent, the browser is told unambiguously to GET the sign in
-    # page. It also keeps the response uncacheable, unlike the 301 `redirect` defaults to, which a
-    # browser would hold on to and keep replaying after the visitor had signed in.
-    sign_in_redirect = redirect(status: 303) do |_params, request|
-      "/users/sign_in?next=#{CGI.escape(request.fullpath)}"
-    end
-
-    constraints ->(request) { SidekiqAdminConstraint.new(request).signed_out? } do
-      # Every method, not just GET: the dashboard's own buttons (retry, kill, delete) are POSTs, so
-      # a session that lapses while it is open should send its owner to sign in rather than 404.
-      match '/sidekiq(/*rest)', to: sign_in_redirect, via: :all
-    end
+    # Anyone the constraint turns away lands here to be signed in through Keycloak, because a
+    # server-rendered page cannot mint the access_token cookie the constraint reads, and so cannot
+    # be fixed by redirecting to the client app's sign in page. See the controller.
+    match '/sidekiq(/*rest)', to: 'system/admin/sidekiq_sessions#show', via: :all
   end
 
   resources :announcements, only: [:index] do

--- a/spec/requests/sidekiq_web_spec.rb
+++ b/spec/requests/sidekiq_web_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe 'Sidekiq Web dashboard' do
       end
     end
 
+    # The controller that runs the authorization code flow inherits ApplicationController, whose
+    # multitenancy before_action rejects a host that is not a known instance.
+    before { host! instance.host }
+
+    # The authorization code flow reads these; the deployed values live in credentials.
+    before do
+      allow(Keycloak).to receive_messages(auth_server_url: 'http://keycloak.test', realm: 'coursemology')
+      allow(Rails.application.credentials).to receive(:dig).and_call_original
+      allow(Rails.application.credentials).to receive(:dig).
+        with(:keycloak, :frontend, :client_id).and_return('frontend-client')
+    end
+
     # The dashboard's retry, kill and delete buttons are POSTs, so every rule below has to hold for
     # more than GET.
     WRITE_METHODS = [:post, :put, :patch, :delete].freeze
@@ -76,9 +88,8 @@ RSpec.describe 'Sidekiq Web dashboard' do
         end
       end
 
-      # Neither route matches, so the router raises ActionController::RoutingError and the exception
-      # middleware turns it into a 404 - the same answer as any path the app does not serve, which
-      # is the point: the dashboard is not advertised to people who cannot open it.
+      # A credential the app accepts, refused on the role: sending them round Keycloak would only
+      # return them to the same answer, so this short-circuits without leaving the app.
       context 'when the user is signed in but not an administrator' do
         it 'does not route to the dashboard' do
           get '/sidekiq', headers: bearer('user-token')
@@ -111,41 +122,127 @@ RSpec.describe 'Sidekiq Web dashboard' do
         end
       end
 
+      # No usable credential, so there is someone to sign in: start the authorization code flow at
+      # Keycloak rather than at the client app's sign in page, which cannot mint the cookie.
       context 'when the user is not signed in' do
-        it 'redirects to the sign in page, returning here afterwards' do
+        it 'starts the authorization code flow' do
           get '/sidekiq'
 
-          # See Other, so the browser fetches the sign in page with GET and does not cache its way
-          # past the dashboard once signed in.
-          expect(response).to have_http_status(:see_other)
-          expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq')
+          expect(response).to have_http_status(:redirect)
+          expect(redirect_query['client_id']).to eq(['frontend-client'])
+          expect(redirect_query['redirect_uri']).to eq(["http://#{instance.host}/sidekiq"])
+          expect(redirect_query['response_type']).to eq(['code'])
+          expect(redirect_query['code_challenge_method']).to eq(['S256'])
+          expect(redirect_query['code_challenge'].first).to be_present
+          expect(redirect_query['state'].first).to be_present
           expect(Sidekiq::Web).to_not have_received(:call)
         end
 
-        # A session that lapses while the dashboard is open should send its owner to sign in, not
-        # 404 them the moment they press one of its buttons.
+        it 'starts the flow for a token the auth server does not recognise' do
+          get '/sidekiq', headers: bearer('forged-token')
+
+          expect(response).to have_http_status(:redirect)
+          expect(response.location).to start_with('http://keycloak.test/realms/coursemology')
+        end
+
+        # Only a browser navigation can go round Keycloak; a lapsed dashboard button press cannot.
         WRITE_METHODS.each do |method|
-          it "redirects #{method.to_s.upcase} requests to the sign in page" do
+          it "does not route #{method.to_s.upcase} requests to the dashboard" do
             public_send(method, '/sidekiq/retries')
 
-            expect(response).to have_http_status(:see_other)
-            expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq%2Fretries')
+            expect(response).to have_http_status(:not_found)
             expect(Sidekiq::Web).to_not have_received(:call)
           end
         end
 
-        it 'preserves the requested path and query in the next URL' do
-          get '/sidekiq/retries?count=25'
+        # A cancelled login must not be answered by starting the flow again.
+        it 'does not restart the flow when Keycloak hands back an error' do
+          get '/sidekiq', params: { error: 'access_denied' }
 
-          expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq%2Fretries%3Fcount%3D25')
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      # The half that a redirect to the client app's sign in page could never do: the callback lands
+      # on Rails, so the access_token cookie can be written before the dashboard is served.
+      context 'when Keycloak calls back with an authorization code' do
+        # Runs the real first leg so that state and the PKCE verifier are the ones in the session.
+        def start_flow
+          get '/sidekiq'
+          CGI.parse(URI.parse(response.location).query.to_s)['state'].first
+        end
+
+        def stub_exchange(token)
+          exchanged = instance_double(Net::HTTPOK, body: { access_token: token }.to_json)
+          allow(exchanged).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+          allow(Net::HTTP).to receive(:post_form).and_return(exchanged)
+        end
+
+        it 'admits an administrator and leaves them a usable cookie' do
+          state = start_flow
+          stub_exchange('admin-token')
+
+          get '/sidekiq', params: { code: 'an-authorization-code', state: state }
+
+          expect(response).to redirect_to('/sidekiq')
+
+          # The whole point: the next request now carries a credential the constraint accepts.
+          get '/sidekiq'
+          expect(response).to have_http_status(:ok)
+          expect(Sidekiq::Web).to have_received(:call)
+        end
+
+        it 'sends the verifier and the registered redirect URI to the token endpoint' do
+          state = start_flow
+          stub_exchange('admin-token')
+
+          get '/sidekiq', params: { code: 'an-authorization-code', state: state }
+
+          expect(Net::HTTP).to have_received(:post_form).with(
+            URI.parse('http://keycloak.test/realms/coursemology/protocol/openid-connect/token'),
+            hash_including(grant_type: 'authorization_code',
+                           code: 'an-authorization-code',
+                           client_id: 'frontend-client',
+                           redirect_uri: "http://#{instance.host}/sidekiq")
+          )
+        end
+
+        it 'refuses a non-administrator who signed in successfully' do
+          state = start_flow
+          stub_exchange('user-token')
+
+          get '/sidekiq', params: { code: 'an-authorization-code', state: state }
+
+          expect(response).to have_http_status(:not_found)
           expect(Sidekiq::Web).to_not have_received(:call)
         end
 
-        it 'redirects when the token is not one the auth server recognises' do
-          get '/sidekiq', headers: bearer('forged-token')
+        it 'refuses a mismatched state' do
+          start_flow
+          stub_exchange('admin-token')
 
-          expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq')
-          expect(Sidekiq::Web).to_not have_received(:call)
+          get '/sidekiq', params: { code: 'an-authorization-code', state: 'not-the-state' }
+
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'refuses a code with no flow in the session' do
+          stub_exchange('admin-token')
+
+          get '/sidekiq', params: { code: 'an-authorization-code', state: 'anything' }
+
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'refuses when the token endpoint rejects the exchange' do
+          state = start_flow
+          failed = instance_double(Net::HTTPBadRequest, body: '{}')
+          allow(failed).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+          allow(Net::HTTP).to receive(:post_form).and_return(failed)
+
+          get '/sidekiq', params: { code: 'an-authorization-code', state: state }
+
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -160,8 +257,12 @@ RSpec.describe 'Sidekiq Web dashboard' do
         expect(response).to have_http_status(:not_found)
 
         get '/sidekiq'
-        expect(response).to redirect_to('/users/sign_in?next=%2Fsidekiq')
+        expect(response).to have_http_status(:redirect)
       end
+    end
+
+    def redirect_query
+      CGI.parse(URI.parse(response.location).query.to_s)
     end
 
     def bearer(token)


### PR DESCRIPTION
Follow-up to "migrate admin console to use app authentication" (`503a2bcdc`), which shipped with a
redirect that cannot work for this route. Reported from staging: opening `/sidekiq` while not signed
in produced an infinite redirect chain that eventually 502'd, and an already-signed-in visitor landed
on `/users/sign_in?next=%2Fsidekiq`, which rendered as a broken page inside the authenticated app.
Both affected administrators too, not only non-admins.

## Why the old redirect could not work

`503a2bcdc` sent anyone the constraint turned away to the client app's sign in page with
`next=/sidekiq`. But `/sidekiq` is served by Rails, not by the client app, so the client never runs
on that page and nothing there can obtain a token or write the `access_token` cookie the constraint
reads.

`AuthenticationRedirection` sets the OIDC `redirect_uri` to the next URL, so Keycloak returns the
visitor straight to `/sidekiq` — still with no cookie. The constraint refuses again, redirects to
sign in again, and because the Keycloak SSO session is already live the round trip is instant. That
is the loop. For a visitor who was already authenticated, `Redirectable` performs a client-side
`<Navigate>` to `/sidekiq`, which is not a client-app route, hence the broken page.

The same reasoning explains why the intended "404 for signed-in non-admins" mostly did not happen.
The constraint can only see a credential that is actually presented, and a top-level browser
navigation carries no `Authorization` header — only the cookie, which is written as a side effect of
the client app's authenticated requests and holds a Keycloak access token with a 15 minute lifespan
(`accessTokenLifespan: 900`). So a direct visit or a bookmark routinely looks signed out to the
constraint whatever the visitor's role, and nearly everyone fell into the signed-out branch.

## The fix

Run the authorization code flow on the server, where the callback lands on Rails and the cookie can
be written before the dashboard is served. `System::Admin::SidekiqSessionsController` picks up
everything `SidekiqAdminConstraint` turns away:

| Situation | Result |
| --- | --- |
| Valid credential, system admin | The dashboard (unchanged — the constraint admits them) |
| Valid credential, not an admin | 404 immediately, no Keycloak round trip |
| No usable credential | 302 to Keycloak, then the callback decides |
| Callback, admin | Cookie minted, redirected to the path originally requested |
| Callback, not an admin | 404 |
| Keycloak error param, or any non-GET | 404 — never restarts the flow |

## Notes for review

- **PKCE, not a client secret.** The frontend Keycloak client is public. The confidential client has
  standard flow disabled (it exists for client credentials), so it is not an option here.

- **`scope: 'openid'` deliberately matches the client app exactly.** `oidcConfig` sets no scope, so
  oidc-client-ts uses its default of `openid`. Requesting anything more risks an `invalid_scope`
  refusal, and can change the `aud` claim — which `JwtVerificationService#decode_token` checks with
  `verify_aud: true`, so the exchange would succeed and the token would then be rejected. This was a
  real bug in an earlier revision of this branch.

- **No Keycloak configuration change is needed.** `KeycloakAdminService` already registers
  `"#{instance.redirect_uri}/*"` per instance, which covers `<host>/sidekiq`.

- **The redirect URI is fixed; the requested path travels in the session.** `redirect_uri` must be
  one registered value, so `return_to` is carried in the session instead and is constrained to paths
  under `/sidekiq`, so a crafted value cannot turn this into an open redirect that hands out a
  freshly minted cookie.

- **`auth_server_url` may carry a trailing slash** (it does in the test credentials), so it is
  chomped rather than producing `//realms/...`, which is not the same path to every proxy.

- **The session key is namespaced** (`:sidekiq_authorization`) and consumed on use, so a replayed
  callback finds nothing and 404s. In production sessions live in Redis, so the PKCE verifier never
  reaches the browser.

- **This route is now tenant-sensitive.** The controller inherits `ApplicationController`, so
  `deduce_tenant` runs and rejects a host that is not a known instance. 

### Tokens are interchangeable with the client app's

Worth stating explicitly, since this mints tokens by a second route: they are the same tokens. Same
realm, same public client, so the same signing key, `iss` and `aud`, and both are validated by the
identical `Authentication::AuthenticationService.validate_token(..., :local)` path — nothing in it
can tell where a token came from. The cookie is a shared slot that `ApplicationUserConcern` also
writes on every authenticated request, and both flows resolve to the same Keycloak SSO session, so
`session_state` matches and no spurious sign-ins are recorded.

## Tests

`spec/requests/sidekiq_web_spec.rb`, 28 examples. Keycloak token *decoding* and the token endpoint
are stubbed; everything else runs for real — header parsing, cookie encryption, the user lookup, the
role check, `state` and PKCE handling, and the end-to-end assertion that after the callback the next
request carries a credential the constraint accepts.

Covered: admin via bearer token and via the encrypted cookie, nested paths, every write method,
signed-in non-admin refused without leaving the app, the authorization request's parameters
(`response_type`, `scope`, `code_challenge_method`, `state`), a successful callback, a callback for a
non-admin, mismatched `state`, a code with no flow in the session, a rejected exchange, a Keycloak
error param, and no identity bleeding between requests.

## Manual verification

End to end against a local Keycloak (`coursemology_test` realm, real login form, real code exchange):

- admin, no credential → Keycloak → dashboard, `<title>[TEST] Sidekiq</title>`
- admin starting at `/sidekiq/retries` → returned to `/sidekiq/retries` after the flow
- non-admin who signs in successfully at Keycloak → 404 at the callback, no cookie minted

Also verified on staging.
