### PR TITLE
fix(sign_out): invalidate cookie server-side on user sign out

### DIFF
--- a/app/controllers/access_token_controller.rb
+++ b/app/controllers/access_token_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+# Expires the +access_token+ cookie that ApplicationUserConcern writes.
+#
+# The cookie is httponly, so the client cannot clear it on its own: js-cookie deletes by writing
+# through +document.cookie+, which an httponly cookie is invisible to by definition. Signing out
+# therefore has to ask the server to expire it, or it outlives the sign out as a usable credential
+# for browser-issued requests, which fall back to the cookie when no bearer token is present.
+#
+# A caller can only ever clear their own cookie. This action takes no parameters and identifies no
+# user - it expires the cookie on the response to this very request, so the only browser it can
+# affect is the one that made it.
+class AccessTokenController < ApplicationController
+  # +refresh_token_cookie+ would otherwise mint the cookie from this request's own bearer token
+  # moments before the action deletes it. The net result is the same, but this endpoint should only
+  # ever be capable of clearing a credential, never of issuing one.
+  skip_before_action :refresh_token_cookie
+
+  def destroy
+    cookies.delete(:access_token)
+    head :no_content
+  end
+
+  protected
+
+  # Signing out has to work with a credential that has already lapsed, which is exactly when a
+  # stale cookie is most likely to still be sitting in the browser.
+  def publicly_accessible?
+    true
+  end
+end

--- a/client/app/lib/components/wrappers/AuthProvider.tsx
+++ b/client/app/lib/components/wrappers/AuthProvider.tsx
@@ -4,7 +4,6 @@ import {
   AuthProvider as OIDCAuthProvider,
   useAuth,
 } from 'react-oidc-context';
-import Cookies from 'js-cookie';
 import {
   type SigninRedirectArgs,
   type SignoutRedirectArgs,
@@ -13,6 +12,7 @@ import {
   UserManager,
   WebStorageStateStore,
 } from 'oidc-client-ts';
+import { revokeAccessTokenCookie } from 'utilities/authentication';
 
 interface AuthProviderProps {
   children: ReactNode;
@@ -108,11 +108,29 @@ export const useAuthAdapter = (): AuthAdapterProps => {
   // Not supported yet as signoutCallback from oidc-client-ts is not called in react-oidc-context.
   // Has been fixed in v3.1.0 in react-oidc-context but not released yet.
 
+  /**
+   * The order here is load-bearing in both directions, and there is no third step to slot in
+   * between them.
+   *
+   * `revokeAccessTokenCookie` must come first and must be awaited. The cookie is httponly, so that
+   * request is the only thing in the system that can clear it, and `signoutRedirect` navigates the
+   * document away - an in-flight request is cancelled with it. It is awaited for delivery, not for
+   * its result: a failure is swallowed, since a user signing out should never be shown an error and
+   * the cookie's own JWT lapses shortly regardless.
+   *
+   * Nothing may clear stored auth state before `signoutRedirect`. It reads the stored user itself
+   * to build `id_token_hint`, and removes the user itself once it has. Clearing storage first
+   * leaves the hint out of the request, and Keycloak then prompts for confirmation rather than
+   * ending the session - so a user who does not complete that prompt stays signed in upstream.
+   */
   const handleLogout = async (): Promise<void> => {
-    await otherProps.removeUser();
+    await revokeAccessTokenCookie().catch((error) => {
+      // Swallowed so a failure never blocks signing out, but never silently: swallowing this once
+      // hid a revocation that was not happening at all.
+      console.warn('Access token cookie was not revoked on sign out', error);
+    });
+
     await adaptedSignOutRedirect();
-    localStorage.clear();
-    Cookies.remove('access_token');
   };
 
   return {

--- a/client/app/utilities/authentication.ts
+++ b/client/app/utilities/authentication.ts
@@ -19,3 +19,55 @@ export const getUserToken = (): string => {
  */
 export const hasStoredUser = (): boolean =>
   Boolean(localStorage.getItem(OIDC_STORAGE_KEY));
+
+// The `format=json` is what routes a request to Rails rather than to the client app: the dev server
+// serves the SPA for anything without it, so omitting it returns an HTML page with a 200.
+const CSRF_TOKEN_URL = '/csrf_token?format=json' as const;
+const ACCESS_TOKEN_URL = '/access_token?format=json' as const;
+
+/**
+ * Best effort, because a missing token is not worth abandoning the sign out over: the DELETE is
+ * still attempted without the header, and fails loudly there instead of silently here.
+ */
+const fetchCsrfToken = async (): Promise<string | undefined> => {
+  try {
+    const response = await fetch(CSRF_TOKEN_URL, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) return undefined;
+
+    return (await response.json()).csrfToken;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Asks the server to expire the `access_token` cookie.
+ *
+ * The cookie is httponly, so nothing here can clear it directly - `document.cookie`, which every
+ * client-side cookie library writes through, cannot see it at all. Only a server response can, and
+ * until one does the cookie stays a usable credential for requests that carry no bearer token.
+ *
+ * Deliberately built on bare `fetch` rather than `BaseAPI`: the API layer reaches back into
+ * `AuthProvider` for its 401 handling, and importing it from there would close an import cycle.
+ */
+export const revokeAccessTokenCookie = async (): Promise<void> => {
+  const csrfToken = await fetchCsrfToken();
+
+  const response = await fetch(ACCESS_TOKEN_URL, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+    },
+  });
+
+  if (!response.ok)
+    throw new Error(
+      `Could not revoke the access token cookie: ${response.status}`,
+    );
+};

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
   }
 
   get 'csrf_token' => 'csrf_token#csrf_token'
+  delete 'access_token' => 'access_token#destroy'
 
   # Sidekiq's own dashboard, gated on the same access token as the rest of the app rather than on
   # separate HTTP Basic credentials. Guarded because the sidekiq gems are in the :production (and

--- a/spec/requests/access_token_spec.rb
+++ b/spec/requests/access_token_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+# The cookie under test is httponly, so only a server response can expire it. That makes this a
+# request spec: what matters is the Set-Cookie the browser actually receives.
+RSpec.describe 'Access token cookie' do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:administrator) { create(:administrator) }
+
+    before { host! instance.host }
+
+    # Mirrors the controller specs, which sidestep Keycloak the same way.
+    before do
+      allow(Authentication::AuthenticationService).to receive(:validate_token) do |access_token, _method|
+        if access_token == 'a-valid-token'
+          Authentication::VerificationService::Response.new(
+            { email: administrator.email, session_state: 'a-session' }, nil
+          )
+        else
+          error = Authentication::VerificationService::Error.new('Invalid token', :unauthorized)
+          Authentication::VerificationService::Response.new(nil, error)
+        end
+      end
+    end
+
+    def deleted_in_response?
+      # Rails expires a cookie by sending it back empty, so the header names it with a nil value.
+      response.cookies.key?('access_token') && response.cookies['access_token'].nil?
+    end
+
+    it 'expires the cookie the request arrived with' do
+      delete '/access_token', headers: access_token_cookie('a-previously-issued-token')
+
+      expect(response).to have_http_status(:no_content)
+      expect(deleted_in_response?).to be(true)
+    end
+
+    # Signing out is exactly when the credential is most likely to be unusable already, so this
+    # must not require one.
+    it 'succeeds without any credential' do
+      delete '/access_token'
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    # ApplicationUserConcern#refresh_token_cookie mints the cookie on every publicly accessible
+    # action, and this is one. Skipping it here keeps the endpoint incapable of issuing a
+    # credential, so a bearer token cannot leave a freshly minted cookie behind.
+    it 'does not mint a cookie when a bearer token is presented' do
+      expect_any_instance_of(AccessTokenController).not_to receive(:refresh_token_cookie)
+      delete '/access_token', headers: { 'Authorization' => 'Bearer a-valid-token' }
+
+      expect(response).to have_http_status(:no_content)
+      expect(response.cookies['access_token']).to be_nil
+    end
+  end
+end

--- a/spec/requests/sidekiq_web_spec.rb
+++ b/spec/requests/sidekiq_web_spec.rb
@@ -274,17 +274,5 @@ RSpec.describe 'Sidekiq Web dashboard' do
     def bearer(token)
       { 'Authorization' => "Bearer #{token}" }
     end
-
-    # Mirrors ApplicationUserConcern#add_token_to_cookie: a browser's copy of the access token is an
-    # encrypted, httponly cookie, so build one exactly as the app writes it. The ciphertext has to
-    # be escaped the way Rails escapes it on the way out, otherwise any '+' it happens to contain
-    # is read back as a space and decryption fails for roughly half of all generated tokens.
-    def access_token_cookie(token)
-      env = Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'test.host').merge(Rails.application.env_config)
-      jar = ActionDispatch::Cookies::CookieJar.build(ActionDispatch::Request.new(env), {})
-      jar.encrypted[:access_token] = token
-
-      { 'HTTP_COOKIE' => "access_token=#{Rack::Utils.escape(jar[:access_token])}" }
-    end
   end
 end

--- a/spec/support/access_token_cookie.rb
+++ b/spec/support/access_token_cookie.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# Builds the access_token cookie that ApplicationUserConcern#add_token_to_cookie writes, for specs
+# that need a request to arrive carrying one.
+#
+# It cannot be seeded through an integration session's own jar: that is a Rack::Test::CookieJar,
+# which has no #encrypted. So the ciphertext is produced from a real CookieJar and handed over as a
+# raw request header.
+module AccessTokenCookieHelpers
+  # @param [String] token The access token to encrypt into the cookie.
+  # @return [Hash] Headers to merge into a request, carrying the cookie as the browser would.
+  def access_token_cookie(token)
+    env = Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'test.host').merge(Rails.application.env_config)
+    jar = ActionDispatch::Cookies::CookieJar.build(ActionDispatch::Request.new(env), {})
+    jar.encrypted[:access_token] = token
+
+    # The ciphertext has to be escaped the way Rails escapes it on the way out, otherwise any '+' it
+    # happens to contain is read back as a space and decryption fails for roughly half of all
+    # generated tokens.
+    { 'HTTP_COOKIE' => "access_token=#{Rack::Utils.escape(jar[:access_token])}" }
+  end
+end
+
+RSpec.configure do |config|
+  config.include AccessTokenCookieHelpers, type: :request
+end

--- a/spec/support/authentication_performers.rb
+++ b/spec/support/authentication_performers.rb
@@ -20,11 +20,13 @@ module AuthenticationPerformersTestHelpers
     expect(page).to have_css('div[data-testid="user-menu-button"]')
   end
 
+  # The Logout button this used to click was Keycloak's logout confirmation page, shown only because
+  # the client cleared its stored auth state before signoutRedirect could read the ID token out of
+  # it. With id_token_hint restored, Keycloak ends the session without prompting.
   def logout(*_)
     find('div[data-testid="user-menu-button"]').click
     wait_for_animation
     find('li', text: 'Sign out').click
-    click_button('Logout')
     expect(page).to_not have_css('div[data-testid="user-menu-button"]')
   end
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -140,10 +140,18 @@ export const test = base.extend<TestFixtures>({
 
     await extend(use, page.originalPage, {
       user,
+      // The third click this used to need was Keycloak's logout confirmation page, which only
+      // appeared because `handleLogout` cleared stored auth state before `signoutRedirect` could
+      // read the ID token out of it. With `id_token_hint` restored, Keycloak ends the session
+      // without prompting, as it did before the Keycloak migration.
       signOut: async () => {
         await page.getUserMenuButton().click();
         await page.getByRole('button', { name: 'Sign out' }).click();
-        await page.getByRole('button', { name: 'Logout' }).click();
+
+        // Sign out revokes the cookie, then round-trips through Keycloak back to the origin. The
+        // click alone returns long before any of that lands, so wait for the destination or every
+        // assertion after `signOut()` races it. (Callers already on `/` get no wait from this.)
+        await page.waitForURL('/');
       },
     });
   },

--- a/tests/tests/courses/landing-page-auth.spec.ts
+++ b/tests/tests/courses/landing-page-auth.spec.ts
@@ -57,6 +57,11 @@ const watchAttachmentResponses = (page: Page, id: string): number[] => {
   return statuses;
 };
 
+const getAccessTokenCookie = async (
+  page: Page,
+): Promise<{ name: string } | undefined> =>
+  (await page.context().cookies()).find((c) => c.name === ATTACHMENT_COOKIE);
+
 const expectAttachmentToLoad = async (statuses: number[]): Promise<void> => {
   await expect
     .poll(() => statuses.length, {
@@ -190,5 +195,61 @@ test.describe('signing in from a publicly accessible course page', () => {
     await expect(page).toHaveURL(new RegExp(`/courses/${course.id}`), {
       timeout: 30_000,
     });
+  });
+});
+
+test.describe('signing out', () => {
+  let course: { id: number };
+  let attachmentId: string;
+
+  test.beforeEach(async () => {
+    const attachment = await manufacture({ attachment_reference: {} });
+    attachmentId = attachment.id;
+
+    course = await manufacture({
+      course: {
+        traits: ['published'],
+        description: `<p>Welcome</p><img src="/attachments/${attachmentId}">`,
+      },
+    });
+  });
+
+  test('clears the access token cookie', async ({ authedPage: page }) => {
+    // Visiting the landing page mints the cookie, so it is definitely present
+    // before we sign out and the assertion below cannot pass vacuously.
+    await page.goto(`/courses/${course.id}`);
+    await expect.poll(() => getAccessTokenCookie(page)).toBeDefined();
+
+    await page.signOut();
+
+    // The cookie is httponly, so nothing on the page can remove it. Only the
+    // server call in `handleLogout` can, and if that call is ever dropped or
+    // sequenced after `signoutRedirect` this is what catches it.
+    await expect.poll(() => getAccessTokenCookie(page)).toBeUndefined();
+  });
+
+  test('leaves no credential behind for subresource requests', async ({
+    authedPage: page,
+  }) => {
+    await page.goto(`/courses/${course.id}`);
+
+    // The cookie is minted by the course fetch the app makes after load, not by
+    // the navigation itself, so wait for it rather than racing it: `goto`
+    // resolves long before the app has called the API. Without this the request
+    // below reliably 401s, since `AttachmentReferencesController` requires
+    // authentication and this request carries no bearer token to fall back on.
+    await expect.poll(() => getAccessTokenCookie(page)).toBeDefined();
+
+    // Requested through the context rather than the page, so it carries the
+    // cookie and no Authorization header - exactly what an <img> sends.
+    const whileSignedIn = await page.request.get(`/attachments/${attachmentId}`);
+    expect(whileSignedIn.ok()).toBe(true);
+
+    await page.signOut();
+
+    // The symptom that prompted this: a signed-out user whose surviving cookie
+    // still authenticated them to the backend for up to an hour.
+    const afterSignOut = await page.request.get(`/attachments/${attachmentId}`);
+    expect(afterSignOut.status()).toBe(401);
   });
 });


### PR DESCRIPTION

## Problem

After signing out, a publicly accessible course landing page still rendered as though the user were signed in. The client chrome was correct — Sign in button, no user menu — but the data behind it was still personalised.

The credential that survived is the `access_token` cookie, and it survived because **nothing was capable of deleting it**.

`ApplicationUserConcern` writes it `httponly`:

```ruby
cookies.encrypted[:access_token] =
  { value: token_from_request, httponly: true, expires: 1.hour.from_now }
```

And `handleLogout` tried to clear it from the browser:

```ts
Cookies.remove('access_token');
```

js-cookie deletes a cookie by writing an expired one of the same name through `document.cookie`. An `httponly` cookie is invisible and unwritable from `document.cookie` *by definition* — that is the entire purpose of the flag. This line has always been a guaranteed no-op.

The client state *was* cleared correctly: `removeUser()` drops the `oidc.user:` key, so `hasStoredUser()` is false and `isAuthenticated` is false. That is why the shell looked signed out. But the backend never saw a sign-out at all. Extraction is `token_from_bearer || token_from_cookies`, so a browser-issued request with no bearer falls back to the surviving cookie, resolves `current_user`, and `Course::CoursesController#show` — publicly accessible, so no `authenticate!` to fail — serves the personalised payload: `registrationInfo`, announcements, todos, notifications, all gated on `current_course.user?(current_user)`.

The result was a signed-out shell over signed-in data, for up to an hour. This is a live, usable credential outliving an explicit sign-out, not a rendering artefact.

### A second defect in the same function

```ts
await otherProps.removeUser();
await adaptedSignOutRedirect();   // full page navigation to Keycloak
localStorage.clear();             // races page teardown
Cookies.remove('access_token');   // ditto, and a no-op regardless
```

`signoutRedirect` navigates the document away. Everything sequenced after it is racing teardown and may never run. `removeUser()` happened to cover the OIDC key, which limited the damage, but any other `localStorage` state was left to chance.

## Changes

### `AccessTokenController`

[`app/controllers/access_token_controller.rb`](app/controllers/access_token_controller.rb), routed as `DELETE /access_token`. It expires the cookie and returns `204`.

**It is publicly accessible.** Signing out has to work with a credential that has already lapsed, which is precisely when a stale cookie is most likely to still be sitting in the browser. Requiring `authenticate!` would mean an expired user could never clear theirs.

**A caller can only ever clear their own cookie.** This is structural rather than enforced: the action takes no parameters and identifies no user. It expires the cookie on the response to that very request, so the only browser it can affect is the one that made the call. There is no target to select.

**It skips `refresh_token_cookie`.** That before_action — added in the preceding attachment fix — mints the cookie from the request's own bearer on every publicly accessible action, and this is one. Without the skip it would issue a cookie moments before the action deletes it. The net response is identical either way, but this endpoint should only ever be *capable* of clearing a credential, never of issuing one. Pinned by a test.

### `handleLogout` revokes, then redirects — and nothing in between

[`client/app/lib/components/wrappers/AuthProvider.tsx`](client/app/lib/components/wrappers/AuthProvider.tsx). The order is constrained from both directions, and there is no third step to slot between them.

The server call is **awaited**, which is worth being explicit about because the obvious reading is that it need not be. There is no client-side fallback: the cookie is `httponly`, so this request is the only thing in the system that can clear it, and an in-flight request is cancelled by the navigation that follows. It is awaited for *delivery*, not for its result — failures are swallowed and logged, since a user signing out should never be shown an error and the cookie's own JWT lapses shortly regardless.

**Nothing may clear stored auth state before `signoutRedirect`.** That is the subject of the next section, and it is why `removeUser()` and `localStorage.clear()` are gone from this function rather than merely reordered — `signoutRedirect` performs the removal itself.

`Cookies.remove('access_token')` is deleted outright rather than kept as belt-and-braces, because it never did anything and reading it suggests otherwise. The `js-cookie` import went with it; that was its only use.

### The Keycloak sign-out confirmation disappears, deliberately

Sign-out currently shows a Keycloak-hosted "Logout" confirmation page. This change removes it. That is a user-visible difference, so it is worth setting out why it was there and why dropping it costs nothing.

**It was never a designed feature.** Before the Keycloak migration, sign-out was one click. [`8e7718f1f`](../../commit/8e7718f1f) shows the original test helper:

```ts
await page.getUserMenuButton().click();
await page.getByRole('button', { name: 'Sign out' }).click();
await page.waitForURL('/users/sign_in');
```

The migration commit [`4ededeb78`](../../commit/4ededeb78) introduced `handleLogout` with this ordering:

```ts
await auth.removeUser();        // discards the stored user
await auth.signoutRedirect();   // ...which is where the ID token lived
```

and in the same commit changed the helper's last line to `getByRole('button', { name: 'Logout' }).click()`. The extra click was added to get *past* the new prompt, not because anyone wanted it. Three days later [`07c956efd`](../../commit/07c956efd) moved `handleLogout` into `AuthProvider` carrying the same ordering, where it has sat since May 2024.

**Why that ordering produces a prompt.** `signoutRedirect` reads the stored user itself to obtain `id_token_hint`, and removes the user itself once it has ([`oidc-client-ts`, `UserManager._signoutStart`](https://github.com/authts/oidc-client-ts/blob/main/src/UserManager.ts)):

```js
const user = await this._loadUser();                        // null, if we cleared it first
const id_token = args.id_token_hint || user && user.id_token;
if (id_token) args.id_token_hint = id_token;                // skipped
await this.removeUser();                                    // it would have done this anyway
```

Clearing storage first removes its only source for the hint, so the parameter is omitted from the logout URL. The earlier `removeUser()` call was not merely harmful — it was redundant.

**Keycloak is then obliged to ask.** Per [OpenID Connect RP-Initiated Logout 1.0 §2](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout), `id_token_hint` is RECOMMENDED, and:

> At the Logout Endpoint, the OP SHOULD ask the End-User whether to log out of the OP as well. Furthermore, the OP **MUST** ask the End-User this question if an `id_token_hint` was not provided or if the supplied ID Token does not belong to the current OP session with the RP and/or currently logged in End-User.

[§6 Security Considerations](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Security) gives the reason:

> Logout requests without a valid `id_token_hint` value are a potential means of denial of service; therefore, OPs should obtain explicit confirmation from the End-User before acting upon them.

So the prompt is a forced-logout mitigation. Without the hint, the request carries nothing that proves who asked: `client_id` is an unauthenticated URL parameter, and the `KEYCLOAK_IDENTITY` / `AUTH_SESSION_ID` cookies are ambient authority that a hostile cross-origin navigation would carry identically. Keycloak substitutes a human click, protected by the `state_checker` value it stores in the identity cookie and renders into the confirmation page.

Keycloak's own behaviour here dates from its move to spec compliance — see [Keycloak Upgrading Guide, "OpenID Connect Logout" under *Migrating to 19.0.0*](https://www.keycloak.org/docs/latest/upgrading/index.html) and the [logout endpoint documentation](https://www.keycloak.org/securing-apps/oidc-layers).

**Restoring the hint loses no protection.** Both mechanisms rest on the same primitive — prove you can read something same-origin that an attacker cannot:

| | what must be readable | at which origin |
|---|---|---|
| `id_token_hint` | the stored ID token | the app, via same-origin `localStorage` |
| `state_checker` | the rendered confirmation page | Keycloak, via a same-origin response body |

The ID token is issued at sign-in, kept in `localStorage`, and — unlike the access token — never transmitted anywhere, including to Rails (`includeIdTokenInSilentRenew` defaults to `false`). A cross-origin page cannot read it, so its presence in the request is itself the evidence the prompt was standing in for. Keycloak stops asking because the request is now authenticated, not because a check was disabled.

**And the prompt we had was worse than none.** Because teardown ran *before* the redirect, its Cancel button could not cancel anything: the cookie was already revoked and local state already discarded. Cancelling left the app signed out with the Keycloak session still live. The prompt was also a second confirmation of an intent the user had already expressed by clicking `Sign out` in the app.

No in-app replacement is being added. Sign-out returns to the single click it was before the migration.

**On dropping `localStorage.clear()`.** `signoutRedirect` removes the stored OIDC user itself, which is the only auth-bearing key. The rest of the app's `localStorage` is already namespaced by user id — see [`useDismissibleOnce`](client/app/lib/hooks/useDismissibleOnce.ts) (`${userId}:${key}`) and the table builder's sort/column state — specifically so two users on one device do not share it. So nothing leaks across a sign-out, and the call is not merely reordered but removed: it could not have run reliably where it sat, after a navigation.

### `revokeAccessTokenCookie`

[`client/app/utilities/authentication.ts`](client/app/utilities/authentication.ts) — built on bare `fetch` rather than `BaseAPI`. `Base.ts` imports `ErrorHandling.ts`, which imports `AUTH_USER_MANAGER` from `AuthProvider` for its 401 redirect, so calling the API layer from `AuthProvider` would close an import cycle.

It costs two round trips: fetch the CSRF token, then `DELETE`. The alternative was exempting a state-changing endpoint from CSRF protection to save one hop on sign-out, which is the wrong trade — logout CSRF is a real if minor nuisance, and sign-out latency is irrelevant.

**Both URLs carry `?format=json`.** That is what routes a request to Rails; the dev server serves the client app for anything without it. An early revision omitted it, so `/csrf_token` returned a `200` of HTML, `.json()` threw, and the `DELETE` was never sent at all — an entire sign-out flow that looked correct and did nothing. That failure was invisible because the caller swallowed it, so the CSRF fetch is now best-effort (the `DELETE` proceeds without the header rather than being abandoned), the `DELETE` throws on a non-`ok` response, and `handleLogout` logs a warning when it swallows.

## Testing

[`spec/requests/access_token_spec.rb`](spec/requests/access_token_spec.rb) — a request spec rather than a controller spec, because the cookie is `httponly` and what matters is the `Set-Cookie` the browser actually receives.

| Test | Asserts |
|---|---|
| expires the cookie the request arrived with | `204`, and the cookie comes back nil-valued |
| succeeds without any credential | sign-out works when the token has already lapsed |
| does not mint a cookie when a bearer token is presented | the `refresh_token_cookie` skip holds |

The first of those seeds a genuine encrypted cookie rather than a bare string, so the fixture matches what the app actually writes. That cannot go through the integration session's own jar — it is a `Rack::Test::CookieJar` and has no `#encrypted` — so the ciphertext is built from a real `CookieJar` and passed as a raw header. [`spec/requests/sidekiq_web_spec.rb`](spec/requests/sidekiq_web_spec.rb) had already solved this, so the two copies are lifted into [`spec/support/access_token_cookie.rb`](spec/support/access_token_cookie.rb). The escaping caveat travels with it: the ciphertext must be escaped the way Rails escapes it, or a `+` comes back as a space and decryption fails for roughly half of all generated tokens.

Two cases added to [`tests/tests/courses/landing-page-auth.spec.ts`](tests/tests/courses/landing-page-auth.spec.ts):

- **`clears the access token cookie`** — visits the landing page first so the cookie is definitely minted, otherwise the post-sign-out assertion passes vacuously. This is what catches the server call being dropped or re-sequenced after `signoutRedirect`.
- **`leaves no credential behind for subresource requests`** — issues the attachment request through `page.request`, which shares the context's cookie jar but sends no `Authorization` header, so it is exactly what an `<img>` sends. `ok()` before sign-out, `401` after. This is the one that encodes the reported symptom: not that the UI looks signed out, which it always did, but that the surviving cookie no longer authenticates.

### Two sign-out helpers clicked the confirmation button

Removing the Keycloak prompt breaks anything that clicked through it, and there were two such helpers — one per test stack. Both are updated.

[`tests/helpers.ts`](tests/helpers.ts) — the Playwright `signOut` fixture, used by every test taking `authedPage`, not only the two above. It loses the third click and **gains a `waitForURL('/')` in its place**. That click was doing double duty: it also made the helper wait for the Keycloak round trip to finish. Without a replacement the helper returns while the revoke and redirect are still in flight, and every assertion after `signOut()` races them — which the `page.request` case above would have hit intermittently rather than failing outright, the worst way for it to go wrong.

[`spec/support/authentication_performers.rb`](spec/support/authentication_performers.rb) — the Capybara `logout` helper, called by four feature specs under `spec/features/course/assessment/submission/`. CI globs `spec/**/*_spec.rb`, so these run alongside everything else. Here the click is simply removed: the existing `expect(page).to_not have_css('div[data-testid="user-menu-button"]')` already provides the wait, so nothing takes its place.

### What has actually been run

The RSpec request and controller specs are verified green, including a check that the cookie-expiry example fails when `cookies.delete` is removed rather than passing vacuously.

**Not run:** the Playwright cases and the four feature specs. Both need the full stack — Keycloak, the test Rails server, dirt-cheap-rocket — and are verified by inspection only. Between them they are the first real exercise of the new sign-out path, so the first CI run is the one to watch.

## Notes for review

- **Sign-out is now one click.** The Keycloak confirmation page is gone, for the reasons set out above, and no in-app replacement is added. Nothing depended on it but the two test helpers, both updated here. It is the change users will notice: an accidental click on `Sign out` no longer has an undo step. That was equally true before the Keycloak migration, and re-authenticating is a single click while the SSO session is alive.
- **This changes behaviour for the Sidekiq dashboard.** [`SidekiqAdminConstraint`](app/constraints/sidekiq_admin_constraint.rb) is the one place that reads the cookie without a bearer, and it previously benefited from the cookie outliving a sign-out. An admin who signs out will now have to go back through the authorization code flow in [`System::Admin::SidekiqSessionsController`](app/controllers/system/admin/sidekiq_sessions_controller.rb). That is correct, but it is a change in what admins experience.
- **The `INVALID_GRANT_ERROR` branch in `AuthenticatableApp` is dead code.** Unrelated to this change and pre-existing, but found while working nearby. `react-oidc-context` normalises every error it dispatches to `{ name, message, stack, innerError }`, so the OAuth `error` code the branch tests for only ever exists under `innerError`. The condition can never match. Either `error?.innerError?.error` is the one-line fix, or the branch should be removed — but that is a behaviour decision worth taking on its own.
- **Description images still 401 for genuinely anonymous visitors** on a published course, since `AttachmentReferencesController` has no `publicly_accessible?` override. Pre-existing and out of scope here, but this change makes it easier to hit: signing out now really does make you anonymous. Worth a look separately.
