### PR TITLE
fix(submission): manage behaviors when observing other users' submissions

### DIFF
--- a/app/views/course/assessment/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/edit.json.jbuilder
@@ -26,7 +26,14 @@ json.assessment do
   # timeline). Null when the submission is never force-submitted. Sending the remaining duration
   # rather than an absolute timestamp lets the client anchor to its own clock, so a skewed client
   # clock does not fire the force-submit early or late.
-  force_submit_at = @submission.attempting? ? @submission.force_submit_at : nil
+  #
+  # Only sent to the submission's own creator: this value drives the client-side auto-submit timer
+  # (and the countdown banner), which must fire only for the student taking the assessment. A grader
+  # or instructor merely viewing an in-progress attempt must never trigger a finalise, so they get
+  # nil and no timer — matching the creator-only #edit fail-safe. The background job enforces the
+  # deadline server-side regardless.
+  is_creator = current_user.id == @submission.creator_id
+  force_submit_at = (@submission.attempting? && is_creator) ? @submission.force_submit_at : nil
   json.forceSubmitRemainingTime force_submit_at && ((force_submit_at - Time.zone.now) * 1000).round
   json.questionIds @submission.questions.pluck(:id)
   json.passwordProtected @assessment.session_password_protected?

--- a/client/app/bundles/course/assessment/submission/components/ProgressPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/components/ProgressPanel.tsx
@@ -13,6 +13,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 import { formatLongDateTime } from 'lib/moment';
 
 import { workflowStates } from '../constants';
+import ObservingAttemptAlert from '../pages/SubmissionEditIndex/ObservingAttemptAlert';
 import { submissionShape } from '../propTypes';
 import translations from '../translations';
 
@@ -69,6 +70,8 @@ const ProgressPanel = (props): JSX.Element => {
           {t(translations.lateSubmission)}
         </Alert>
       )}
+
+      <ObservingAttemptAlert />
 
       <Table style={styles.table}>
         <TableBody>

--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
@@ -79,8 +79,10 @@ const Programming = (props) => {
   const submission = useAppSelector(getSubmission);
   const isAttempting = submission.workflowState === workflowStates.Attempting;
 
+  // Get Help is a one-on-one conversation between the student and Codaveri, so the chat panel is
+  // shown only to the submission's own creator, never to staff viewing the attempt.
   const isLiveFeedbackChatOpen =
-    liveFeedbackChatForAnswer?.isLiveFeedbackChatOpen;
+    liveFeedbackChatForAnswer?.isLiveFeedbackChatOpen && submission.isCreator;
   const fileSubmission = question.fileSubmission;
   const isSavingAnswer = useAppSelector((state) =>
     getIsSavingAnswer(state, answerId),

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/ObservingAttemptAlert.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/ObservingAttemptAlert.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import { Alert } from '@mui/material';
+
+import { workflowStates } from 'course/assessment/submission/constants';
+import { getSubmission } from 'course/assessment/submission/selectors/submissions';
+import translations from 'course/assessment/submission/translations';
+import { useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
+
+/**
+ * Warns a viewer who is not the submission's creator that the attempt is still in progress, and that
+ * anything they change here writes straight into the student's own answers.
+ *
+ * Staff editing a third party's answers is not currently locked down (managers and owners hold
+ * `:update`/`:submit_answer` on every answer in their course), so this is a deterrent rather than a
+ * guard: it makes the consequence visible at the point of editing.
+ */
+const ObservingAttemptAlert: FC = () => {
+  const { t } = useTranslation();
+  const submission = useAppSelector(getSubmission);
+
+  const attempting = submission.workflowState === workflowStates.Attempting;
+  if (!attempting || submission.isCreator) return null;
+
+  return (
+    <Alert severity="warning">{t(translations.observingAttemptWarning)}</Alert>
+  );
+};
+
+export default ObservingAttemptAlert;

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/__test__/ObservingAttemptAlert.test.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/__test__/ObservingAttemptAlert.test.tsx
@@ -1,0 +1,57 @@
+import { AppState } from 'store';
+import { render } from 'test-utils';
+
+import ObservingAttemptAlert from '../ObservingAttemptAlert';
+
+const WARNING = /has not yet finalised their submission/i;
+
+// Only the two fields the component reads. `Partial<AppState>` allows omitting whole slices but not
+// fields within one, hence the cast.
+const stateWith = (
+  workflowState: string,
+  isCreator: boolean,
+): Partial<AppState> =>
+  ({
+    assessments: { submission: { submission: { workflowState, isCreator } } },
+  }) as unknown as Partial<AppState>;
+
+// `TestApp` mounts `I18nProvider`, which shows a loading indicator until it has asynchronously
+// loaded the locale messages. A synchronous `queryByText` therefore runs before the component under
+// test has rendered at all, and would pass whatever the component does. Render a marker alongside
+// it and await that first, so an absence assertion is made against a mounted tree.
+const renderAlert = async (
+  workflowState: string,
+  isCreator: boolean,
+): Promise<ReturnType<typeof render>> => {
+  const page = render(
+    <>
+      <span data-testid="mounted" />
+      <ObservingAttemptAlert />
+    </>,
+    { state: stateWith(workflowState, isCreator) },
+  );
+
+  await page.findByTestId('mounted');
+
+  return page;
+};
+
+describe('<ObservingAttemptAlert />', () => {
+  it('warns a non-creator viewing an attempt still in progress', async () => {
+    const page = await renderAlert('attempting', false);
+
+    expect(page.getByText(WARNING)).toBeVisible();
+  });
+
+  it('stays silent for the submission creator', async () => {
+    const page = await renderAlert('attempting', true);
+
+    expect(page.queryByText(WARNING)).toBeNull();
+  });
+
+  it('stays silent once the submission is no longer attempting', async () => {
+    const page = await renderAlert('submitted', false);
+
+    expect(page.queryByText(WARNING)).toBeNull();
+  });
+});

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/ActionButtonsRow.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/ActionButtonsRow.tsx
@@ -47,8 +47,12 @@ const ActionButtonsRow: FC<Props> = (props) => {
   ].filter(Boolean);
 
   const rightAlignedButtons = [
+    // Get Help is a one-on-one conversation between the student and Codaveri, so it is offered only
+    // to the submission's own creator. Staff audit it through the Get Help History chip instead of
+    // posting into the student's thread.
     question.type === questionTypes.Programming &&
-      question.liveFeedbackEnabled && (
+      question.liveFeedbackEnabled &&
+      submission.isCreator && (
         <LiveFeedbackButton key="get-help" answerId={question.answerId} />
       ),
   ].filter(Boolean);

--- a/client/app/bundles/course/assessment/submission/translations.ts
+++ b/client/app/bundles/course/assessment/submission/translations.ts
@@ -705,6 +705,12 @@ const translations = defineMessages({
     defaultMessage:
       'Submission for this assessment cannot be viewed once finalised.',
   },
+  observingAttemptWarning: {
+    id: 'course.assessment.submission.SubmissionEditIndex.observingAttemptWarning',
+    defaultMessage:
+      'This user has not yet finalised their submission. Edits made on this \
+page will affect answers directly, which can influence auto grading results.',
+  },
   hoursMinutesSeconds: {
     id: 'course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.hoursMinutesSeconds',
     defaultMessage:

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -4172,6 +4172,9 @@
   "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.seconds": {
     "defaultMessage": "{secs, plural, one {# second} other {# seconds}}"
   },
+  "course.assessment.submission.SubmissionEditIndex.observingAttemptWarning": {
+    "defaultMessage": "This user has not yet finalised their submission. Edits made on this page will affect answers directly, which can influence auto grading results."
+  },
   "course.assessment.submission.submissionBlocked": {
     "defaultMessage": "Submission for this assessment cannot be viewed once finalised."
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -4157,6 +4157,9 @@
   "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.seconds": {
     "defaultMessage": "{secs, plural, other {#초}}"
   },
+  "course.assessment.submission.SubmissionEditIndex.observingAttemptWarning": {
+    "defaultMessage": "이 사용자는 아직 제출물을 최종 제출하지 않았습니다. 이 페이지에서 수정한 내용은 답안에 직접 반영되며, 자동 채점 결과에 영향을 줄 수 있습니다."
+  },
   "course.assessment.submission.submissionBlocked": {
     "defaultMessage": "이 평가의 제출물은 최종화된 후에는 볼 수 없습니다."
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -4151,6 +4151,9 @@
   "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.seconds": {
     "defaultMessage": "{secs, plural, other {#秒}}"
   },
+  "course.assessment.submission.SubmissionEditIndex.observingAttemptWarning": {
+    "defaultMessage": "该用户尚未最终提交其作答。在此页面所做的修改将直接影响答案，并可能影响自动评分结果。"
+  },
   "course.assessment.submission.submissionBlocked": {
     "defaultMessage": "此测验的内容提交后将无法查看。"
   },

--- a/spec/controllers/course/assessment/submission/late_submission_spec.rb
+++ b/spec/controllers/course/assessment/submission/late_submission_spec.rb
@@ -145,5 +145,36 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
         expect(JSON.parse(subject.body)['submission']['late']).to be true
       end
     end
+
+    describe '#edit force-submit countdown' do
+      render_views
+
+      let(:end_at) { 30.minutes.from_now }
+      let!(:submission) do
+        create(:submission, :attempting, assessment: assessment,
+                                         creator: student.user, course_user: student)
+      end
+
+      subject do
+        get :edit, params: {
+          course_id: course, assessment_id: assessment, id: submission, format: :json
+        }
+        JSON.parse(response.body)['assessment']['forceSubmitRemainingTime']
+      end
+
+      it 'sends the remaining time to the creator' do
+        is_expected.to be_within(5_000).of(30.minutes.in_milliseconds)
+      end
+
+      context 'when a grading instructor (not the creator) opens the attempt' do
+        let(:manager) { create(:course_manager, course: course) }
+
+        before { controller_sign_in(controller, manager.user) }
+
+        it 'does not send a countdown (their timer must never auto-submit the student)' do
+          is_expected.to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes a path where a grader merely *having a student's in-progress submission open* could finalise it,
limits the Get Help chat to the submission's own author, and warns staff that edits made while observing
an unfinalised attempt write straight into the student's answers.

## Background

The submission edit page renders the same `SubmissionForm` for everyone — `renderContent()` does not
branch on grader status — so a staff member opening a student's attempt gets the full answering UI. Two
consequences followed from that.

**The auto-submit timer fired for whoever had the page open.** The client arms an interval from
`forceSubmitRemainingTime` and dispatches `finalise` when it expires. The server sent that value to *any*
viewer of an attempting submission, so an instructor who left a student's timed (or deadline-enforced)
attempt open in a tab would have their own browser finalise the student's work when the clock ran out.
This was latent for timed assessments and widened to every enforced end date by the late-submission work.

**Staff hold real write access on that page.** Teaching staff and above get `:update` on every submission
in the course (`allow_teaching_staff_grade_assessment_submissions`, which is what authorises finalise,
unsubmit and autograde), and managers/owners additionally get `:update`/`:submit_answer` on every *answer*
(`allow_manager_update_assessment_answer` — a deliberate 2023 feature, widened from submission-level
`:submit_answer` to answer-level editing when the answer and submission APIs were split in 2024). The
deadline restriction is students-only, so none of this is time-bounded. Locking that down is out of scope
here; this PR removes the *automatic* write and discourages the manual ones.

## Key changes

### 1. The force-submit countdown is sent only to the submission's creator

`edit.json.jbuilder` now requires `current_user.id == @submission.creator_id` before emitting
`forceSubmitRemainingTime`. The countdown banner, the entry warning dialog and the auto-submit timer all
key off that single value, so gating it at the source suppresses all three for non-creators without a
scattered client-side check — matching the creator-only `#edit` fail-safe that already existed. The
background `ForceSubmitTimedSubmissionJob` still enforces the deadline server-side, so nothing is lost by
taking the timer away from an observer.

This was the only automatic write on the page: the two other on-mount effects (`pollAllFeedback`,
`handleEvaluationPolling`) are read-only status polls, gated on state a prior action already created.
Everything else requires an explicit click.

### 2. Get Help is limited to the submission's author

Gated at both render sites — the button in `ActionButtonsRow`, and the chat panel in
`Programming/index.jsx` (folding `isCreator` into `isLiveFeedbackChatOpen` covers both the panel and the
half-width editor layout, so a chat left open in Redux cannot reappear). That closes every write path into
the thread, since the input area, suggestion chips and chip button all live inside the panel. The **Get
Help History** chip staff use to audit conversations is untouched.

The feature is meant to be a one-on-one conversation between the student and Codaveri, and a staff message
posted into it is not merely an extra line:

- the thread stays owned by the student (`submission_creator_id`), and there is at most one active thread
  per submission question, so the message lands in *the* student's conversation rather than a side thread;
- the message is stored with the instructor's `creator_id`, but the chat derives its sender purely from
  "is this the system user?", so it renders to the student as **their own message** — there is no staff
  attribution anywhere in the UI;
- Codaveri answers the instructor's prompt inside the student's thread, so the reply the student reads is
  conditioned on input they never wrote;
- the student's quota is `sent_user_messages(submission_creator_id)`, so staff messages bypass it while
  still being sent to (and billed by) Codaveri;
- `user_get_help_message_counts` counts every non-system message, so the history count silently includes
  staff messages, indistinguishable from the student's.

### 3. A warning when observing an unfinalised attempt

New `ObservingAttemptAlert`, rendered in `ProgressPanel`, shown when the submission is still `attempting`
and the viewer is not its creator:

> This user has not yet finalised their submission. Edits made on this page will affect answers directly,
> which can influence auto grading results.

This is a deterrent rather than a guard — third-party answer editing remains possible — but it puts the
consequence in front of the person at the point where they would make the edit.

The `isCreator` flag all three changes key off already existed on the payload and in `SubmissionState`; it
had only ever been read by two file-view components.

## Testing

- Request specs on `#edit`: the creator receives `forceSubmitRemainingTime`; a grading manager receives
  `nil`.
- Component specs for the alert: shown for a non-creator on an attempt in progress, silent for the
  creator, silent once the submission is no longer attempting.
- **A note on the alert specs, because the first version was worthless.** They passed with the
  `isCreator` guard deleted. `TestApp` mounts `I18nProvider`, which renders a loading indicator until it
  has asynchronously loaded the locale messages, so a synchronous `queryByText` asserts against a tree in
  which the component has not rendered at all — and passes whatever the component does. Fixed by rendering
  a marker alongside the component and awaiting it before asserting absence, and by seeding an isolated
  store through `render(ui, { state })` instead of the shared global one. Both mutations (dropping
  `isCreator`, dropping the `attempting` check) now fail exactly one test each.
- Full submission bundle green: 50 examples over 11 suites. `tsc`, `eslint` and `prettier` clean.

## Notes / follow-ups

- **Get Help is disabled in the UI only.** `allow_teaching_staff_interact_with_live_feedback` still grants
  staff `:generate_live_feedback`, `:save_live_feedback` and `:create_live_feedback_chat`, so the endpoints
  stay reachable outside the app. Narrowing that method to its two `fetch_*` reads would make the
  restriction true at the API as well.
- **The alert does not survive the Student View toggle.** `ProgressPanel` renders only when `graderView`
  is true and `ENTER_STUDENT_VIEW` sets it to false, while `SaveDraftButton` is gated on `attempting`
  alone — so editing is still possible in that mode with the warning hidden. Known and accepted for now;
  hoisting the alert out of the `graderView` branch would fix it.
- **Third-party answer modification is still open.** A real lockdown would have to decide whether
  managers/owners should keep answer-level `:update`/`:submit_answer` on a submission that is still being
  attempted, and whether teaching staff should be able to finalise one.
- An observer (staff without `:grade`) gets no `ProgressPanel` and therefore no alert, but also cannot
  edit, so nothing is lost there.
