### PR TITLE
feat(submission): offload background operations from finalise transaction

### DIFF
--- a/app/jobs/course/assessment/submission/publish_task_completion_job.rb
+++ b/app/jobs/course/assessment/submission/publish_task_completion_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# Pushes a submission's task status to Cikgo once the transaction that changed it has committed.
+#
+# The push is a synchronous HTTP call with a five second timeout, so it is kept off the request: a
+# slow or unavailable Cikgo must not delay a response, hold locks on a submission that is already
+# saved, or fail a request for work that has been committed.
+#
+# Unlike the inline +publish_task_completion+, which logs and swallows in production, a failure here
+# is allowed to propagate. That is the point of running it as a job: Sidekiq retries it and Rollbar
+# records it, rather than the error disappearing into the log.
+class Course::Assessment::Submission::PublishTaskCompletionJob < ApplicationJob
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # The submission was deleted before the job ran; there is no status left to publish.
+  end
+
+  def perform(submission)
+    instance = Course.unscoped { submission.assessment.course.instance }
+
+    ActsAsTenant.with_tenant(instance) do
+      # Re-read rather than trusting the state at enqueue time. A later transition may already have
+      # been pushed, and the status Cikgo should end up with is the current one either way — which
+      # also makes two pushes racing each other harmless.
+      next unless submission.should_publish_task_completion?
+
+      submission.publish_task_completion!
+    end
+  end
+end

--- a/app/jobs/course/lesson_plan/personalized_timeline_update_job.rb
+++ b/app/jobs/course/lesson_plan/personalized_timeline_update_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# Recomputes one course user's personalised timeline.
+#
+# Enqueued after a submission is finalised, rather than run inside the finalise transaction: the
+# recomputation walks every lesson plan item in the course and writes a personal time per shiftable
+# item, which is by far the largest unit of work in that transaction and the only part that contends
+# with +CoursewidePersonalizedTimelineUpdateJob+ for the same rows.
+#
+# The timeline is derived state. If this job never succeeds the student's timeline is one submission
+# stale but still valid, and the next recomputation for them — their next submission, an instructor
+# pressing "Recompute all times", or a coursewide run — brings it forward.
+class Course::LessonPlan::PersonalizedTimelineUpdateJob < ApplicationJob
+  include Course::LessonPlan::PersonalizationConcern
+
+  queue_as :lowest
+
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # The course user was removed from the course before the job ran; there is no timeline to update.
+  end
+
+  def perform(course_user)
+    instance = Course.unscoped { course_user.course.instance }
+
+    ActsAsTenant.with_tenant(instance) do
+      update_personalized_timeline_for_user(course_user)
+    end
+  end
+end

--- a/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
@@ -10,18 +10,27 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
   extend ActiveSupport::Concern
 
   included do
-    after_save :publish_task_completion, if: -> { should_publish_task_completion? && saved_change_to_workflow_state? }
+    after_save :enqueue_publish_task_completion,
+               if: -> { should_publish_task_completion? && saved_change_to_workflow_state? }
   end
 
+  # Pushes the status, absorbing failures the way the controller's +edit+ hook needs: logged, and
+  # fatal only outside production so a broken Cikgo integration is noticed in development.
   def publish_task_completion
+    publish_task_completion!
+  rescue StandardError => e
+    Rails.logger.error("Cikgo: Cannot publish task completion for submission #{id}: #{e}")
+    raise e unless Rails.env.production?
+  end
+
+  # Pushes the status and lets failures propagate, for callers that can act on them —
+  # +PublishTaskCompletionJob+, where Sidekiq retries and Rollbar records.
+  def publish_task_completion!
     Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, {
       user_id: creator_id_on_cikgo,
       url: submission_url,
       score: grade&.to_i
     })
-  rescue StandardError => e
-    Rails.logger.error("Cikgo: Cannot publish task completion for submission #{id}: #{e}")
-    raise e unless Rails.env.production?
   end
 
   def should_publish_task_completion?
@@ -30,6 +39,14 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
   end
 
   private
+
+  # Hands the push to a job once the transaction that changed the status has committed, so the
+  # request neither waits on Cikgo nor fails because of it. See +PublishTaskCompletionJob+.
+  def enqueue_publish_task_completion
+    ActiveRecord.after_all_transactions_commit do
+      Course::Assessment::Submission::PublishTaskCompletionJob.perform_later(self)
+    end
+  end
 
   delegate :edit_course_assessment_submission_url, to: 'Rails.application.routes.url_helpers'
 

--- a/app/models/concerns/course/assessment/submission/notification_concern.rb
+++ b/app/models/concerns/course/assessment/submission/notification_concern.rb
@@ -27,6 +27,14 @@ module Course::Assessment::Submission::NotificationConcern
     return if assessment.autograded?
     return unless course_user.student?
 
-    Course::AssessmentNotifier.assessment_submitted(creator, course_user, self)
+    # Building the activity walks the submitter's groups to find managers and subtracts the
+    # unsubscribed ones, then writes the activity and its notifications. None of that needs to be in
+    # the transaction that commits the student's work: an unsent notification is recoverable
+    # attention, a rolled back submission is lost work. It stays on the request rather than becoming
+    # a job of its own, since its real work is enqueuing mail delivery jobs — already deferred to
+    # after commit by Notifier::Base::ActivityWrapper.
+    ActiveRecord.after_all_transactions_commit do
+      Course::AssessmentNotifier.assessment_submitted(creator, course_user, self)
+    end
   end
 end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module Course::Assessment::Submission::WorkflowEventConcern
   extend ActiveSupport::Concern
-  include Course::LessonPlan::PersonalizationConcern
   include Course::Assessment::Submission::CikgoTaskCompletionConcern
 
   included do
@@ -30,7 +29,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
     # NB: We are not recomputing on unsubmission because unsubmit is not done by the student
     #     It will recompute again when resubmission occurs. This also prevents the timings for
     #     the unsubmitted item from changing e.g. from other submissions that the student has done.
-    update_personalized_timeline_for_user(course_user)
+    enqueue_personalized_timeline_update
   end
 
   # Handles the marking of a submission.
@@ -103,6 +102,21 @@ module Course::Assessment::Submission::WorkflowEventConcern
   end
 
   private
+
+  # Recomputes the submitter's personalised timeline out of band.
+  #
+  # The recomputation reads every lesson plan item in the course and writes a personal time per
+  # shiftable item, so it is kept out of the transaction that commits the student's work: a failure
+  # there used to roll the whole finalise back (see
+  # docs/personal_time_duplicate_incident_summary.md). Enqueued after commit so the job also reads a
+  # committed submission — +submitted_items+ is meant to include this one.
+  def enqueue_personalized_timeline_update
+    submitter = course_user
+
+    ActiveRecord.after_all_transactions_commit do
+      Course::LessonPlan::PersonalizedTimelineUpdateJob.perform_later(submitter)
+    end
+  end
 
   # finalise event (from attempting) - Assign 0 points as there are no questions.
   def assign_zero_experience_points

--- a/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
+++ b/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
@@ -197,9 +197,15 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
 
     context 'when the course has many course users' do
       let!(:course_users) do
-        create_list(:course_user, 3, course: course, timeline_algorithm: 'fomo').each do |course_user|
+        users = create_list(:course_user, 3, course: course, timeline_algorithm: 'fomo')
+        users.each do |course_user|
           create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
         end
+        # Each finalise enqueues a PersonalizedTimelineUpdateJob for its submitter. Settle them
+        # before the example runs, so the coursewide recomputation under test is not racing three
+        # per-user recomputations over the same rows.
+        wait_for_enqueued_jobs
+        users
       end
 
       it 'shifts the item for every course user' do

--- a/spec/jobs/course/assessment/submission/publish_task_completion_job_spec.rb
+++ b/spec/jobs/course/assessment/submission/publish_task_completion_job_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Submission::PublishTaskCompletionJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, course: course) }
+    let(:course_student) { create(:course_student, course: course) }
+    let(:submission) do
+      create(:submission, :attempting, assessment: assessment,
+                                       creator: course_student.user, course_user: course_student)
+    end
+    subject { Course::Assessment::Submission::PublishTaskCompletionJob }
+
+    it 'can be queued' do
+      expect { subject.perform_later(submission) }.to have_enqueued_job(subject).exactly(:once)
+    end
+
+    it 'pushes the current status' do
+      allow(submission).to receive(:should_publish_task_completion?).and_return(true)
+      expect(submission).to receive(:publish_task_completion!)
+
+      subject.perform_now(submission)
+    end
+
+    # Re-read at run time rather than trusted from enqueue time, so a superseded push is dropped.
+    it 'does not push when the submission no longer qualifies' do
+      allow(submission).to receive(:should_publish_task_completion?).and_return(false)
+      expect(submission).not_to receive(:publish_task_completion!)
+
+      subject.perform_now(submission)
+    end
+
+    it 'lets a failed push propagate, so Sidekiq retries and Rollbar records it' do
+      allow(submission).to receive(:should_publish_task_completion?).and_return(true)
+      allow(submission).to receive(:publish_task_completion!).and_raise(StandardError, 'cikgo down')
+
+      expect { subject.perform_now(submission) }.to raise_error(StandardError, 'cikgo down')
+    end
+  end
+end

--- a/spec/jobs/course/lesson_plan/personalized_timeline_update_job_spec.rb
+++ b/spec/jobs/course/lesson_plan/personalized_timeline_update_job_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::LessonPlan::PersonalizedTimelineUpdateJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let!(:submitted_assessment) do
+      create(:assessment, course: course, start_at: 2.days.ago, end_at: 3.days.from_now, published: true)
+    end
+    let!(:upcoming_assessment) do
+      create(:assessment, course: course, start_at: 5.days.from_now, end_at: 10.days.from_now, published: true)
+    end
+    let(:timeline_algorithm) { 'fomo' }
+    let(:course_user) { create(:course_user, course: course, timeline_algorithm: timeline_algorithm) }
+    let(:submission) do
+      create(:course_assessment_submission, assessment: submitted_assessment, creator: course_user.user)
+    end
+    subject { Course::LessonPlan::PersonalizedTimelineUpdateJob }
+
+    it 'can be queued' do
+      expect { subject.perform_later(course_user) }.to have_enqueued_job(subject).exactly(:once)
+    end
+
+    it 'is enqueued when a submission is finalised' do
+      expect { submission.finalise! }.to have_enqueued_job(subject).exactly(:once)
+    end
+
+    context 'when the course user is on a personalized timeline' do
+      it 'shifts the timeline for the course user', :sidekiq_same_thread do
+        submission.finalise!
+        submission.save!
+        expect(course_user.personal_times).to be_empty
+
+        perform_sidekiq_jobs { subject.perform_later(course_user) }
+
+        # The submitted item is never shifted, so only the upcoming one gets a personal time.
+        expect(course_user.personal_times.count).to eq(1)
+        expect(course_user.personal_times.first.lesson_plan_item_id).
+          to eq(upcoming_assessment.lesson_plan_item.id)
+      end
+
+      it 'is safe to run more than once', :sidekiq_same_thread do
+        submission.finalise!
+        submission.save!
+
+        perform_sidekiq_jobs { subject.perform_later(course_user) }
+        first_run = course_user.personal_times.pluck(:lesson_plan_item_id, :start_at, :end_at)
+
+        perform_sidekiq_jobs { subject.perform_later(course_user) }
+
+        # Idempotent, and — importantly for the offload — it never accumulates rows: the timeline is
+        # recomputed from current state rather than appended to.
+        expect(course_user.personal_times.reload.pluck(:lesson_plan_item_id, :start_at, :end_at)).
+          to match_array(first_run)
+      end
+    end
+
+    context 'when the course user is on the fixed timeline' do
+      let(:timeline_algorithm) { 'fixed' }
+
+      it 'creates no personal times', :sidekiq_same_thread do
+        submission.finalise!
+        submission.save!
+
+        perform_sidekiq_jobs { subject.perform_later(course_user) }
+
+        expect(course_user.personal_times).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -344,6 +344,81 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
 
+      # The finalise transaction commits the student's work, so nothing derived from it — the
+      # personalised timeline, the notification, the Cikgo push — may be able to roll it back. The
+      # first two also leave the request entirely, as jobs, because they call out to a third party
+      # or walk the whole course.
+      describe 'work deferred past the finalise transaction' do
+        # Created up front so that only the finalise itself is observed: creating a submission
+        # notifies too, and would otherwise land inside the transaction under test.
+        before { submission }
+
+        # The notification is only sent when the student submits for themselves, so the stamper has
+        # to be the creator — as it is on every path that reaches here in production.
+        def finalise
+          User.with_stamper(submission.creator) { submission.update!('finalise' => 'true') }
+        end
+
+        def rolled_back_finalise
+          User.with_stamper(submission.creator) do
+            ActiveRecord::Base.transaction do
+              submission.update!('finalise' => 'true')
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+
+        with_active_job_queue_adapter(:test) do
+          context 'when the course is pushed to Cikgo' do
+            before { allow(submission).to receive(:should_publish_task_completion?).and_return(true) }
+
+            it 'enqueues the Cikgo push instead of calling out during the request' do
+              expect(submission).not_to receive(:publish_task_completion!)
+
+              expect { finalise }.
+                to have_enqueued_job(Course::Assessment::Submission::PublishTaskCompletionJob).
+                exactly(:once)
+            end
+
+            it 'does not enqueue the push when the finalise is rolled back' do
+              expect { rolled_back_finalise }.
+                not_to have_enqueued_job(Course::Assessment::Submission::PublishTaskCompletionJob)
+            end
+          end
+
+          it 'enqueues the personalised timeline recomputation rather than running it inline' do
+            expect { finalise }.
+              to have_enqueued_job(Course::LessonPlan::PersonalizedTimelineUpdateJob).exactly(:once)
+          end
+
+          it 'does not enqueue the recomputation when the finalise is rolled back' do
+            expect { rolled_back_finalise }.
+              not_to have_enqueued_job(Course::LessonPlan::PersonalizedTimelineUpdateJob)
+          end
+        end
+
+        # Asserted through the activity record rather than the notifier, which is reached through
+        # Notifier::Base.method_missing and so cannot be a verified double. The notification stays on
+        # the request — its own work is enqueuing mail delivery — so this only checks that it is out
+        # of the transaction.
+        it 'writes the submission activity only once the transaction has committed' do
+          activities = Activity.count
+
+          User.with_stamper(submission.creator) do
+            ActiveRecord::Base.transaction do
+              submission.update!('finalise' => 'true')
+              expect(Activity.count).to eq(activities)
+            end
+          end
+
+          expect(Activity.count).to eq(activities + 1)
+        end
+
+        it 'does not write the activity when the finalise is rolled back' do
+          expect { rolled_back_finalise }.not_to change(Activity, :count)
+        end
+      end
+
       context 'when one of the answers is finalised' do
         before do
           answer = submission.answers.sample

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -122,6 +122,17 @@ module TrackableJob::SpecHelpers
     ActiveJob::Base.queue_adapter.clear_enqueued_jobs
   end
 
+  # Blocks until every job enqueued so far has finished.
+  #
+  # Unlike +wait_for_job+, this does not skip the example. Use it when setup enqueues work whose
+  # effects the example depends on — the background thread adapter otherwise runs those jobs
+  # concurrently with the example body, and only joins them once the example is over.
+  def wait_for_enqueued_jobs
+    return unless ActiveJob::Base.queue_adapter.is_a?(ActiveJob::QueueAdapters::BackgroundThreadAdapter)
+
+    ActiveJob::Base.queue_adapter.wait_for_jobs
+  end
+
   # Polls until at least +count+ emails have been delivered, or the Capybara wait time elapses. Under
   # the :sidekiq_separate_thread harness a mail job enqueued by the Capybara server thread is delivered
   # out-of-band by the worker thread, so feature specs must wait for it rather than assert immediately.


### PR DESCRIPTION
The third mitigation following the duplicate `course_personal_times` incident, after
[#8559](https://github.com/Coursemology/coursemology2/pull/8559) (client fix: debounce the lesson plan
editor so it stops firing overlapping PATCHes) and
[#8560](https://github.com/Coursemology/coursemology2/pull/8560) (unique index on
`(course_user_id, lesson_plan_item_id)`).

## Background

Two `Course::LessonPlan::CoursewidePersonalizedTimelineUpdateJob` runs executing concurrently each
inserted a `Course::PersonalTime` row for the same `(course_user_id, lesson_plan_item_id)` pair.
Neither failed: the uniqueness check was a model-level validation with no backing index, so neither
transaction saw the other's uncommitted row.

Once a duplicate pair existed, *every* later personalisation run for that course user failed
deterministically — for an existing record the validation excludes only itself, so it always found the
twin. Finalising a submission recomputes the submitter's timeline, and did so **inside the same
transaction that commits the student's work**. So the exception unwound the whole submission: affected
students could not finalise anything in that course, on every retry, until we intervened.

#8560 stops the duplicates being created. This PR stops a failure in derived, recomputable state from
being able to destroy student work in the first place.

## What moves out of the transaction

The transaction is opened in `Course::Assessment::Submission::UpdateService#update_submission` and
covers both the answer writes and the workflow transition — the `finalise` handler's `save!` only
opens a joined nested transaction, so every `after_save` callback is part of it too.

### 1. Personalised timeline recomputation

`update_personalized_timeline_for_user` is replaced by a new
`Course::LessonPlan::PersonalizedTimelineUpdateJob`, enqueued from
`ActiveRecord.after_all_transactions_commit`.

This is by far the largest unit of work in the transaction: `precompute_data` loads **every lesson plan
item in the course** with its reference and personal times, builds the user's submission-time hash and
computes a learning-rate EMA over it; `execute` then walks that list and inserts or updates a personal
time per shiftable item. It is also the only part that contends with the coursewide job for the same
rows.

Enqueuing after commit has an incidental benefit: the job now reads a *committed* submission, which is
what `submitted_items` was always meant to include.

`Course::LessonPlan::PersonalizationConcern` is no longer included in the submission model.

### 2. Cikgo task completion

`publish_task_completion` is a synchronous `Excon` PATCH with a five second timeout. It moves into a
new `Course::Assessment::Submission::PublishTaskCompletionJob`, enqueued after commit, so the request
neither waits on Cikgo nor fails because of it.

Two things worth knowing when reviewing this one:

- On `attempting → submitted` it is semantically a no-op. `WORKFLOW_STATE_TO_TASK_COMPLETION_STATUS`
  maps both `attempting` and `submitted` to `:ongoing`, so finalising pushes the status Cikgo already
  has. Only `→ published` carries new information.
- It was **not** rolling back finalise in production — the rescue is `raise e unless
  Rails.env.production?`, so production logs and swallows. The production cost was up to five seconds
  of an open transaction holding locks on the submission and its answers while waiting on a third
  party. Outside production the behaviour was the inverted one, where a Cikgo hiccup *did* roll a
  finalise back.

The method is split so the two call sites get the error handling each needs, rather than one swallowing
compromise:

- `publish_task_completion!` pushes and lets failures propagate. The job uses it, so a failure is
  retried by Sidekiq and reported to Rollbar (`ApplicationJob` includes `Rollbar::ActiveJob`, which
  reports and re-raises) instead of vanishing into the log.
- `publish_task_completion` keeps the existing log-and-swallow-in-production behaviour for
  `SubmissionsController#publish_cikgo_task_completion`, the `after_action` on `edit` that repairs a
  missed push. That path is unchanged by this PR.

The job re-reads `should_publish_task_completion?` at run time rather than trusting the state at
enqueue, so a superseded push is dropped and two pushes racing each other converge on the current
status.

### 3. Submission notification

Email *delivery* was already deferred to after commit by `Notifier::Base::ActivityWrapper`. The queries
behind it were not: building the activity walks the submitter's groups to find managers, falls back to
course managers, subtracts the unsubscribed ones, and writes the activity and its notification rows.
That now happens after commit too. The guards stay inline, since they read
`workflow_state_before_last_save`.

This one stays on the request rather than becoming a job of its own, since its real work is enqueuing
mail delivery jobs.

## What deliberately stays

- **Answer updates, `finalise_current_answers`, `submitted_at`** — the student's work and the
  definition of the state transition.
- **`assign_zero_experience_points`** — not a side effect. An assessment with no questions finalises
  straight to `published`, skipping the states where grading would assign points, and `published`
  carries `validate_awarded_attributes`. It is three in-memory assignments on the record being saved,
  persisted by the outer `update!`'s own `save!`; there is no separate write to move, and deferring it
  would mean saving a record its own validation rejects.
- **`update_todo`** — one row in the same database. Deferring it buys no latency and would leave the
  student's landing page showing a submitted assessment as still in progress, with nothing to
  reconcile it.

## Consequences if the offloaded work fails

The point of the change is that these are now recoverable rather than destructive, so they are worth
stating explicitly:

| Offloaded work | If it fails after the finalise commits | Recovery |
|---|---|---|
| Timeline recomputation | The student's timeline is one submission stale but still internally valid — upcoming items keep the dates from the previous recomputation. | Sidekiq retries. Any later recomputation for that user (their next submission, "Recompute all times" on their personal times page, or a coursewide run) brings it forward. Note the strategies refuse to move dates that have already passed, so the repair is complete only for items that have not yet opened. |
| `Course::LearningRateRecord` row | A gap in a log. It is written after `execute` and never read back — `compute_learning_rate_ema` re-derives from submissions and personal times each run. Its only readers are the personal times and course user pages. | None needed. |
| Other submissions' force-submit schedule | `force_submit_at` derives from the timeline, so a stale timeline can leave a job scheduled against a deadline that would have shifted. | Self-corrects. `ScheduleExpiringSubmissionsJob` runs hourly and reschedules any submission whose `force_submit_at` no longer matches its recorded `force_submit_scheduled_at`, and `ForceSubmitTimedSubmissionJob` re-checks live before submitting. |
| Cikgo push | Cikgo's copy of the task shows a stale status — usually no observable difference on finalise, given the status mapping above. | Sidekiq retries, and the failure is reported to Rollbar. Beyond that it self-heals: `SubmissionsController` already re-pushes on `edit`. |
| Submission notification | Managers do not get the "new submission" email and the activity feed misses an entry. | None. Low impact — graders still see the submission in the submissions list. |

## Why this is safe without locking

Offloading widens the window in which the recomputation can overlap a coursewide run. That overlap was
always possible — the finalise transaction took no lock that excluded the job, which is exactly how the
duplicates were created — so this is a widening, not a new exposure. With #8560 already merged, what
changes is the outcome when two runs do collide:

| | before #8560 | after #8560, before this PR | after this PR |
|---|---|---|---|
| Two runs insert the same pair | both commit; a duplicate is created silently | one commits, the other raises inside the finalise transaction | one commits, the other raises inside a job |
| Cost to the loser | a poisoned row that fails every later run | **the student's submission is rolled back** | a Sidekiq retry, which finds the row and succeeds |

Locking would reduce the collisions themselves, but nothing here depends on it: a collision is now
transient and self-correcting, and a run that fails permanently leaves a stale timeline rather than
lost work.

## Behaviour changes

- Finalising no longer recomputes the timeline before the response returns. The student's own next
  deadlines may lag their submission by however long the job queue takes. The recomputation runs on
  `:lowest`, matching `CoursewidePersonalizedTimelineUpdateJob`.
- A failed recomputation is now a retried job reported to Rollbar, instead of a silently rolled back
  submission.
- A Cikgo outage no longer delays or fails a finalise in any environment, and — new — is now *visible*
  in Rollbar rather than only in the production log.
- Nothing that finalise defers can turn a committed submission into an error response. Only three
  `perform_later`/notifier calls remain on the request after the commit, and an enqueue failure there
  would already be failing `auto_grade_submission` on the same path.

## Testing

New `spec/jobs/course/lesson_plan/personalized_timeline_update_job_spec.rb`: the job is queued,
enqueued by finalising, shifts only the unsubmitted item, no-ops on the fixed algorithm, and — the one
that matters here — running it twice neither duplicates rows nor drifts.

New `spec/jobs/course/assessment/submission/publish_task_completion_job_spec.rb`: the job pushes the
current status, drops a push whose submission no longer qualifies, and lets a failed push propagate,
which is what puts it in front of Sidekiq's retries and Rollbar.

New `work deferred past the finalise transaction` group in
`spec/models/course/assessment/submission_spec.rb`, asserting each of the three is invisible while the
transaction is open, absent entirely if it rolls back, and — for the Cikgo push — enqueued rather than
called during the request.

Checked against the old behaviour by restoring `master`'s three concerns and re-running the group: **4
of its 6 examples fail**, including the Cikgo rollback case, which errors on `master` because the
inline push raises inside the transaction. The two that pass beforehand are the rollback cases for the
timeline and the activity — vacuously, since on `master` that work was inside the transaction and rolled
back with it. They are kept as forward guards against the deferral being moved back out of the
after-commit hook.

The notification assertion goes through `Activity.count` rather than a message expectation, because
`assessment_submitted` is reached via `Notifier::Base.method_missing` and cannot be a verified double.

**One spec-infrastructure note for reviewers.** The offload makes the suite run these jobs concurrently
with example bodies, since the background thread adapter only joins them when the example ends. That
surfaced a real failure in `personalization_concern_spec.rb` — three per-user recomputations racing the
coursewide run under test, which is the incident in miniature. This PR adds a `wait_for_enqueued_jobs`
helper to `spec/support/active_job.rb` and settles the setup before that example. Other specs that
finalise a submission in setup and then assert on personal times may need the same.

Run locally: the submission model, controller, service, job, personalisation-concern and notifier specs
all pass. Feature specs run: `spec/features/course/assessment/assessment_attempt_spec.rb` and all of
`spec/features/course/assessment/submission/` — 66 examples, one failure, which is a pre-existing local
Keycloak login problem (`submissions_spec.rb:54` dies in `login_as` before it reaches a submission, and
fails identically with this branch's changes reverted).

## Follow-ups, not in this PR

- `Course::PersonalTimesController#recompute` still runs the recomputation synchronously in the
  request, with the same "hundreds of items in one request" shape removed from finalise here. It should
  go through the same job.
- `Course::LearningRateRecord`'s timestamp is effectively a "last successfully recomputed at" marker,
  and surfacing it on the personal times page would make a failed recomputation visible to
  instructors. Useful, but a feature rather than part of this fix.
- Locking around the personalisation entry points, as described above — optional given the index.
- The analogous transactions for other lesson plan item classes that recompute timelines on submission
  were not examined; only the assessment path is covered here.