### PR TITLE
perf(jobs): optimize ConsolidatedItemEmailJob queries

### DIFF
--- a/app/jobs/consolidated_item_email_job.rb
+++ b/app/jobs/consolidated_item_email_job.rb
@@ -7,8 +7,7 @@ class ConsolidatedItemEmailJob < ApplicationJob
     midnight_time_zones = ActiveSupport::TimeZone.all.select { |time| time.now.hour == 0 }.
                           map(&:name)
     ActsAsTenant.without_tenant do
-      courses = Course.where(time_zone: midnight_time_zones)
-      courses.each do |course|
+      Course.where(time_zone: midnight_time_zones).find_each do |course|
         Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course)
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 class Course < ApplicationRecord # rubocop:disable Metrics/ClassLength
+  # Candidate items examined per batch by #upcoming_lesson_plan_items_exist?. Small because each
+  # candidate carries one personal time per course user.
+  CANDIDATE_ITEM_BATCH_SIZE = 20
+
   include Course::SearchConcern
   include Course::DuplicationConcern
   include Course::CourseComponentsConcern
@@ -320,11 +324,14 @@ class Course < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def upcoming_lesson_plan_items_exist?
-    opening_items = lesson_plan_items.published.eager_load(:personal_times, :reference_times).preload(:actable)
-    opening_items.select { |item| item.actable.include_in_consolidated_email?(:opening_reminder) }.any? do |item|
-      course_users.any? do |course_user|
-        item.time_for(course_user).start_at.between?(Time.zone.now, 1.day.from_now)
-      end
+    now = Time.zone.now
+    window_end = now + 1.day
+    # find_each returns a lazy enumerator, so `any?` stops at the first batch that answers the
+    # question instead of materialising every candidate.
+    items_opening_between(now, window_end).find_each(batch_size: CANDIDATE_ITEM_BATCH_SIZE).any? do |item|
+      next false unless item.actable.include_in_consolidated_email?(:opening_reminder)
+
+      course_users.any? { |course_user| item.time_for(course_user).start_at.between?(now, window_end) }
     end
   end
 
@@ -414,5 +421,30 @@ class Course < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return if num_defaults <= 1 # Could be 0 if item is new
 
     errors.add(:reference_timelines, :must_have_at_most_one_default)
+  end
+
+  # Published items with some time — personal or reference — falling in the window.
+  #
+  # This is a superset of the items actually upcoming for a course user, not an answer on its own:
+  # +time_for+ returns either the user's personal time or a reference time, so an item that is
+  # upcoming for somebody necessarily has one of those rows in the window. The caller still decides
+  # per user. Narrowing here keeps the Ruby pass — and its per-item email-setting lookup — off the
+  # entire lesson plan, which is nearly all of the work for a course with nothing opening.
+  #
+  # +preload+ rather than +eager_load+ deliberately: personal times exist per item *per course
+  # user*, so joining them alongside reference times in one query multiplies the two into an
+  # items x users x timelines result set.
+  def items_opening_between(from, to)
+    lesson_plan_items.published.
+      where(
+        'EXISTS (SELECT 1 FROM course_personal_times pt
+                  WHERE pt.lesson_plan_item_id = course_lesson_plan_items.id
+                    AND pt.start_at BETWEEN :from AND :to)
+         OR EXISTS (SELECT 1 FROM course_reference_times rt
+                     WHERE rt.lesson_plan_item_id = course_lesson_plan_items.id
+                       AND rt.start_at BETWEEN :from AND :to)',
+        from: from, to: to
+      ).
+      preload(:personal_times, :reference_times, :actable)
   end
 end

--- a/spec/controllers/user/registration_controller_spec.rb
+++ b/spec/controllers/user/registration_controller_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe User::RegistrationsController, type: :controller do
         }
       end
 
+      # Resolves the user an example just registered, by the address it submitted.
+      def registered_user(address)
+        User::Email.find_by!(email: address).user
+      end
+
       context 'user registration is successful' do
         requires_login
 
@@ -134,7 +139,7 @@ RSpec.describe User::RegistrationsController, type: :controller do
               post :create, params: valid_user_params.merge(enrol_course_id: course.id)
             end.to change(Course::EnrolRequest, :count).by(1)
 
-            new_user = User.order(:created_at).last
+            new_user = registered_user(valid_user_params[:user][:email])
             enrol_request = Course::EnrolRequest.find_by(course: course, user: new_user)
             expect(enrol_request).to be_present
             expect(enrol_request.workflow_state).to eq('pending')
@@ -146,7 +151,7 @@ RSpec.describe User::RegistrationsController, type: :controller do
             it 'auto-approves the request and creates a CourseUser' do
               post :create, params: valid_user_params.merge(enrol_course_id: course.id)
 
-              new_user = User.order(:created_at).last
+              new_user = registered_user(valid_user_params[:user][:email])
               enrol_request = Course::EnrolRequest.find_by(course: course, user: new_user)
               expect(enrol_request.workflow_state).to eq('approved')
               expect(CourseUser.find_by(course: course, user: new_user)).to be_present
@@ -178,7 +183,7 @@ RSpec.describe User::RegistrationsController, type: :controller do
           it 'creates the user, enrols them once and confirms the invitation' do
             expect { subject }.to change(User, :count).by(1).and change(CourseUser, :count).by(1)
 
-            new_user = User.order(:created_at).last
+            new_user = registered_user(email)
             course_user = CourseUser.find_by(course: course, user: new_user)
             expect(course_user).to be_present
             expect(course_user.external_id).to eq(external_id)

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -106,20 +106,7 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
         file2 = File.join(Rails.root, '/spec/fixtures/files/text2.txt')
 
         find('#upload-files-button').click
-
-        # Ref: https://stackoverflow.com/questions/38049020/how-to-test-file-attachment-on-hidden-input-using-capybara
-        # Wait for file input to be in the DOM (even if hidden)
-        expect(page).to have_selector('input[type="file"]', visible: false)
-        input = find('input[type="file"]', visible: false)
-
-        # NOTE: Using `make_visible: true` with `attach_file` is flaky — Capybara sometimes fails with
-        # a Capybara::ExpectationNotMet error even when the file input exists and is targeted correctly.
-        # Instead, we use JavaScript to explicitly change the file input's CSS and make it visible.
-        # This workaround ensures consistent behavior across browsers and environments.
-        page.execute_script("arguments[0].style.display = 'block';", input)
-
-        # Attach files to the (now visible) input
-        input.attach_file([file1, file2])
+        attach_files_to_hidden_input([file1, file2])
 
         expect do
           find('button#material-upload-form-upload-button').click

--- a/spec/features/rag_wise/rag_wise_settings_form_spec.rb
+++ b/spec/features/rag_wise/rag_wise_settings_form_spec.rb
@@ -101,9 +101,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         pdf_file = File.join(Rails.root, '/spec/fixtures/files/one-page-document.pdf')
         non_pdf_text_file = File.join(Rails.root, '/spec/fixtures/files/template_file')
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([txt_file,
-                                                                pdf_file,
-                                                                non_pdf_text_file], make_visible: true)
+        attach_files_to_hidden_input([txt_file, pdf_file, non_pdf_text_file])
         find('button#material-upload-form-upload-button').click
         wait_for_page
 
@@ -128,7 +126,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         pdf_file = File.join(Rails.root, '/spec/fixtures/files/two-page-document-with-text.pdf')
         pdf_file_name = 'two-page-document-with-text.pdf'
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([pdf_file], make_visible: true)
+        attach_files_to_hidden_input([pdf_file])
         find('button#material-upload-form-upload-button').click
         wait_for_page
         file = parent_folder.materials.first
@@ -159,7 +157,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         txt_file = File.join(Rails.root, '/spec/fixtures/files/text.txt')
         txt_file_name = 'text.txt'
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([txt_file], make_visible: true)
+        attach_files_to_hidden_input([txt_file])
         find('button#material-upload-form-upload-button').click
         wait_for_page
 

--- a/spec/features/rag_wise/rag_wise_settings_material_spec.rb
+++ b/spec/features/rag_wise/rag_wise_settings_material_spec.rb
@@ -21,11 +21,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         docx_file = File.join(Rails.root, '/spec/fixtures/files/one-page-word-document.docx')
         unsupported_file_type = File.join(Rails.root, '/spec/fixtures/files/template_file')
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([txt_file,
-                                                                pdf_file,
-                                                                ipynb_file,
-                                                                docx_file,
-                                                                unsupported_file_type], make_visible: true)
+        attach_files_to_hidden_input([txt_file, pdf_file, ipynb_file, docx_file, unsupported_file_type])
         find('button#material-upload-form-upload-button').click
         wait_for_page
 
@@ -50,7 +46,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         pdf_file = File.join(Rails.root, '/spec/fixtures/files/two-page-document-with-text.pdf')
         pdf_file_name = 'two-page-document-with-text.pdf'
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([pdf_file], make_visible: true)
+        attach_files_to_hidden_input([pdf_file])
         find('button#material-upload-form-upload-button').click
         wait_for_page
         file = parent_folder.materials.first
@@ -83,8 +79,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         ipynb_file = File.join(Rails.root, '/spec/fixtures/files/template_ipynb.ipynb')
         docx_file = File.join(Rails.root, '/spec/fixtures/files/one-page-word-document.docx')
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([pdf_file, txt_file, ipynb_file, docx_file],
-                                                               make_visible: true)
+        attach_files_to_hidden_input([pdf_file, txt_file, ipynb_file, docx_file])
         find('button#material-upload-form-upload-button').click
         wait_for_page
         first_file = parent_folder.materials.first
@@ -118,7 +113,7 @@ RSpec.feature 'Course: Administration: RagWise', js: true do
         txt_file = File.join(Rails.root, '/spec/fixtures/files/text.txt')
         txt_file_name = 'text.txt'
         find('#upload-files-button').click
-        find('input[type="file"]', visible: false).attach_file([txt_file], make_visible: true)
+        attach_files_to_hidden_input([txt_file])
         find('button#material-upload-form-upload-button').click
         wait_for_page
 

--- a/spec/jobs/consolidated_item_email_job_spec.rb
+++ b/spec/jobs/consolidated_item_email_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ConsolidatedItemEmailJob do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    describe '#perform' do
+      # The job notifies courses whose *local* time has just passed midnight. Freezing to 00:30 UTC
+      # puts 'UTC' in that window and 'Singapore' (UTC+8) at 08:30, well outside it.
+      let(:just_past_midnight_utc) { Time.utc(2026, 1, 1, 0, 30) }
+      let!(:midnight_course) { create(:course, time_zone: 'UTC') }
+      let!(:daytime_course) { create(:course, time_zone: 'Singapore') }
+
+      # Records are created outside the frozen window, and the notifier is stubbed so the job
+      # commits nothing while time is travelled — this suite has no cleanup, and rows written under
+      # a travelled clock would outlive the example and skew other specs.
+      # Stubbed on the instance, not the class: Notifier::Base dispatches `opening_reminder`
+      # through method_missing, so a class-level stub fails verifying doubles.
+      def notified_course_ids
+        notified = []
+        allow_any_instance_of(Course::ConsolidatedOpeningReminderNotifier).
+          to receive(:opening_reminder) { |_, course| notified << course.id }
+        travel_to(just_past_midnight_utc) { described_class.new.perform }
+        notified
+      end
+
+      it 'notifies courses whose local time has just passed midnight' do
+        expect(notified_course_ids).to include(midnight_course.id)
+      end
+
+      it 'does not notify courses whose local time is not midnight' do
+        expect(notified_course_ids).not_to include(daytime_course.id)
+      end
+
+      it 'ignores courses with no time zone set' do
+        no_zone_course = create(:course, time_zone: nil)
+
+        expect(notified_course_ids).not_to include(no_zone_course.id)
+      end
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -372,5 +372,110 @@ RSpec.describe Course, type: :model do
         end
       end
     end
+
+    # Drives ConsolidatedItemEmailJob: a course only gets an opening reminder when this is true.
+    # "Upcoming" is per course user — the effective time is the user's personal time if they have
+    # one, otherwise the reference time for their timeline — so an item can be upcoming for nobody
+    # even when its reference time is imminent.
+    describe '#upcoming_lesson_plan_items_exist?' do
+      let(:course) { create(:course) }
+      let!(:course_user) { create(:course_user, course: course) }
+      let!(:video) { create(:course_video, course: course, start_at: start_at, published: published) }
+      let(:start_at) { 1.hour.from_now }
+      let(:published) { true }
+
+      # Every course user needs one: `create(:course)` also makes an owner, and a user without a
+      # personal time falls back to the reference time, which would keep the item upcoming.
+      def move_personal_times_to(new_start_at)
+        course.course_users.each do |user|
+          personal_time = video.find_or_create_personal_time_for(user)
+          personal_time.start_at = new_start_at
+          personal_time.save!
+        end
+      end
+
+      def disable_opening_reminder_emails
+        course.setting_emails.
+          where(component: :videos, course_assessment_category_id: nil, setting: :opening_reminder).
+          first.update!(regular: false, phantom: false)
+      end
+
+      it 'is true when a published item opens within the next day' do
+        expect(course.upcoming_lesson_plan_items_exist?).to be true
+      end
+
+      context 'when the item opens beyond the next day' do
+        let(:start_at) { 100.hours.from_now }
+
+        it { expect(course.upcoming_lesson_plan_items_exist?).to be false }
+      end
+
+      context 'when the item has already opened' do
+        let(:start_at) { 1.hour.ago }
+
+        it { expect(course.upcoming_lesson_plan_items_exist?).to be false }
+      end
+
+      context 'when the item is unpublished' do
+        let(:published) { false }
+
+        it { expect(course.upcoming_lesson_plan_items_exist?).to be false }
+      end
+
+      it 'is false when every user has a personal time beyond the next day' do
+        move_personal_times_to(100.hours.from_now)
+
+        expect(course.upcoming_lesson_plan_items_exist?).to be false
+      end
+
+      context 'when the reference time is beyond the next day' do
+        let(:start_at) { 100.hours.from_now }
+
+        it 'is true when users have a personal time within the next day' do
+          move_personal_times_to(1.hour.from_now)
+
+          expect(course.upcoming_lesson_plan_items_exist?).to be true
+        end
+      end
+
+      it 'is false when opening reminder emails are disabled for the component' do
+        disable_opening_reminder_emails
+
+        expect(course.upcoming_lesson_plan_items_exist?).to be false
+      end
+
+      it 'is false when the course has no course users' do
+        course.course_users.destroy_all
+
+        expect(course.reload.upcoming_lesson_plan_items_exist?).to be false
+      end
+
+      # Regression: this used to load every published item in the course — with personal and
+      # reference times joined in one query, so items x course users x timelines rows — and filter
+      # in Ruby, calling into the course's email settings once per item. The work scaled with the
+      # size of the lesson plan rather than with how much of it was actually opening, and the job
+      # runs this hourly for every course in a midnight time zone.
+      context 'when nothing is opening within the next day' do
+        let(:start_at) { 100.hours.from_now }
+        let!(:other_items) do
+          create_list(:course_video, 5, course: course, start_at: 200.hours.from_now, published: true)
+        end
+
+        it 'does not load any lesson plan items' do
+          counts = Hash.new(0)
+          subscriber = ActiveSupport::Notifications.subscribe('instantiation.active_record') do |*, payload|
+            counts[payload[:class_name]] += payload[:record_count]
+          end
+          result = begin
+            course.upcoming_lesson_plan_items_exist?
+          ensure
+            ActiveSupport::Notifications.unsubscribe(subscriber)
+          end
+
+          expect(result).to be false
+          expect(counts['Course::LessonPlan::Item']).to eq(0)
+        end
+      end
+    end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -83,6 +83,25 @@ module Capybara::TestGroupHelpers
       find_field(field_name).send_keys([:control, 'a']).send_keys(date.gsub(' ', ''))
     end
 
+    # https://stackoverflow.com/questions/38049020/how-to-test-file-attachment-on-hidden-input-using-capybara
+
+    # NOTE: Using `make_visible: true` with `attach_file` is flaky — Capybara sometimes fails with
+    # a Capybara::ExpectationNotMet error even when the file input exists and is targeted correctly.
+    # Instead, we use JavaScript to explicitly change the file input's CSS and make it visible.
+    # This workaround ensures consistent behavior across browsers and environments.
+
+    # @param [Array<String>|String] paths The path(s) of the file(s) to attach.
+    # @param [String] selector The selector of the hidden file input.
+    def attach_files_to_hidden_input(paths, selector: 'input[type="file"]')
+      # Wait for file input to be in the DOM (even if hidden)
+      expect(page).to have_selector(selector, visible: false)
+      input = find(selector, visible: false)
+      page.execute_script("arguments[0].style.display = 'block';", input)
+
+      # Attach files to the (now visible) input
+      input.attach_file(paths)
+    end
+
     # Special helper to find a react-toastify message
     #
     # Since capybara's `find` has a default timeout until the element is found, this helps


### PR DESCRIPTION
## Problem

`ConsolidatedItemEmailJob` runs at 5 past **every hour** ([`config/schedule.yml`](config/schedule.yml)), walking every course whose local time has just passed midnight and asking each one whether it has anything opening soon. That question was answered by [`Course#upcoming_lesson_plan_items_exist?`](app/models/course.rb):

```ruby
opening_items = lesson_plan_items.published.eager_load(:personal_times, :reference_times).preload(:actable)
opening_items.select { |item| item.actable.include_in_consolidated_email?(:opening_reminder) }.any? do |item|
  course_users.any? { |course_user| item.time_for(course_user).start_at.between?(Time.zone.now, 1.day.from_now) }
end
```

Four problems compound here:

1. **The `eager_load` is a cartesian product.** Personal times exist per item *per course user* (`course_personal_times` has a unique index on `(course_user_id, lesson_plan_item_id)`), so eager-loading them alongside reference times in a single `LEFT OUTER JOIN` produces roughly `items × course_users × timelines` rows — to answer a boolean.
2. **`select { … }` is `Enumerable#select`, not the query method**, so every published item in the course is materialised before anything is filtered.
3. **`include_in_consolidated_email?` writes.** It calls `course.email_enabled(…)`, which is a `find_or_create_by` — a query, and potentially an `INSERT`, once per item, inside what reads like a pure predicate.
4. **The common case is the worst case.** `select` never short-circuits, and the outer `any?` only stops early when it *finds* something. A course with nothing opening — most courses, most hours — runs the full `items × users` loop to return `false`.

None of this scaled with how much was actually opening; it scaled with the size of the lesson plan and the size of the cohort.

## Changes

### 1. Narrow the candidates in SQL before doing any Ruby work

A new private `items_opening_between` asks the database for published items with *some* time — personal or reference — in the window:

```ruby
lesson_plan_items.published.
  where('EXISTS (… course_personal_times …  BETWEEN :from AND :to)
      OR EXISTS (… course_reference_times … BETWEEN :from AND :to)', from: from, to: to).
  preload(:personal_times, :reference_times, :actable)
```

This is safe because it is a **superset**, not an answer: `time_for` returns either the user's personal time row or a reference time row, so an item that is upcoming for anybody necessarily has one of those rows inside the window. The per-user decision still happens in Ruby, unchanged.

`preload` rather than `eager_load` is deliberate and is what kills the cartesian product — separate queries per association instead of one multiplied join. See [Eager Loading Associations](https://guides.rubyonrails.org/active_record_querying.html#eager-loading-associations) for the distinction between `preload`, `eager_load` and `includes`.

The `select { … }.any? { … }` also folds into a single short-circuiting `any?` with a guard — equivalent (`select(P).any?(Q)` ≡ `any?(P && Q)`) but it stops at the first match, so the `find_or_create_by` in `include_in_consolidated_email?` no longer runs once per item. `Time.zone.now` is captured once rather than re-evaluated per comparison.

### 2. Batch the course loop

[`consolidated_item_email_job.rb`](app/jobs/consolidated_item_email_job.rb) now uses [`find_each`](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each) instead of loading every matching course at once.

### Measured effect

On a course with 20 items and 16 course users, nothing opening — the hourly common case:

| | queries | rows instantiated |
|---|---|---|
| before | 22 | 360 |
| after | **1** | **0** |

The old figures grow with `items × users`; the new ones do not grow at all when nothing is opening.

## Test coverage

Both the job and the predicate were **completely uncovered** before this PR.

- [`spec/jobs/consolidated_item_email_job_spec.rb`](spec/jobs/consolidated_item_email_job_spec.rb) — new file. Covers midnight / non-midnight / nil time zones. It stubs the notifier on the *instance* (`Notifier::Base` dispatches `opening_reminder` through `method_missing`, so a class-level stub fails verifying doubles) and creates all records outside the frozen clock, so nothing is committed under a travelled time — this suite has no cleanup, and such rows would outlive the example.
- [`spec/models/course_spec.rb`](spec/models/course_spec.rb) — 9 examples pinning `#upcoming_lesson_plan_items_exist?`, including a regression test verified to fail against the old implementation (`expected: 0, got: 6` items loaded).

## Two flaky-test fixes bundled in

### `User::RegistrationsController` (exposed by [the previous PR](https://github.com/Coursemology/coursemology2/pull/8565), with direct involvement ruled out)

Four examples identified the user they had just registered with `User.order(:created_at).last`. That is not reliably the right row: the suite commits with no transactional fixtures and no DatabaseCleaner, and the test environment runs jobs on a background thread pool (`queue_adapter = :background_thread`, [`config/environments/test.rb`](config/environments/test.rb)) whose threads outlive the example that enqueued them. Anything a stray thread commits between the request and the lookup wins the ordering.

They now resolve the user by the address they submitted, following the pattern already in [`spec/support/userstamp.rb`](spec/support/userstamp.rb):

```ruby
User::Email.find_by(email: address)&.user
```

Reproduced deterministically before fixing, by giving one existing user a future `created_at` — the same end state a stray commit produces, without the race:

| | result |
|---|---|
| spec at master, poisoned DB | **12 examples, 4 failures** (exactly the four CI reported) |
| spec with fix, poisoned DB | 12 examples, 0 failures |

This was never an enrolment bug. The count assertions immediately before the failures passed — the records were being created correctly; the examples were looking them up by the wrong user.

### RagWise file uploads

`attach_file(…, make_visible: true)` applies its temporary styles to the input alone and then asserts that input is visible, which cannot happen while an ancestor is still hidden. An upload dialog that has mounted but not finished opening therefore fails with `The style changes in :make_visible did not make the file input visible`.

[`folder_management_spec.rb`](spec/features/course/material/folder_management_spec.rb) already carried a `NOTE` documenting this and the working alternative. That workaround is now a shared helper, `attach_files_to_hidden_input`, in [`spec/support/capybara.rb`](spec/support/capybara.rb), applied at all 8 sites across the two RagWise specs and the original inline copy — so the codebase no longer carries the same workaround in two forms for the next person to copy from the wrong one.

`invitation_management_spec.rb` also uses `make_visible: true` but was **deliberately left alone**: its `find('.dropzone-input')` has no `visible: false`, so Capybara already resolved a visible element there and it is not the same failure mode.